### PR TITLE
feat(Android, Stack): Add support for nested stacks

### DIFF
--- a/android/app/src/main/java/com/lynxscreens/screens/ext/ViewExt.kt
+++ b/android/app/src/main/java/com/lynxscreens/screens/ext/ViewExt.kt
@@ -1,0 +1,12 @@
+package com.lynxscreens.screens.ext
+
+import android.view.View
+import androidx.fragment.app.Fragment
+import androidx.fragment.app.findFragment
+
+internal fun View.findFragmentOrNull(): Fragment? =
+    try {
+        this.findFragment()
+    } catch (_: IllegalStateException) {
+        null
+    }

--- a/android/app/src/main/java/com/lynxscreens/screens/host/StackHostComponent.kt
+++ b/android/app/src/main/java/com/lynxscreens/screens/host/StackHostComponent.kt
@@ -31,11 +31,6 @@ internal class StackHostComponent(context: LynxContext) : UIGroup<StackHostView>
         if (child.activityMode == StackScreenComponent.ActivityMode.ATTACHED) {
             // Insert always at the last index
             mountLynxSubviewAt(child)
-            // We manually trigger a layout pass because we have disabled Lynx's default
-            // native view management for StackHostComponent. Since the FragmentManager
-            // now handles the insertion of views into this container, we must ensure
-            // that the CoordinatorLayout (StackContainer) re-measures its children when relevant.
-            requestLayout()
             // Add the component to Lynx children, only when it's attached
             super.insertChild(child, super.getChildCount())
         }
@@ -63,6 +58,14 @@ internal class StackHostComponent(context: LynxContext) : UIGroup<StackHostView>
         // transferred to StackContainer, which utilizes FragmentManager to
         // handle view detachment within the Fragment lifecycle.
     }
+
+    // Overriding needCustomLayout to return `true` allows this component to handle its own
+    // child layout logic instead of relying on Lynx's default layout mechanism.
+    // This is necessary because StackScreenComponent instances are managed manually and rendered
+    // through StackContainer, which uses FragmentManager to attach/detach views as Android fragments.
+    // Automatic Lynx layout would interfere with fragment lifecycle.
+    // This is correlated with overridden `onLayout` method on StackHostView.
+    override fun needCustomLayout(): Boolean = true
 
     override fun removeAll() {
         unmountAllLynxSubviews()

--- a/android/app/src/main/java/com/lynxscreens/screens/screen/StackScreenView.kt
+++ b/android/app/src/main/java/com/lynxscreens/screens/screen/StackScreenView.kt
@@ -1,10 +1,17 @@
 package com.lynxscreens.screens.screen
 
 import android.annotation.SuppressLint
+import androidx.fragment.app.Fragment
 import com.lynx.tasm.behavior.LynxContext
 import com.lynx.tasm.behavior.ui.view.AndroidView
+import com.lynxscreens.screens.common.FragmentProviding
+import com.lynxscreens.screens.ext.findFragmentOrNull
 
 @SuppressLint("ViewConstructor") // should never be restored
 class StackScreenView(
     private val lynxContext: LynxContext,
-) : AndroidView(lynxContext) {}
+) : AndroidView(lynxContext), FragmentProviding {
+    override fun getAssociatedFragment(): Fragment? = this.findFragmentOrNull()?.also {
+        check(it is StackScreenFragment) { "[RNScreens] Unexpected fragment type: ${it.javaClass.simpleName}"}
+    }
+}

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -10,7 +10,7 @@ export function App(props: { onRender?: () => void }) {
         height: '100%',
       }}
     >
-      <Tests.TestBase />
+      <Tests.TestNested />
     </page>
   );
 }

--- a/src/examples/TestNested.tsx
+++ b/src/examples/TestNested.tsx
@@ -1,0 +1,131 @@
+import React from 'react';
+
+import { StackContainer } from '../components/StackContainer';
+import type { StackRouteConfig } from '../types/StackContainer';
+import { useStackNavigationContext } from '../hooks/useStackNavigationContext';
+
+interface ButtonProps {
+  onTap: () => void;
+  label: string;
+}
+
+const Button = ({ onTap, label }: ButtonProps) => (
+  <view
+    style={{
+      width: '200px',
+      height: '50px',
+      backgroundColor: 'blue',
+      justifyContent: 'center',
+      alignItems: 'center',
+      marginBottom: '10px',
+    }}
+    bindtap={onTap}
+  >
+    <text
+      native-interaction-enabled={false}
+      user-interaction-enabled={false}
+      style={{ color: 'white' }}
+    >
+      {label}
+    </text>
+  </view>
+);
+
+function TemplateScreen() {
+  const navigation = useStackNavigationContext();
+
+  return (
+    <view
+      style={{
+        display: 'flex',
+        height: '100%',
+        width: '100%',
+        backgroundColor: 'white',
+        justifyContent: 'center',
+        alignItems: 'center',
+        flexDirection: 'column',
+      }}
+    >
+      <text>Route: {navigation.routeKey}</text>
+      <Button label="Push A" onTap={() => navigation.push('A')} />
+      <Button label="Push B" onTap={() => navigation.push('B')} />
+      <Button
+        label="Push NestedStack"
+        onTap={() => navigation.push('NestedStack')}
+      />
+      <Button label="Pop" onTap={() => navigation.pop(navigation.routeKey)} />
+      <Button label="Preload A" onTap={() => navigation.preload('A')} />
+      <Button label="Preload B" onTap={() => navigation.preload('B')} />
+    </view>
+  );
+}
+
+function NestedTemplateScreen() {
+  const navigation = useStackNavigationContext();
+
+  return (
+    <view
+      style={{
+        display: 'flex',
+        height: '100%',
+        width: '100%',
+        backgroundColor: 'white',
+        justifyContent: 'center',
+        alignItems: 'center',
+        flexDirection: 'column',
+      }}
+    >
+      <text>Route: {navigation.routeKey}</text>
+      <Button label="Push NestedA" onTap={() => navigation.push('NestedA')} />
+      <Button label="Push NestedB" onTap={() => navigation.push('NestedB')} />
+      <Button label="Pop" onTap={() => navigation.pop(navigation.routeKey)} />
+      <Button
+        label="Preload NestedA"
+        onTap={() => navigation.preload('NestedA')}
+      />
+      <Button
+        label="Preload NestedB"
+        onTap={() => navigation.preload('NestedB')}
+      />
+    </view>
+  );
+}
+
+function NestedStackScreen() {
+  return <StackContainer routeConfigs={ROUTE_CONFIGS_NESTED_STACK} />;
+}
+
+const ROUTE_CONFIGS: StackRouteConfig[] = [
+  {
+    name: 'A',
+    Component: TemplateScreen,
+    options: {},
+  },
+  {
+    name: 'B',
+    Component: TemplateScreen,
+    options: {},
+  },
+  {
+    name: 'NestedStack',
+    Component: NestedStackScreen,
+    options: {},
+  },
+];
+
+const ROUTE_CONFIGS_NESTED_STACK: StackRouteConfig[] = [
+  {
+    name: 'NestedA',
+    Component: NestedTemplateScreen,
+    options: {},
+  },
+  {
+    name: 'NestedB',
+    Component: NestedTemplateScreen,
+    options: {},
+  },
+];
+
+export default function App() {
+  return <StackContainer routeConfigs={ROUTE_CONFIGS} />;
+}

--- a/src/examples/index.ts
+++ b/src/examples/index.ts
@@ -1,2 +1,3 @@
 export { default as TestBatch } from './TestBatch';
 export { default as TestBase } from './TestBase';
+export { default as TestNested } from './TestNested';

--- a/src/native_components/StackHostNativeComponent.tsx
+++ b/src/native_components/StackHostNativeComponent.tsx
@@ -7,6 +7,8 @@ export const StackHostNativeComponent = ({ children }: Lynx.ViewProps) => {
       style={{
         display: 'flex',
         flex: 1,
+        width: '100%',
+        height: '100%',
       }}
     >
       {children}


### PR DESCRIPTION
Related commit from RNS: https://github.com/software-mansion/react-native-screens/commit/b6d053c0911bc477a78595fa3e64ec55aed24e08 

### Description

`StackScreen` implements the `FragmentProviding` interface. This causes the `StackContainer` of the nested stack to use the parent container's `childFragmentManager` instead of reusing `supportFragmentManager`.

### Other non-RN related changes

Previously, we manually called `requestLayout` to ensure that `CoordinatorLayout` recognized view updates. This approach has been replaced by overriding `needCustomLayout` on Host. It prevents Lynx native view management from clashing with the Android FragmentManager.

Closes: https://github.com/software-mansion/lynx-screens/issues/34

---

### Testing

Added TestNested to examples.

https://github.com/user-attachments/assets/62695082-ab58-4fa8-9b65-9a99964c804b
