### PR TITLE
chore: Align tsconfig files

### DIFF
--- a/src/tsconfig.json
+++ b/src/tsconfig.json
@@ -3,12 +3,6 @@
   "compilerOptions": {
     "composite": true,
 
-    "jsx": "react-jsx",
-    "jsxImportSource": "@lynx-js/react",
-
-    "module": "ESNext",
-    "moduleResolution": "Bundler",
-
     "noEmit": true,
   },
   "include": ["./**/*.ts", "./**/*.tsx"],

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -3,8 +3,9 @@
     "jsx": "preserve",
     "jsxImportSource": "@lynx-js/react",
 
-    "module": "node16",
-    "moduleResolution": "node16",
+    "target": "ESNext",
+    "module": "ESNext", 
+    "moduleResolution": "Bundler",
 
     "strict": true,
     "isolatedModules": true,


### PR DESCRIPTION
Fixing type errors about explicit file extensions, because these were really annoying.

- Switched from `node16` to `Bundler` to support extension-less imports
- Aligned module generation between configs to use `ESNext` standard
- Deduplicated entries

`npm run dev` shouldn't throw any TS errors