### PR TITLE
feat(Android, Stack): Add support for native navigation in nested stacks

### DIFF
--- a/android/app/src/main/java/com/lynxscreens/screens/host/FragmentOperation.kt
+++ b/android/app/src/main/java/com/lynxscreens/screens/host/FragmentOperation.kt
@@ -1,0 +1,69 @@
+package com.lynxscreens.screens.host
+
+import androidx.fragment.app.FragmentManager
+import com.lynxscreens.screens.screen.StackScreenFragment
+
+internal sealed class FragmentOperation {
+    internal abstract fun execute(
+        fragmentManager: FragmentManager,
+        executor: FragmentOperationExecutor,
+    )
+}
+
+internal class AddOp(
+    val fragment: StackScreenFragment,
+    val containerViewId: Int,
+    val addToBackStack: Boolean,
+    val allowStateLoss: Boolean = true,
+) : FragmentOperation() {
+    override fun execute(
+        fragmentManager: FragmentManager,
+        executor: FragmentOperationExecutor,
+    ) {
+        executor.executeAddOp(fragmentManager, this)
+    }
+}
+
+internal class PopBackStackOp(
+    val fragment: StackScreenFragment,
+) : FragmentOperation() {
+    override fun execute(
+        fragmentManager: FragmentManager,
+        executor: FragmentOperationExecutor,
+    ) {
+        executor.executePopBackStackOp(fragmentManager, this)
+    }
+}
+
+internal class RemoveOp(
+    val fragment: StackScreenFragment,
+    val allowStateLoss: Boolean = true,
+    val flushSync: Boolean = false,
+) : FragmentOperation() {
+    override fun execute(
+        fragmentManager: FragmentManager,
+        executor: FragmentOperationExecutor,
+    ) {
+        executor.executeRemoveOp(fragmentManager, this)
+    }
+}
+
+internal class FlushNowOp : FragmentOperation() {
+    override fun execute(
+        fragmentManager: FragmentManager,
+        executor: FragmentOperationExecutor,
+    ) {
+        executor.executeFlushOp(fragmentManager, this)
+    }
+}
+
+internal class SetPrimaryNavFragmentOp(
+    val fragment: StackScreenFragment,
+) : FragmentOperation() {
+    override fun execute(
+        fragmentManager: FragmentManager,
+        executor: FragmentOperationExecutor,
+    ) {
+        executor.executeSetPrimaryNavFragmentOp(fragmentManager, this)
+    }
+}

--- a/android/app/src/main/java/com/lynxscreens/screens/host/FragmentOperationExecutor.kt
+++ b/android/app/src/main/java/com/lynxscreens/screens/host/FragmentOperationExecutor.kt
@@ -1,0 +1,82 @@
+package com.lynxscreens.screens.host
+
+import androidx.fragment.app.FragmentManager
+import androidx.fragment.app.FragmentTransaction
+import com.lynxscreens.screens.helpers.createTransactionWithReordering
+
+internal class FragmentOperationExecutor {
+    internal fun executeOperations(
+        fragmentManager: FragmentManager,
+        ops: List<FragmentOperation>,
+        flushSync: Boolean = false
+    ) {
+        ops.forEach { it.execute(fragmentManager, this) }
+
+        if (flushSync) {
+            fragmentManager.executePendingTransactions()
+        }
+    }
+
+    internal fun executeAddOp(fragmentManager: FragmentManager, op: AddOp) {
+        fragmentManager.createTransactionWithReordering().let { tx ->
+            tx.add(op.containerViewId, op.fragment)
+            if (op.addToBackStack) {
+                tx.addToBackStack(op.fragment.stackScreen.screenKey)
+            }
+            commitTransaction(tx, op.allowStateLoss)
+        }
+    }
+
+    internal fun executePopBackStackOp(fragmentManager: FragmentManager, op: PopBackStackOp) {
+        fragmentManager.popBackStack(
+            op.fragment.stackScreen.screenKey,
+            FragmentManager.POP_BACK_STACK_INCLUSIVE
+        )
+    }
+
+    internal fun executeRemoveOp(fragmentManager: FragmentManager, op: RemoveOp) {
+        fragmentManager.createTransactionWithReordering().let { tx ->
+            tx.remove(op.fragment)
+            commitTransaction(tx, op.allowStateLoss, op.flushSync)
+        }
+    }
+
+    internal fun executeFlushOp(fragmentManager: FragmentManager, op: FlushNowOp) {
+        fragmentManager.executePendingTransactions()
+    }
+
+    internal fun executeSetPrimaryNavFragmentOp(fragmentManager: FragmentManager, op: SetPrimaryNavFragmentOp) {
+        fragmentManager.createTransactionWithReordering().let { tx ->
+            tx.setPrimaryNavigationFragment(op.fragment)
+            commitTransaction(tx, allowStateLoss = true, flushSync = false)
+        }
+    }
+
+    private fun commitTransaction(
+        tx: FragmentTransaction,
+        allowStateLoss: Boolean,
+        flushSync: Boolean = false
+    ) {
+        if (flushSync) {
+            commitSync(tx, allowStateLoss)
+        } else {
+            commitAsync(tx, allowStateLoss)
+        }
+    }
+
+    private fun commitAsync(tx: FragmentTransaction, allowStateLoss: Boolean) {
+        if (allowStateLoss) {
+            tx.commitAllowingStateLoss()
+        } else {
+            tx.commit()
+        }
+    }
+
+    private fun commitSync(tx: FragmentTransaction, allowStateLoss: Boolean) {
+        if (allowStateLoss) {
+            tx.commitNowAllowingStateLoss()
+        } else {
+            tx.commitNow()
+        }
+    }
+}

--- a/android/app/src/main/java/com/lynxscreens/screens/host/StackContainer.kt
+++ b/android/app/src/main/java/com/lynxscreens/screens/host/StackContainer.kt
@@ -4,10 +4,10 @@ import android.annotation.SuppressLint
 import android.content.Context
 import android.util.Log
 import androidx.coordinatorlayout.widget.CoordinatorLayout
+import androidx.fragment.app.Fragment
 import androidx.fragment.app.FragmentManager
 import com.lynxscreens.screens.helpers.FragmentManagerHelper
 import com.lynxscreens.screens.helpers.ViewIdGenerator
-import com.lynxscreens.screens.helpers.createTransactionWithReordering
 import com.lynxscreens.screens.screen.StackScreenComponent
 import com.lynxscreens.screens.screen.StackScreenFragment
 import java.lang.ref.WeakReference
@@ -16,15 +16,17 @@ import java.lang.ref.WeakReference
 internal class StackContainer(
     context: Context,
     private val delegate: WeakReference<StackContainerDelegate>,
-) : CoordinatorLayout(context) {
+) : CoordinatorLayout(context),
+    FragmentManager.OnBackStackChangedListener {
     private var fragmentManager: FragmentManager? = null
+
+    private fun requireFragmentManager(): FragmentManager =
+        checkNotNull(fragmentManager) { "[RNScreens] Attempt to use nullish FragmentManager" }
 
     /**
      * Describes most up-to-date view of the stack. It might be different from
      * state kept by FragmentManager as this data structure is updated immediately,
      * while operations on fragment manager are scheduled.
-     *
-     * FIXME: In case of native-pop, this might be out of date!
      */
     private val stackModel: MutableList<StackScreenFragment> = arrayListOf()
 
@@ -32,6 +34,8 @@ internal class StackContainer(
     private val pendingPushOperations: MutableList<PushOperation> = arrayListOf()
     private val hasPendingOperations: Boolean
         get() = pendingPushOperations.isNotEmpty() || pendingPopOperations.isNotEmpty()
+
+    private val fragmentOpExecutor: FragmentOperationExecutor = FragmentOperationExecutor()
 
     init {
         id = ViewIdGenerator.generateViewId()
@@ -41,14 +45,26 @@ internal class StackContainer(
         Log.d(TAG, "StackContainer [$id] attached to window")
         super.onAttachedToWindow()
 
-        fragmentManager =
-            checkNotNull(FragmentManagerHelper.findFragmentManagerForView(this)) {
-                "[RNScreens] Nullish fragment manager - can't run container operations"
-            }
+        setupFragmentManger()
 
         // We run container update to handle any pending updates requested before container was
         // attached to window.
         performContainerUpdateIfNeeded()
+    }
+
+    override fun onDetachedFromWindow() {
+        super.onDetachedFromWindow()
+        requireFragmentManager().removeOnBackStackChangedListener(this)
+        fragmentManager = null
+    }
+
+    internal fun setupFragmentManger() {
+        fragmentManager =
+            checkNotNull(FragmentManagerHelper.findFragmentManagerForView(this)) {
+                "[RNScreens] Nullish fragment manager - can't run container operations"
+            }.also {
+                it.addOnBackStackChangedListener(this)
+            }
     }
 
     /**
@@ -59,9 +75,7 @@ internal class StackContainer(
         // the call because we don't have valid fragmentManager yet.
         // Update will be eventually executed in onAttachedToWindow().
         if (hasPendingOperations && isAttachedToWindow) {
-            val fragmentManager =
-                checkNotNull(fragmentManager) { "[RNScreens] Fragment manager was null during stack container update" }
-            performOperations(fragmentManager)
+            performOperations(requireFragmentManager())
         }
     }
 
@@ -74,62 +88,107 @@ internal class StackContainer(
     }
 
     private fun performOperations(fragmentManager: FragmentManager) {
-        pendingPopOperations.forEach { performPopOperation(fragmentManager, it) }
-        pendingPushOperations.forEach { performPushOperation(fragmentManager, it) }
+        val fragmentOps = applyOperationsAndComputeFragmentManagerOperations()
+        fragmentOpExecutor.executeOperations(fragmentManager, fragmentOps, flushSync = false)
+
+        dumpStackModel()
+    }
+
+    private fun applyOperationsAndComputeFragmentManagerOperations(): List<FragmentOperation> {
+        val fragmentOps = mutableListOf<FragmentOperation>()
+
+        // Handle pop operations first.
+        // We don't care about pop/push duplicates, as long as we don't let the main loop progress
+        // before we commit all the transactions, FragmentManager will handle that for us.
+
+        pendingPopOperations.forEach { operation ->
+            val fragment =
+                checkNotNull(stackModel.find { it.stackScreen === operation.screen }) {
+                    "[RNScreens] Unable to find a fragment to pop"
+                }
+
+            check(stackModel.size > 1) {
+                "[RNScreens] Attempt to pop last screen from the stack"
+            }
+
+            fragmentOps.add(PopBackStackOp(fragment))
+
+            check(stackModel.removeAt(stackModel.lastIndex) === fragment) {
+                "[RNScreens] Attempt to pop non-top screen"
+            }
+        }
+
+        pendingPushOperations.forEach { operation ->
+            val newFragment = createFragmentForScreen(operation.screen)
+            fragmentOps.add(
+                AddOp(
+                    newFragment,
+                    containerViewId = this.id,
+                    addToBackStack = stackModel.isNotEmpty(),
+                ),
+            )
+            stackModel.add(newFragment)
+        }
+
+        check(stackModel.isNotEmpty()) { "[RNScreens] Stack should never be empty after updates" }
+
+        // Top fragment is the primary navigation fragment.
+        fragmentOps.add(SetPrimaryNavFragmentOp(stackModel.last()))
 
         pendingPopOperations.clear()
         pendingPushOperations.clear()
+
+        return fragmentOps
     }
 
-    private fun performPushOperation(
-        fragmentManager: FragmentManager,
-        operation: PushOperation,
-    ) {
-        val transaction = fragmentManager.createTransactionWithReordering()
+    private fun onNativeFragmentPop(fragment: StackScreenFragment) {
+        Log.d(TAG, "StackContainer [$id] natively removed fragment ${fragment.stackScreen.screenKey}")
+        require(stackModel.remove(fragment)) { "[RNScreens] onNativeFragmentPop must be called with the fragment present in stack model" }
+        check(stackModel.isNotEmpty()) { "[RNScreens] Stack model should not be empty after a native pop" }
 
-        val associatedFragment = StackScreenFragment(WeakReference(this), operation.screen)
-        stackModel.add(associatedFragment)
-
-        transaction.add(this.id, associatedFragment)
-
-        // Don't add root screen to back stack to handle exiting from app.
-        if (fragmentManager.fragments.isNotEmpty()) {
-            transaction.addToBackStack(operation.screen.screenKey)
-        }
-
-        transaction.commitAllowingStateLoss()
-    }
-
-    private fun performPopOperation(
-        fragmentManager: FragmentManager,
-        operation: PopOperation,
-    ) {
-        val associatedFragment = stackModel.find { it.stackScreen === operation.screen }
-        require(associatedFragment != null) {
-            "[RNScreens] Unable to find a fragment to pop."
-        }
-
-        val backStackEntryCount = fragmentManager.backStackEntryCount
-        if (backStackEntryCount > 0) {
-            fragmentManager.popBackStack(
-                operation.screen.screenKey,
-                FragmentManager.POP_BACK_STACK_INCLUSIVE,
+        val fragmentManager = requireFragmentManager()
+        if (fragmentManager.primaryNavigationFragment === fragment) {
+            // We need to update the primary navigation fragment, otherwise the fragment manager
+            // will have invalid state, pointing to the dismissed fragment.
+            fragmentOpExecutor.executeOperations(
+                fragmentManager,
+                listOf(SetPrimaryNavFragmentOp(stackModel.last())),
             )
-        } else {
-            // When fast refresh is used on root screen, we need to remove the screen manually.
-            val transaction = fragmentManager.createTransactionWithReordering()
-            transaction.remove(associatedFragment)
-            transaction.commitNowAllowingStateLoss()
         }
-
-        stackModel.remove(associatedFragment)
     }
 
-    internal fun onFragmentDestroyView(fragment: StackScreenFragment) {
-        if (stackModel.remove(fragment) && !fragment.stackScreen.isNativelyDismissed) {
-            Log.e(TAG, "[RNScreens] StackContainer natively popped a screen that was not in model!")
+    private fun dumpStackModel() {
+        Log.d(TAG, "StackContainer [$id] MODEL BEGIN")
+        stackModel.forEach {
+            Log.d(TAG, "${it.stackScreen.screenKey}")
         }
-        delegate.get()?.onScreenDismiss(fragment.stackScreen)
+    }
+
+    private fun createFragmentForScreen(screen: StackScreenComponent): StackScreenFragment =
+        StackScreenFragment(screen).also {
+            Log.d(TAG, "Created Fragment $it for screen ${screen.screenKey}")
+        }
+
+    // This is called after special effects (animations) are dispatched
+    override fun onBackStackChanged() = Unit
+
+    // This is called before the special effects (animations) are dispatched, however mid transaction!
+    // Therefore make sure to not execute any action that might cause synchronous transaction synchronously
+    // from this callback.
+    override fun onBackStackChangeCommitted(
+        fragment: Fragment,
+        pop: Boolean,
+    ) {
+        if (fragment !is StackScreenFragment) {
+            Log.w(TAG, "[RNScreens] Unexpected type of fragment: ${fragment.javaClass.simpleName}")
+            return
+        }
+        if (pop) {
+            delegate.get()?.onScreenDismiss(fragment.stackScreen)
+            if (stackModel.contains(fragment)) {
+                onNativeFragmentPop(fragment)
+            }
+        }
     }
 
     companion object {

--- a/android/app/src/main/java/com/lynxscreens/screens/host/StackHostComponent.kt
+++ b/android/app/src/main/java/com/lynxscreens/screens/host/StackHostComponent.kt
@@ -1,6 +1,7 @@
 package com.lynxscreens.screens.host
 
 import android.content.Context
+import android.util.Log
 import com.lynx.tasm.behavior.LynxContext
 import com.lynx.tasm.behavior.PatchFinishListener
 import com.lynx.tasm.behavior.ui.LynxBaseUI
@@ -109,6 +110,8 @@ internal class StackHostComponent(context: LynxContext) : UIGroup<StackHostView>
         if (stackScreen.activityMode == StackScreenComponent.ActivityMode.ATTACHED && !stackScreen.isNativelyDismissed) {
             // This shouldn't happen in typical scenarios but it can happen with fast-refresh.
             containerUpdateCoordinator.addPopOperation(stackScreen)
+        } else {
+            Log.d(TAG, "Ignoring pop operation of ${stackScreen.screenKey}, already not attached or natively dismissed")
         }
     }
 
@@ -125,9 +128,17 @@ internal class StackHostComponent(context: LynxContext) : UIGroup<StackHostView>
         }
     }
 
-    override fun onScreenDismiss(stackScreen: StackScreenComponent) = Unit
+    override fun onScreenDismiss(stackScreen: StackScreenComponent) {
+        if (stackScreen.activityMode == StackScreenComponent.ActivityMode.ATTACHED) {
+            stackScreen.isNativelyDismissed = true
+        }
+    }
 
     override fun onPatchFinish() {
         containerUpdateCoordinator.executePendingOperationsIfNeeded(container, renderedScreens)
+    }
+
+    companion object {
+        const val TAG = "StackHostComponent"
     }
 }

--- a/android/app/src/main/java/com/lynxscreens/screens/screen/StackScreenFragment.kt
+++ b/android/app/src/main/java/com/lynxscreens/screens/screen/StackScreenFragment.kt
@@ -1,15 +1,13 @@
 package com.lynxscreens.screens.screen
 
 import android.os.Bundle
+import android.util.Log
 import android.view.LayoutInflater
 import android.view.View
 import android.view.ViewGroup
 import androidx.fragment.app.Fragment
-import com.lynxscreens.screens.host.StackContainer
-import java.lang.ref.WeakReference
 
 internal class StackScreenFragment(
-    private val stackContainer: WeakReference<StackContainer>,
     internal val stackScreen: StackScreenComponent,
 ) : Fragment() {
     private var screenLifecycleEventEmitter: StackScreenAppearanceEventsEmitter? = null
@@ -30,8 +28,12 @@ internal class StackScreenFragment(
 
     override fun onDestroyView() {
         super.onDestroyView()
-        stackScreen.onDismiss()
-        stackContainer.get()?.onFragmentDestroyView(this)
         screenLifecycleEventEmitter = null
+    }
+
+    override fun onDestroy() {
+        super.onDestroy()
+        Log.i("StackScreenFragment", "onDestroy")
+        stackScreen.onDismiss()
     }
 }

--- a/src/examples/TestNested.tsx
+++ b/src/examples/TestNested.tsx
@@ -78,6 +78,21 @@ function NestedTemplateScreen() {
       <text>Route: {navigation.routeKey}</text>
       <Button label="Push NestedA" onTap={() => navigation.push('NestedA')} />
       <Button label="Push NestedB" onTap={() => navigation.push('NestedB')} />
+      <Button
+        label="Push both"
+        onTap={() =>
+          navigation.batch([
+            {
+              type: 'push',
+              routeName: 'NestedA',
+            },
+            {
+              type: 'push',
+              routeName: 'NestedB',
+            },
+          ])
+        }
+      />
       <Button label="Pop" onTap={() => navigation.pop(navigation.routeKey)} />
       <Button
         label="Preload NestedA"
@@ -99,17 +114,32 @@ const ROUTE_CONFIGS: StackRouteConfig[] = [
   {
     name: 'A',
     Component: TemplateScreen,
-    options: {},
+    options: {
+      onWillAppear: () => console.log('A onWillAppear'),
+      onWillDisappear: () => console.log('A onWillDisappear'),
+      onDidAppear: () => console.log('A onDidAppear'),
+      onDidDisappear: () => console.log('A onDidDisappear'),
+    },
   },
   {
     name: 'B',
     Component: TemplateScreen,
-    options: {},
+    options: {
+      onWillAppear: () => console.log('B onWillAppear'),
+      onWillDisappear: () => console.log('B onWillDisappear'),
+      onDidAppear: () => console.log('B onDidAppear'),
+      onDidDisappear: () => console.log('B onDidDisappear'),
+    },
   },
   {
     name: 'NestedStack',
     Component: NestedStackScreen,
-    options: {},
+    options: {
+      onWillAppear: () => console.log('NestedStack onWillAppear'),
+      onWillDisappear: () => console.log('NestedStack onWillDisappear'),
+      onDidAppear: () => console.log('NestedStack onDidAppear'),
+      onDidDisappear: () => console.log('NestedStack onDidDisappear'),
+    },
   },
 ];
 


### PR DESCRIPTION
(This should be 1:1 copy from RNS)
Related commit from RNS: https://github.com/software-mansion/react-native-screens/commit/82ce103b5f1d1009d38a959089ecbdc045225fe6 

### Description

(Description copied from RNS)

This commit refactors *StackContainer* code. Achieved functional effect boils down to support for native-pop in nested stack, and in outer stack after closing the nested one.

I've added abstraction over *FragmentManager* operations. This is done mostly to structure and better manage container update code complexity. The *FragmentManager* facing code is now moved into `FragmentOperationExecutor` class.

Now *FragmentManager* reference is cleaned up in `onDetachedFromWindow`.

The *StackContainer* is now `OnBackStackChangedListener`. This is done to better time & detect that a screen has been dismissed. This callback is invoked mid-transaction execution by fragment manager, not after all animations finish & the UI disappears. It seems like much more appropriate place to keep the *StackContainer* possibly up-to-date.

Please note, that *StackScreen* still emits `onDismiss` event much later, after the UI hides & fragment is destroyed. I've changed it a bit here. Earlier it has been emitted in `onDestroyView`, now I emit it in `onDestroy`. I've changed that to prevent incorrect emitting when fragment moves to *STARTED* lifecycle state but is not detached from fragment manager - such situation might happen when we use `FragmentTransaction.detach`, which is planned.

This commit also adds basic *primaryNavigationFragment* management. This is necessary for native navigation in nested stacks to work. If we do not set it correctly, then *childFragmentManager* (used by nested stack) won't handle `backPressed` at all. This responsibility will be delegated to the *supportFragmentManager* and whole nested stack will be popped immediately, instead of only single screen. Important thing to note here is that we need to run additional fragment manager operations when we detect that a fragment has been natively popped. `FragmentManager.primaryNavigationFragment` state seems to not be updated automatically once written to, hence unless we update it, we will encounter a crash where *FragmentManager* attempts to delegate back
handling to already detached fragment.

Closes: https://github.com/software-mansion/lynx-screens/issues/36

---

### Testing

Nested Stack example updated. Push, Pop, Native pop work nicely, even when popping nested stack. The same action via JS popping should not work yet & will be handled separately. 

https://github.com/user-attachments/assets/524b63eb-a46b-4b6a-b812-877aaef5352b