### PR TITLE
fix(Android, Stack): Update stack model after native pop

### DIFF
--- a/android/app/src/main/java/com/lynxscreens/screens/host/StackContainer.kt
+++ b/android/app/src/main/java/com/lynxscreens/screens/host/StackContainer.kt
@@ -19,7 +19,14 @@ internal class StackContainer(
 ) : CoordinatorLayout(context) {
     private var fragmentManager: FragmentManager? = null
 
-    private val stackScreenFragments: MutableList<StackScreenFragment> = arrayListOf()
+    /**
+     * Describes most up-to-date view of the stack. It might be different from
+     * state kept by FragmentManager as this data structure is updated immediately,
+     * while operations on fragment manager are scheduled.
+     *
+     * FIXME: In case of native-pop, this might be out of date!
+     */
+    private val stackModel: MutableList<StackScreenFragment> = arrayListOf()
 
     private val pendingPopOperations: MutableList<PopOperation> = arrayListOf()
     private val pendingPushOperations: MutableList<PushOperation> = arrayListOf()
@@ -81,7 +88,7 @@ internal class StackContainer(
         val transaction = fragmentManager.createTransactionWithReordering()
 
         val associatedFragment = StackScreenFragment(WeakReference(this), operation.screen)
-        stackScreenFragments.add(associatedFragment)
+        stackModel.add(associatedFragment)
 
         transaction.add(this.id, associatedFragment)
 
@@ -97,7 +104,7 @@ internal class StackContainer(
         fragmentManager: FragmentManager,
         operation: PopOperation,
     ) {
-        val associatedFragment = stackScreenFragments.find { it.stackScreen === operation.screen }
+        val associatedFragment = stackModel.find { it.stackScreen === operation.screen }
         require(associatedFragment != null) {
             "[RNScreens] Unable to find a fragment to pop."
         }
@@ -115,10 +122,13 @@ internal class StackContainer(
             transaction.commitNowAllowingStateLoss()
         }
 
-        stackScreenFragments.remove(associatedFragment)
+        stackModel.remove(associatedFragment)
     }
 
     internal fun onFragmentDestroyView(fragment: StackScreenFragment) {
+        if (stackModel.remove(fragment) && !fragment.stackScreen.isNativelyDismissed) {
+            Log.e(TAG, "[RNScreens] StackContainer natively popped a screen that was not in model!")
+        }
         delegate.get()?.onScreenDismiss(fragment.stackScreen)
     }
 


### PR DESCRIPTION
Related commit from RNS: https://github.com/software-mansion/react-native-screens/commit/ec8623025d19499470c32e43a6920f80603be4aa

### Description

(Copying the description from RNS, because it nicely describes the problem.)

Currently when doing native pop, the `stackModel` stored in `StackContainer` is never updated, therefore leading to an incorrect state held (natively dismissed fragments are never removed from the state).

This PR changes that.

Currently I remove them from the state in `onFragmentDestroyView`, and it seems to work, however I'm not sure, this is the perfect place timing-wise. This callback is called only after fragment's view is destroyed, which might be pretty late in component lifecycle, and we might execute container operations still taking into consideration possibly removed screens. We need to look into that later.

Closes: https://github.com/software-mansion/lynx-screens/issues/35

---

### Testing

Verified with breakpoints in StackContainer that stackModel is up-to-date after dismissing screens natively.