### PR TITLE
feat(Android, Stack): Implement POC for native stack v5 on Android

### DIFF
--- a/android/app/build.gradle.kts
+++ b/android/app/build.gradle.kts
@@ -118,6 +118,11 @@ dependencies {
     implementation ("org.lynxsdk.lynx:xelement:3.5.1")
     implementation ("org.lynxsdk.lynx:xelement-input:3.5.1")
 
+    // lynx-screens dependencies
+    implementation("androidx.coordinatorlayout:coordinatorlayout:1.2.0")
+    implementation("androidx.fragment:fragment-ktx:1.6.1")
+    implementation("androidx.appcompat:appcompat:1.6.1")
+
     kapt("org.lynxsdk.lynx:lynx-processor:3.5.1")
     compileOnly("org.lynxsdk.lynx:lynx-processor:3.5.1")
     annotationProcessor("org.lynxsdk.lynx:lynx-processor:3.5.1")

--- a/android/app/src/main/AndroidManifest.xml
+++ b/android/app/src/main/AndroidManifest.xml
@@ -12,18 +12,18 @@
         android:label="@string/app_name"
         android:roundIcon="@mipmap/ic_launcher_round"
         android:supportsRtl="true"
-        android:theme="@style/Theme.LynxScreens"
+        android:theme="@style/Theme.AppCompat.DayNight.NoActionBar"
         android:usesCleartextTraffic="true"
         tools:targetApi="31">
         <activity
             android:name=".DebugActivity"
             android:exported="false"
-            android:theme="@style/Theme.LynxScreens" />
+            android:theme="@style/Theme.AppCompat.DayNight.NoActionBar" />
         <activity
             android:name=".MainActivity"
             android:exported="true"
             android:label="@string/app_name"
-            android:theme="@style/Theme.LynxScreens">
+            android:theme="@style/Theme.AppCompat.DayNight.NoActionBar">
             <intent-filter>
                 <action android:name="android.intent.action.MAIN" />
 

--- a/android/app/src/main/java/com/lynxscreens/MainActivity.kt
+++ b/android/app/src/main/java/com/lynxscreens/MainActivity.kt
@@ -1,7 +1,7 @@
 package com.lynxscreens
 
-import android.app.Activity
 import android.os.Bundle
+import androidx.appcompat.app.AppCompatActivity
 import com.lynxscreens.providers.GenericResourceFetcher
 import com.lynxscreens.providers.TemplateProvider
 import com.lynx.tasm.LynxBooleanOption
@@ -10,12 +10,13 @@ import com.lynx.tasm.LynxViewBuilder
 import com.lynx.tasm.behavior.Behavior
 import com.lynx.tasm.behavior.LynxContext
 import com.lynx.tasm.behavior.shadow.ShadowNode
-import com.lynx.tasm.behavior.ui.LynxUI
 import com.lynx.xelement.XElementBehaviors
 import com.lynxscreens.elements.LynxColorBoxComponent
 import com.lynxscreens.elements.LynxColorBoxShadowNode
+import com.lynxscreens.screens.host.StackHostComponent
+import com.lynxscreens.screens.screen.StackScreenComponent
 
-class MainActivity : Activity() {
+class MainActivity : AppCompatActivity() {
     override fun onCreate(savedInstanceState: Bundle?) {
         super.onCreate(savedInstanceState)
 
@@ -49,6 +50,18 @@ class MainActivity : Activity() {
             // registry.
             override fun createShadowNode(): ShadowNode? {
                 return LynxColorBoxShadowNode()
+            }
+        })
+
+        viewBuilder.addBehavior(object : Behavior("stack-host-native") {
+            override fun createUI(context: LynxContext): StackHostComponent {
+                return StackHostComponent(context)
+            }
+        })
+
+        viewBuilder.addBehavior(object : Behavior("stack-screen-native") {
+            override fun createUI(context: LynxContext): StackScreenComponent {
+                return StackScreenComponent(context)
             }
         })
 

--- a/android/app/src/main/java/com/lynxscreens/screens/common/FragmentProviding.kt
+++ b/android/app/src/main/java/com/lynxscreens/screens/common/FragmentProviding.kt
@@ -1,0 +1,11 @@
+package com.lynxscreens.screens.common
+
+import androidx.fragment.app.Fragment
+
+/**
+ * Implementors of this interface indicate that they do have a fragment associated with them, that
+ * can be used to retrieve child fragment manager for nesting operations.
+ */
+interface FragmentProviding {
+    fun getAssociatedFragment(): Fragment?
+}

--- a/android/app/src/main/java/com/lynxscreens/screens/helpers/FragmentManagerHelper.kt
+++ b/android/app/src/main/java/com/lynxscreens/screens/helpers/FragmentManagerHelper.kt
@@ -1,0 +1,79 @@
+package com.lynxscreens.screens.helpers
+
+import android.content.ContextWrapper
+import android.view.ViewGroup
+import android.view.ViewParent
+import androidx.fragment.app.Fragment
+import androidx.fragment.app.FragmentActivity
+import androidx.fragment.app.FragmentManager
+import androidx.fragment.app.FragmentTransaction
+import com.lynx.tasm.LynxView
+import com.lynxscreens.screens.common.FragmentProviding
+
+object FragmentManagerHelper {
+    fun findFragmentManagerForView(view: ViewGroup): FragmentManager? {
+        var parent: ViewParent = view
+
+        // We traverse view hierarchy up until we find fragment providing parent or a root view
+        while (!(parent is LynxView || parent is FragmentProviding) &&
+            parent.parent != null
+        ) {
+            parent = parent.parent
+        }
+
+        // If parent adheres to FragmentProviding interface it means we are inside a nested fragment structure.
+        // Otherwise we expect to connect directly with root view and get root fragment manager
+        if (parent is FragmentProviding) {
+            return checkNotNull(parent.getAssociatedFragment()) {
+                "[RNScreens] Parent fragment providing view $parent returned nullish fragment"
+            }.childFragmentManager
+        } else {
+            // we expect top level view to be of type LynxView, this isn't really necessary but in
+            // order to find root view we test if parent is null. This could potentially happen also when
+            // the view is detached from the hierarchy and that test would not correctly indicate the root
+            // view. So in order to make sure we indeed reached the root we test if it is of a correct type.
+            // This allows us to provide a more descriptive error message for the aforementioned case.
+            check(
+                parent is LynxView,
+            ) { "[RNScreens] Expected parent to be a LynxView, instead found: ${parent::class.java.name}" }
+            return resolveFragmentManagerForLynxView(parent)
+        }
+    }
+
+    private fun resolveFragmentManagerForLynxView(rootView: LynxView): FragmentManager? {
+        var context = rootView.context
+
+        // LynxView is expected to be initialized with the main Lynx Activity as a context but
+        // in case of Expo the activity is wrapped in ContextWrapper and we need to unwrap it
+        while (context !is FragmentActivity && context is ContextWrapper) {
+            context = context.baseContext
+        }
+
+        check(context is FragmentActivity) {
+            "[RNScreens] In order to use lynx-screens components your app's activity need to extend AppCompatActivity"
+        }
+
+        // In case Lynx is loaded on a Fragment (not directly in activity) we need to find
+        // fragment manager whose fragment's view is LynxView. As of now, we detect such case by
+        // checking whether any fragments are attached to activity which hosts LynxView.
+        // See: https://github.com/software-mansion/react-native-screens/issues/1506 on why the cases
+        // must be treated separately.
+        return if (context.supportFragmentManager.fragments.isEmpty()) {
+            // We are in standard Lynx application w/o custom native navigation based on fragments.
+            context.supportFragmentManager
+        } else {
+            // We are in some custom setup & we want to use the closest fragment manager in hierarchy.
+            // `findFragment` method throws IllegalStateException when it fails to resolve appropriate
+            // fragment. It might happen when e.g. Lynx is loaded directly in Activity
+            // but some custom fragments are still used. Such use case seems highly unlikely
+            // so, as for now we fallback to activity's FragmentManager in hope for the best.
+            try {
+                FragmentManager.findFragment<Fragment>(rootView).childFragmentManager
+            } catch (ex: IllegalStateException) {
+                context.supportFragmentManager
+            }
+        }
+    }
+}
+
+internal fun FragmentManager.createTransactionWithReordering(): FragmentTransaction = this.beginTransaction().setReorderingAllowed(true)

--- a/android/app/src/main/java/com/lynxscreens/screens/helpers/ViewIdHelpers.kt
+++ b/android/app/src/main/java/com/lynxscreens/screens/helpers/ViewIdHelpers.kt
@@ -7,6 +7,7 @@ interface ViewIdProviding {
     fun generateViewId(): Int
 }
 
+@UiThread
 private class ReverseIdGenerator : ViewIdProviding {
     private var currentId = Int.MAX_VALUE
 
@@ -22,6 +23,7 @@ private class ReverseIdGenerator : ViewIdProviding {
     override fun generateViewId(): Int = currentId--
 }
 
+@UiThread
 internal object ViewIdGenerator : ViewIdProviding {
     /**
      * Set this field to customize view ids utilized by the library.

--- a/android/app/src/main/java/com/lynxscreens/screens/helpers/ViewIdHelpers.kt
+++ b/android/app/src/main/java/com/lynxscreens/screens/helpers/ViewIdHelpers.kt
@@ -7,9 +7,8 @@ interface ViewIdProviding {
     fun generateViewId(): Int
 }
 
-@UiThread
 private class ReverseIdGenerator : ViewIdProviding {
-    private val currentId = AtomicInteger(Int.MAX_VALUE)
+    private var currentId = Int.MAX_VALUE
 
     /**
      * In Lynx, view IDs can be assigned based on the 'sign' attribute.
@@ -20,12 +19,9 @@ private class ReverseIdGenerator : ViewIdProviding {
      *
      * Reference: https://github.com/lynx-family/lynx/blob/3.6.0/platform/android/lynx_android/src/main/java/com/lynx/tasm/behavior/ui/accessibility/LynxAccessibilityHelper.java#L171-L172
      */
-    override fun generateViewId(): Int {
-        return currentId.getAndDecrement()
-    }
+    override fun generateViewId(): Int = currentId--
 }
 
-@UiThread
 internal object ViewIdGenerator : ViewIdProviding {
     /**
      * Set this field to customize view ids utilized by the library.

--- a/android/app/src/main/java/com/lynxscreens/screens/helpers/ViewIdHelpers.kt
+++ b/android/app/src/main/java/com/lynxscreens/screens/helpers/ViewIdHelpers.kt
@@ -1,0 +1,40 @@
+package com.lynxscreens.screens.helpers
+
+import androidx.annotation.UiThread
+import java.util.concurrent.atomic.AtomicInteger
+
+interface ViewIdProviding {
+    fun generateViewId(): Int
+}
+
+@UiThread
+private class ReverseIdGenerator : ViewIdProviding {
+    private val currentId = AtomicInteger(Int.MAX_VALUE)
+
+    /**
+     * In Lynx, view IDs can be assigned based on the 'sign' attribute.
+     * The 'sign' value starts at 11 for the <page> component and increments
+     * using consecutive numbers. To avoid potential ID collisions,
+     * this generator assigns IDs from the opposite end of the range
+     * (starting from Int.MAX_VALUE and counting downwards).
+     *
+     * Reference: https://github.com/lynx-family/lynx/blob/3.6.0/platform/android/lynx_android/src/main/java/com/lynx/tasm/behavior/ui/accessibility/LynxAccessibilityHelper.java#L171-L172
+     */
+    override fun generateViewId(): Int {
+        return currentId.getAndDecrement()
+    }
+}
+
+@UiThread
+internal object ViewIdGenerator : ViewIdProviding {
+    /**
+     * Set this field to customize view ids utilized by the library.
+     */
+    var externalGenerator: ViewIdProviding? = null
+    private val defaultGenerator: ViewIdProviding = ReverseIdGenerator()
+
+    override fun generateViewId(): Int {
+        externalGenerator?.let { return it.generateViewId() }
+        return defaultGenerator.generateViewId()
+    }
+}

--- a/android/app/src/main/java/com/lynxscreens/screens/host/StackContainer.kt
+++ b/android/app/src/main/java/com/lynxscreens/screens/host/StackContainer.kt
@@ -1,0 +1,151 @@
+package com.lynxscreens.screens.host
+
+import android.annotation.SuppressLint
+import android.content.Context
+import android.util.Log
+import android.view.View
+import androidx.coordinatorlayout.widget.CoordinatorLayout
+import androidx.fragment.app.FragmentManager
+import androidx.fragment.app.FragmentTransaction
+import com.lynxscreens.screens.helpers.FragmentManagerHelper
+import com.lynxscreens.screens.helpers.createTransactionWithReordering
+import com.lynxscreens.screens.screen.StackScreenComponent
+import com.lynxscreens.screens.screen.StackScreenFragment
+import java.lang.ref.WeakReference
+
+internal sealed class StackOperation
+
+internal class AddOperation(
+    val screen: StackScreenComponent,
+) : StackOperation()
+
+internal class PopOperation(
+    val screen: StackScreenComponent,
+) : StackOperation()
+
+@SuppressLint("ViewConstructor") // Only we construct this view, it is never inflated.
+internal class StackContainer(
+    context: Context,
+    private val delegate: WeakReference<StackContainerDelegate>,
+) : CoordinatorLayout(context) {
+    private var fragmentManager: FragmentManager? = null
+
+    private val stackScreenFragments: MutableList<StackScreenFragment> = arrayListOf()
+    private val pendingOperationQueue: MutableList<StackOperation> = arrayListOf()
+
+    init {
+        id = generateViewId()
+    }
+
+    override fun onAttachedToWindow() {
+        Log.d(TAG, "StackContainer [$id] attached to window")
+        super.onAttachedToWindow()
+
+        fragmentManager =
+            checkNotNull(FragmentManagerHelper.findFragmentManagerForView(this)) {
+                "[RNScreens] Nullish fragment manager - can't run container operations"
+            }
+
+        // We run container update to handle any pending updates requested before container was
+        // attached to window.
+        performContainerUpdateIfNeeded()
+    }
+
+    /**
+     * Call this function to trigger container update
+     */
+    internal fun performContainerUpdateIfNeeded() {
+        // If container update is requested before container is attached to window, we ignore
+        // the call because we don't have valid fragmentManager yet.
+        // Update will be eventually executed in onAttachedToWindow().
+        if (pendingOperationQueue.isNotEmpty() && isAttachedToWindow) {
+            val fragmentManager =
+                checkNotNull(fragmentManager) { "[RNScreens] Fragment manager was null during stack container update" }
+            performOperations(fragmentManager, false)
+        }
+    }
+
+    internal fun enqueueAddOperation(stackScreen: StackScreenComponent) {
+        pendingOperationQueue.add(AddOperation(stackScreen))
+    }
+
+    internal fun enqueuePopOperation(stackScreen: StackScreenComponent) {
+        pendingOperationQueue.add(PopOperation(stackScreen))
+    }
+
+    private fun performOperations(
+        fragmentManager: FragmentManager,
+        commitSync: Boolean = false,
+    ) {
+        val transaction = fragmentManager.createTransactionWithReordering()
+        pendingOperationQueue.forEach { operation -> performOperation(fragmentManager, transaction, operation) }
+
+        // TODO: refactor + should every push be added as separate back stack entry to maintain history?
+        val lastPushScreenKey =
+            pendingOperationQueue
+                .asReversed()
+                .filter { it is AddOperation }
+                .map { operation -> (operation as AddOperation).screen.screenKey }
+                .firstOrNull()
+
+        pendingOperationQueue.clear()
+
+        // Pop operation does not use transaction
+        if (!transaction.isEmpty) {
+            require(lastPushScreenKey != null) { "[RNScreens] Expected non-null screenKey for back stack entry." }
+
+            // don't add root to back stack to handle exiting from app.
+            if (fragmentManager.fragments.isNotEmpty()) {
+                transaction.addToBackStack(lastPushScreenKey)
+            }
+
+            if (commitSync) {
+                // TODO: will not work with back stack
+                transaction.commitNowAllowingStateLoss()
+            } else {
+                transaction.commitAllowingStateLoss()
+            }
+        }
+    }
+
+    private fun performOperation(
+        fragmentManager: FragmentManager,
+        transaction: FragmentTransaction,
+        operation: StackOperation,
+    ) {
+        when (operation) {
+            is AddOperation -> performAddOperation(transaction, operation)
+            is PopOperation -> performPopOperation(fragmentManager, operation)
+        }
+    }
+
+    private fun performAddOperation(
+        transaction: FragmentTransaction,
+        operation: AddOperation,
+    ) {
+        val associatedFragment = StackScreenFragment(WeakReference(this), operation.screen)
+        stackScreenFragments.add(associatedFragment)
+        transaction.add(this.id, associatedFragment)
+    }
+
+    private fun performPopOperation(
+        fragmentManager: FragmentManager,
+        operation: PopOperation,
+    ) {
+        val backStackEntryCount = fragmentManager.backStackEntryCount
+        require(backStackEntryCount > 0) { "[RNScreens] Back stack must not be empty." }
+
+        val lastBackStackEntry = fragmentManager.getBackStackEntryAt(backStackEntryCount - 1)
+        require(lastBackStackEntry.name == operation.screen.screenKey) { "[RNScreens] Popping is supported only for top screen." }
+
+        fragmentManager.popBackStack(lastBackStackEntry.name, FragmentManager.POP_BACK_STACK_INCLUSIVE)
+    }
+
+    internal fun onFragmentDestroyView(fragment: StackScreenFragment) {
+        delegate.get()?.onDismiss(fragment.stackScreen)
+    }
+
+    companion object {
+        const val TAG = "StackContainer"
+    }
+}

--- a/android/app/src/main/java/com/lynxscreens/screens/host/StackContainer.kt
+++ b/android/app/src/main/java/com/lynxscreens/screens/host/StackContainer.kt
@@ -106,6 +106,15 @@ internal class StackContainer(
                 transaction.commitAllowingStateLoss()
             }
         }
+
+        // We manually trigger a layout pass because we have disabled Lynx's default
+        // native view management for StackHostComponent. Since the FragmentManager
+        // now handles the insertion of views into this container, we must ensure
+        // that the CoordinatorLayout (StackContainer) re-measures its children.
+        // Without this call, newly added fragment views might not be measured or
+        // laid out correctly, as the system may not immediately recognize the
+        // structural changes made by the FragmentManager transaction.
+        requestLayout()
     }
 
     private fun performOperation(

--- a/android/app/src/main/java/com/lynxscreens/screens/host/StackContainer.kt
+++ b/android/app/src/main/java/com/lynxscreens/screens/host/StackContainer.kt
@@ -7,6 +7,7 @@ import androidx.coordinatorlayout.widget.CoordinatorLayout
 import androidx.fragment.app.FragmentManager
 import androidx.fragment.app.FragmentTransaction
 import com.lynxscreens.screens.helpers.FragmentManagerHelper
+import com.lynxscreens.screens.helpers.ViewIdGenerator
 import com.lynxscreens.screens.helpers.createTransactionWithReordering
 import com.lynxscreens.screens.screen.StackScreenComponent
 import com.lynxscreens.screens.screen.StackScreenFragment
@@ -33,7 +34,7 @@ internal class StackContainer(
     private val pendingOperationQueue: MutableList<StackOperation> = arrayListOf()
 
     init {
-        id = generateViewId()
+        id = ViewIdGenerator.generateViewId()
     }
 
     override fun onAttachedToWindow() {

--- a/android/app/src/main/java/com/lynxscreens/screens/host/StackContainer.kt
+++ b/android/app/src/main/java/com/lynxscreens/screens/host/StackContainer.kt
@@ -3,7 +3,6 @@ package com.lynxscreens.screens.host
 import android.annotation.SuppressLint
 import android.content.Context
 import android.util.Log
-import android.view.View
 import androidx.coordinatorlayout.widget.CoordinatorLayout
 import androidx.fragment.app.FragmentManager
 import androidx.fragment.app.FragmentTransaction

--- a/android/app/src/main/java/com/lynxscreens/screens/host/StackContainerDelegate.kt
+++ b/android/app/src/main/java/com/lynxscreens/screens/host/StackContainerDelegate.kt
@@ -1,0 +1,7 @@
+package com.lynxscreens.screens.host
+
+import com.lynxscreens.screens.screen.StackScreenComponent
+
+internal interface StackContainerDelegate {
+    fun onDismiss(stackScreen: StackScreenComponent)
+}

--- a/android/app/src/main/java/com/lynxscreens/screens/host/StackHostComponent.kt
+++ b/android/app/src/main/java/com/lynxscreens/screens/host/StackHostComponent.kt
@@ -28,18 +28,12 @@ internal class StackHostComponent(context: LynxContext) : UIGroup<StackHostView>
         super.insertChild(child, index)
     }
 
-    override fun insertView(child: LynxUI<*>) {
-        super.insertView(child)
-
-        // TODO: @t0maboro 
-        // This is really bad workaround, Lynx takes the responsibility for both Lynx hierarchy (insertChild) and native hierarchy (insertView)
-        // For the native hierarchy, we want to have an intermediate component - StackContainer which will perform operations on FragmentManager level.
-        // FragmentManager should be responsible for attaching/detaching Screens, therefore, I'm forcefully detaching Screen from Host.
-        // This may break some important logic for Lynx that atm. I'm not aware of, but it should be resolved ASAP.
-        val childNativeView: View = child.view
-        if (childNativeView.parent === view) {
-            view.removeView(childNativeView)
-        }
+    override fun insertView(child: LynxUI<*>?) {
+        // NO-OP
+        // We intentionally ignore Lynx's default native view insertion here.
+        // Responsibility for building and managing the native view hierarchy is
+        // transferred to StackContainer, which utilizes FragmentManager to
+        // handle view attachment within the Fragment lifecycle.
     }
 
     override fun removeChild(child: LynxBaseUI?) {
@@ -47,6 +41,14 @@ internal class StackHostComponent(context: LynxContext) : UIGroup<StackHostView>
 
         unmountLynxSubview(child)
         super.removeChild(child)
+    }
+
+    override fun removeView(child: LynxBaseUI?) {
+        // NO-OP
+        // We intentionally ignore Lynx's default native view removal here.
+        // Responsibility for building and managing the native view hierarchy is
+        // transferred to StackContainer, which utilizes FragmentManager to
+        // handle view detachment within the Fragment lifecycle.
     }
 
     override fun removeAll() {

--- a/android/app/src/main/java/com/lynxscreens/screens/host/StackHostComponent.kt
+++ b/android/app/src/main/java/com/lynxscreens/screens/host/StackHostComponent.kt
@@ -1,0 +1,114 @@
+package com.lynxscreens.screens.host
+
+import android.content.Context
+import android.view.View
+import com.lynx.tasm.behavior.LynxContext
+import com.lynx.tasm.behavior.PatchFinishListener
+import com.lynx.tasm.behavior.ui.LynxBaseUI
+import com.lynx.tasm.behavior.ui.LynxUI
+import com.lynx.tasm.behavior.ui.UIGroup
+import com.lynxscreens.screens.screen.StackScreenComponent
+import java.lang.ref.WeakReference
+
+internal class StackHostComponent(context: LynxContext) : UIGroup<StackHostView>(context), StackContainerDelegate, PatchFinishListener {
+    internal val renderedScreens: ArrayList<StackScreenComponent> = arrayListOf()
+    private lateinit var container: StackContainer
+
+    override fun createView(context: Context?): StackHostView {
+        val lynxContext = context as LynxContext
+        container = StackContainer(lynxContext, WeakReference(this))
+
+        return StackHostView(lynxContext, container)
+    }
+
+    override fun insertChild(child: LynxBaseUI?, index: Int) {
+        require(child is StackScreenComponent) { "[RNScreens] Attempt to attach child that is not of type ${StackScreenComponent::javaClass.name}" }
+
+        mountLynxSubviewAt(child, index)
+        super.insertChild(child, index)
+    }
+
+    override fun insertView(child: LynxUI<*>) {
+        super.insertView(child)
+
+        // TODO: @t0maboro 
+        // This is really bad workaround, Lynx takes the responsibility for both Lynx hierarchy (insertChild) and native hierarchy (insertView)
+        // For the native hierarchy, we want to have an intermediate component - StackContainer which will perform operations on FragmentManager level.
+        // FragmentManager should be responsible for attaching/detaching Screens, therefore, I'm forcefully detaching Screen from Host.
+        // This may break some important logic for Lynx that atm. I'm not aware of, but it should be resolved ASAP.
+        val childNativeView: View = child.view
+        if (childNativeView.parent === view) {
+            view.removeView(childNativeView)
+        }
+    }
+
+    override fun removeChild(child: LynxBaseUI?) {
+        require(child is StackScreenComponent) { "[RNScreens] Attempt to remove child that is not of type ${StackScreenComponent::javaClass.name}" }
+
+        unmountLynxSubview(child)
+        super.removeChild(child)
+    }
+
+    override fun removeAll() {
+        unmountAllLynxSubviews()
+        super.removeAll()
+    }
+
+    override fun getChildAt(index: Int): LynxBaseUI? {
+        return renderedScreens.getOrNull(index)
+    }
+
+    override fun getChildCount(): Int {
+        return renderedScreens.size
+    }
+
+    private fun mountLynxSubviewAt(
+        stackScreen: StackScreenComponent,
+        index: Int,
+    ) {
+        renderedScreens.add(index, stackScreen)
+        stackScreen.stackHost = WeakReference(this)
+        enqueueAddOperationToContainerIfNeeded(stackScreen)
+    }
+
+    private fun unmountLynxSubview(lynxSubview: StackScreenComponent) {
+        renderedScreens.remove(lynxSubview)
+        enqueuePopOperationToContainerIfNeeded(lynxSubview)
+    }
+
+    private fun unmountAllLynxSubviews() {
+        renderedScreens.asReversed().forEach {
+            enqueuePopOperationToContainerIfNeeded(it)
+        }
+        renderedScreens.clear()
+    }
+
+    private fun enqueueAddOperationToContainerIfNeeded(stackScreen: StackScreenComponent) {
+        if (stackScreen.activityMode == StackScreenComponent.ActivityMode.ATTACHED) {
+            container.enqueueAddOperation(stackScreen)
+        }
+    }
+
+    private fun enqueuePopOperationToContainerIfNeeded(stackScreen: StackScreenComponent) {
+        if (stackScreen.activityMode == StackScreenComponent.ActivityMode.ATTACHED && !stackScreen.isNativelyDismissed) {
+            container.enqueuePopOperation(stackScreen)
+        }
+    }
+
+    internal fun stackScreenChangedActivityMode(stackScreen: StackScreenComponent) {
+        when (stackScreen.activityMode) {
+            StackScreenComponent.ActivityMode.DETACHED -> container.enqueuePopOperation(stackScreen)
+            StackScreenComponent.ActivityMode.ATTACHED -> container.enqueueAddOperation(stackScreen)
+        }
+    }
+
+    override fun onDismiss(stackScreen: StackScreenComponent) {
+        if (stackScreen.activityMode == StackScreenComponent.ActivityMode.ATTACHED) {
+            stackScreen.isNativelyDismissed = true
+        }
+    }
+
+    override fun onPatchFinish() {
+        container.performContainerUpdateIfNeeded()
+    }
+}

--- a/android/app/src/main/java/com/lynxscreens/screens/host/StackHostComponent.kt
+++ b/android/app/src/main/java/com/lynxscreens/screens/host/StackHostComponent.kt
@@ -21,7 +21,7 @@ internal class StackHostComponent(context: LynxContext) : UIGroup<StackHostView>
         return StackHostView(lynxContext, container)
     }
 
-    override fun insertChild(child: LynxBaseUI?, index: Int) {
+    override fun insertChild(child: LynxBaseUI, index: Int) {
         require(child is StackScreenComponent) { "[RNScreens] Attempt to attach child that is not of type ${StackScreenComponent::javaClass.name}" }
 
         mountLynxSubviewAt(child, index)

--- a/android/app/src/main/java/com/lynxscreens/screens/host/StackHostView.kt
+++ b/android/app/src/main/java/com/lynxscreens/screens/host/StackHostView.kt
@@ -1,0 +1,43 @@
+package com.lynxscreens.screens.host
+
+import android.annotation.SuppressLint
+import android.util.Log
+import android.view.ViewGroup
+import com.lynx.tasm.behavior.LynxContext
+
+@SuppressLint("ViewConstructor") // should never be restored
+internal class StackHostView(
+    private val lynxContext: LynxContext,
+    private val container: StackContainer,
+) : ViewGroup(lynxContext) {
+    init {
+        addView(container)
+    }
+
+    override fun onAttachedToWindow() {
+        Log.d(TAG, "StackHost [$id] attached to window")
+        super.onAttachedToWindow()
+    }
+
+    override fun onMeasure(
+        widthMeasureSpec: Int,
+        heightMeasureSpec: Int,
+    ) {
+        super.onMeasure(widthMeasureSpec, heightMeasureSpec)
+        container.measure(widthMeasureSpec, heightMeasureSpec)
+    }
+
+    override fun onLayout(
+        changed: Boolean,
+        l: Int,
+        t: Int,
+        r: Int,
+        b: Int,
+    ) {
+        container.layout(l, t, r, b)
+    }
+
+    companion object {
+        const val TAG = "StackHost"
+    }
+}

--- a/android/app/src/main/java/com/lynxscreens/screens/screen/StackScreenComponent.kt
+++ b/android/app/src/main/java/com/lynxscreens/screens/screen/StackScreenComponent.kt
@@ -34,6 +34,10 @@ internal class StackScreenComponent(context: LynxContext) : UIGroup<StackScreenV
 
     internal var screenKey: String? = null
 
+    private val eventEmitter: StackScreenEventEmitter by lazy {
+        StackScreenEventEmitter(lynxContext, sign)
+    }
+
     override fun createView(context: Context?): StackScreenView = StackScreenView(context as LynxContext)
 
     @LynxProp(name = "activityMode")
@@ -57,33 +61,9 @@ internal class StackScreenComponent(context: LynxContext) : UIGroup<StackScreenV
         screenKey = value
     }
 
-    internal fun notifyOnWillAppear() {
-        emitEvent("OnWillAppear", null)
-    }
-
-    internal fun notifyOnDidAppear() {
-        emitEvent("OnDidAppear", null)
-    }
-
-    internal fun notifyOnWillDisappear() {
-        emitEvent("OnWillDisappear", null)
-    }
-
-    internal fun notifyOnDidDisappear() {
-        emitEvent("OnDidDisappear", null)
-    }
-
-    internal fun notifyOnDismiss(isNativeDismiss: Boolean) {
-        emitEvent("OnDismiss", mapOf(
-            "isNativeDismiss" to isNativeDismiss
-        ))
-    }
-
-    private fun emitEvent(name: String, value: Map<String, Any>?) {
-        val detail = LynxCustomEvent(sign, name)
-        value?.forEach { (key, v) ->
-            detail.addDetail(key, v)
-        }
-        lynxContext.eventEmitter.sendCustomEvent(detail)
-    }
+    internal fun notifyOnWillAppear() = eventEmitter.notifyOnWillAppear()
+    internal fun notifyOnDidAppear() = eventEmitter.notifyOnDidAppear()
+    internal fun notifyOnWillDisappear() = eventEmitter.notifyOnWillDisappear()
+    internal fun notifyOnDidDisappear() = eventEmitter.notifyOnDidDisappear()
+    internal fun notifyOnDismiss(isNativeDismiss: Boolean) = eventEmitter.notifyOnDismiss(isNativeDismiss)
 }

--- a/android/app/src/main/java/com/lynxscreens/screens/screen/StackScreenComponent.kt
+++ b/android/app/src/main/java/com/lynxscreens/screens/screen/StackScreenComponent.kt
@@ -1,0 +1,89 @@
+package com.lynxscreens.screens.screen
+
+import android.content.Context
+import com.lynx.tasm.behavior.LynxContext
+import com.lynx.tasm.behavior.LynxProp
+import com.lynx.tasm.behavior.ui.UIGroup
+import com.lynx.tasm.event.LynxCustomEvent
+import com.lynxscreens.screens.host.StackHostComponent
+import java.lang.IllegalArgumentException
+import java.lang.ref.WeakReference
+import kotlin.properties.Delegates
+
+internal class StackScreenComponent(context: LynxContext) : UIGroup<StackScreenView>(context) {
+    enum class ActivityMode {
+        DETACHED,
+        ATTACHED,
+    }
+
+    internal var isNativelyDismissed = false
+        set(value) {
+            require(value) {
+                "[RNScreens] Natively dismissed StackScreen must remain dismissed."
+            }
+            field = true
+        }
+
+    internal var stackHost: WeakReference<StackHostComponent?> = WeakReference(null)
+
+    internal var activityMode: ActivityMode by Delegates.observable(ActivityMode.DETACHED) { _, oldValue, newValue ->
+        if (oldValue != newValue) {
+            stackHost.get()?.stackScreenChangedActivityMode(this)
+        }
+    }
+
+    internal var screenKey: String? = null
+
+    override fun createView(context: Context?): StackScreenView = StackScreenView(context as LynxContext)
+
+    @LynxProp(name = "activityMode")
+    fun setActivityMode(
+        value: String?,
+    ) {
+        when (value) {
+            "attached" -> activityMode = ActivityMode.ATTACHED
+            "detached" -> activityMode = ActivityMode.DETACHED
+            else -> throw IllegalArgumentException("[RNScreens] Invalid activity mode: $value.")
+        }
+    }
+
+    @LynxProp(name = "screenKey")
+    fun setScreenKey(
+        value: String?,
+    ) {
+        requireNotNull(value) {
+            "[RNScreens] screenKey must not be null."
+        }
+        screenKey = value
+    }
+
+    internal fun notifyOnWillAppear() {
+        emitEvent("OnWillAppear", null)
+    }
+
+    internal fun notifyOnDidAppear() {
+        emitEvent("OnDidAppear", null)
+    }
+
+    internal fun notifyOnWillDisappear() {
+        emitEvent("OnWillDisappear", null)
+    }
+
+    internal fun notifyOnDidDisappear() {
+        emitEvent("OnDidDisappear", null)
+    }
+
+    internal fun notifyOnDismiss(isNativeDismiss: Boolean) {
+        emitEvent("OnDismiss", mapOf(
+            "isNativeDismiss" to isNativeDismiss
+        ))
+    }
+
+    private fun emitEvent(name: String, value: Map<String, Any>?) {
+        val detail = LynxCustomEvent(sign, name)
+        value?.forEach { (key, v) ->
+            detail.addDetail(key, v)
+        }
+        lynxContext.eventEmitter.sendCustomEvent(detail)
+    }
+}

--- a/android/app/src/main/java/com/lynxscreens/screens/screen/StackScreenEventEmitter.kt
+++ b/android/app/src/main/java/com/lynxscreens/screens/screen/StackScreenEventEmitter.kt
@@ -1,0 +1,37 @@
+package com.lynxscreens.screens.screen
+
+import com.lynx.tasm.behavior.LynxContext
+import com.lynx.tasm.event.LynxCustomEvent
+
+internal class StackScreenEventEmitter(
+    private val lynxContext: LynxContext,
+    private val sign: Int
+) {
+    companion object {
+        private const val EVENT_WILL_APPEAR = "OnWillAppear"
+        private const val EVENT_DID_APPEAR = "OnDidAppear"
+        private const val EVENT_WILL_DISAPPEAR = "OnWillDisappear"
+        private const val EVENT_DID_DISAPPEAR = "OnDidDisappear"
+        private const val EVENT_ON_DISMISS = "OnDismiss"
+    }
+
+    fun notifyOnWillAppear() = emit(EVENT_WILL_APPEAR)
+
+    fun notifyOnDidAppear() = emit(EVENT_DID_APPEAR)
+
+    fun notifyOnWillDisappear() = emit(EVENT_WILL_DISAPPEAR)
+
+    fun notifyOnDidDisappear() = emit(EVENT_DID_DISAPPEAR)
+
+    fun notifyOnDismiss(isNativeDismiss: Boolean) {
+        emit(EVENT_ON_DISMISS, mapOf("isNativeDismiss" to isNativeDismiss))
+    }
+
+    private fun emit(name: String, params: Map<String, Any>? = null) {
+        val event = LynxCustomEvent(sign, name)
+        params?.forEach { (key, value) ->
+            event.addDetail(key, value)
+        }
+        lynxContext.eventEmitter.sendCustomEvent(event)
+    }
+}

--- a/android/app/src/main/java/com/lynxscreens/screens/screen/StackScreenFragment.kt
+++ b/android/app/src/main/java/com/lynxscreens/screens/screen/StackScreenFragment.kt
@@ -1,0 +1,46 @@
+package com.lynxscreens.screens.screen
+
+import android.os.Bundle
+import android.view.LayoutInflater
+import android.view.View
+import android.view.ViewGroup
+import androidx.fragment.app.Fragment
+import com.lynxscreens.screens.host.StackContainer
+import java.lang.ref.WeakReference
+
+internal class StackScreenFragment(
+    internal val stackContainer: WeakReference<StackContainer>,
+    internal val stackScreen: StackScreenComponent,
+) : Fragment() {
+    override fun onCreateView(
+        inflater: LayoutInflater,
+        container: ViewGroup?,
+        savedInstanceState: Bundle?,
+    ): View = stackScreen.view
+
+    override fun onStart() {
+        stackScreen.notifyOnWillAppear()
+        super.onStart()
+    }
+
+    override fun onResume() {
+        stackScreen.notifyOnDidAppear()
+        super.onResume()
+    }
+
+    override fun onPause() {
+        stackScreen.notifyOnWillDisappear()
+        super.onPause()
+    }
+
+    override fun onStop() {
+        stackScreen.notifyOnDidDisappear()
+        super.onStop()
+    }
+
+    override fun onDestroyView() {
+        stackContainer.get()?.onFragmentDestroyView(this)
+        stackScreen.notifyOnDismiss(stackScreen.activityMode == StackScreenComponent.ActivityMode.ATTACHED)
+        super.onDestroyView()
+    }
+}

--- a/android/app/src/main/java/com/lynxscreens/screens/screen/StackScreenView.kt
+++ b/android/app/src/main/java/com/lynxscreens/screens/screen/StackScreenView.kt
@@ -1,0 +1,10 @@
+package com.lynxscreens.screens.screen
+
+import android.annotation.SuppressLint
+import com.lynx.tasm.behavior.LynxContext
+import com.lynx.tasm.behavior.ui.view.AndroidView
+
+@SuppressLint("ViewConstructor") // should never be restored
+class StackScreenView(
+    private val lynxContext: LynxContext,
+) : AndroidView(lynxContext) {}

--- a/src/utils/reducer.ts
+++ b/src/utils/reducer.ts
@@ -72,7 +72,10 @@ function navigationActionPushHandler(
     const route = state[renderedRouteIndex];
 
     console.info(`[Stack] Route ${route.name} already rendered, attaching it`);
-    const newState = state.toSpliced(renderedRouteIndex, 1);
+    const newState = [
+    ...state.slice(0, renderedRouteIndex),
+    ...state.slice(renderedRouteIndex + 1)
+  ];
     const routeCopy = { ...route };
     routeCopy.activityMode = 'attached';
     // Please note that we are pushing the route copy to the end of the array,
@@ -171,7 +174,10 @@ function navigationActionPopCompletedHandler(
 
   // Let's remove the route from the state
   // TODO: Consider adding option for keeping it in state.
-  const newState = state.toSpliced(routeIndex, 1);
+  const newState = [
+    ...state.slice(0, routeIndex),
+    ...state.slice(routeIndex + 1)
+  ];
   return newState;
 }
 
@@ -200,7 +206,10 @@ function navigationActionNativePopHandler(
     console.warn('[Stack] natively popped route has "detached" state');
   }
 
-  const newState = state.toSpliced(routeIndex, 1);
+  const newState = [
+    ...state.slice(0, routeIndex),
+    ...state.slice(routeIndex + 1)
+  ];
   return newState;
 }
 


### PR DESCRIPTION
### Description

This PR introduces a base implementation of native-stack v5 on Android. It's aligned with the state from https://github.com/software-mansion/react-native-screens/tree/59ae1b51d7e208f20483262da543c56fe72f8fcd and does not include any newer updates - these will be added in follow-up PRs.

The general goal was to maintain a shared codebase between platforms. On the JS side, I'm including 1 change to satisfy types
```
Property 'toSpliced' does not exist on type 'StackState'. Do you need to change your target library? Try changing the 'lib' compiler option to 'es2023' or later.
``` 
On the native side, the logic was kept as close as possible to the reference implementation, while also adapting it to fit the Lynx framework. As Lynx currently follows a pattern closer to the old RN architecture, some adjustments were necessary to integrate with the existing framework properly.

The overall design and direction are intended to be compatible with the goals described in https://github.com/software-mansion/react-native-screens-labs/pull/714and https://github.com/software-mansion/react-native-screens-labs/pull/753.

---

### StackHostComponent

> [!NOTE]  
> The current implementation differs from its RN equivalent.

StackHostComponent is a native component responsible for managing a stack-based navigation flow using Lynx UI components. It acts as a controller for child screen components (StackScreenComponent), taking full responsibility for orchestrating their mounting/unmounting logic based on activity state, with integration into the native FragmentManager via an intermediate container.

Key implementation details:

- Upon creation, `StackHostComponent` instantiates a `StackContainer` - a dedicated native handler responsible for managing screen attachment and detachment at the `FragmentManager` level.
- `insertChild` inserts a screen, mounts it in the Lynx Component Tree, and enqueues a container add operation if needed.
- `insertView` contains a workaround for compatibility issues between the Lynx component tree and the native view hierarchy. Since mounting occurs via the `StackContainer` (`FragmentManager`), any view directly added to the parent is forcibly removed to prevent double insertion.
- It implements `PatchFinishListener` to ensure that all scheduled container operations (add/remove) are committed only after the current patching transaction completes.

---

### StackScreenComponent

> [!NOTE]  
> The current implementation should be close to the RN equivalent.

`StackScreenComponent` is a native component that represents a single Screen in a native stack navigator.

`StackScreenComponent` encapsulates screen-specific view and controller logic, exposes lifecycle event hooks, and allows the screen's presence in the stack to be controlled.

---

### A few words about the structure

In Lynx, a `Component` represents a bridge between the declarative UI layer and the native platform-specific rendering and behavior. `Components` provide reusable, composable **units** that can be dynamically created or destroyed based on the Element Tree (JS). Each `Component` abstracts and wraps a native `View`, `ViewGroup` or `AndroidView` (a Lynx custom wrapper over `ViewGroup`) and is responsible for managing:

- communication with children Components.
- the native view's lifecycle and mounting/unmounting.
- event emission.
- synchronization between JS state and native rendering.
- transformation of abstract layout logic into native UI updates.

Component vs. View:

Within this architecture, there's a clear separation between these two:

- The Component - which encapsulates logic, state, and lifecycle behavior (including child components management, mounting transactions, etc.).
- The View - the native view instance that actually gets added to the screen.
- The View class (e.g., `StackHostView`) is lightweight and unaware of high-level behaviors. It simply interacts with Android OS layer and notifies its owning Component of some lifecycle events. The real orchestration - mounting child components, resolving layout, etc. - should always happen on the Component's level.

---

Corresponding commit from `react-native-screens`: https://github.com/software-mansion/react-native-screens/tree/59ae1b51d7e208f20483262da543c56fe72f8fcd

https://github.com/user-attachments/assets/75ceec4b-5402-4ae2-9767-f7718b53b285

