### PR TITLE
feat(Android, Stack): Support nested container pop from JS

### DIFF
--- a/src/components/StackContainer.tsx
+++ b/src/components/StackContainer.tsx
@@ -2,11 +2,12 @@ import React from 'react';
 import type {
   NavigationAction,
   StackContainerProps,
+  StackNavigationState,
   StackRouteConfig,
   StackState,
 } from '../types/StackContainer';
 import {
-  determineFirstRoute,
+  determineInitialNavigationState,
   navigationStateReducerWithLogging,
 } from '../utils/reducer';
 import { useStackOperationMethods } from '../hooks/useStackOperationMethods';
@@ -16,20 +17,25 @@ import {
 } from '../contexts/StackNavigationContext';
 import { StackHostNativeComponent } from '../native_components/StackHostNativeComponent';
 import { StackScreenNativeComponent } from '../native_components/StackScreenNativeComponent';
+import { useParentNavigationEffect } from '../hooks/useParentNavigationEffect';
 
 export function StackContainer({ routeConfigs }: StackContainerProps) {
   useSanitizeRouteConfigs(routeConfigs);
 
-  const [stackState, navActionDispatch]: [
-    StackState,
+  const [stackNavState, navActionDispatch]: [
+    StackNavigationState,
     React.Dispatch<NavigationAction>,
   ] = React.useReducer(
     navigationStateReducerWithLogging,
     routeConfigs,
-    determineFirstRoute,
+    determineInitialNavigationState,
   );
 
   const navMethods = useStackOperationMethods(navActionDispatch, routeConfigs);
+
+  // If reducer produced a parent action, we need to dispatch it
+  // as an effect, because we can not modify the state during the render phase.
+  useParentNavigationEffect(navMethods, stackNavState.effects);
 
   const onDismiss = React.useCallback(
     (screenKey: string) => {
@@ -49,14 +55,15 @@ export function StackContainer({ routeConfigs }: StackContainerProps) {
 
   return (
     <StackHostNativeComponent>
-      {stackState.map(({ Component, options, activityMode, routeKey }) => {
-        const stackNavigationContext: StackNavigationContextPayload = {
-          routeKey,
-          push: navMethods.pushAction,
-          pop: navMethods.popAction,
-          preload: navMethods.preloadAction,
-          batch: navMethods.batchAction,
-        };
+      {stackNavState.stack.map(
+        ({ Component, options, activityMode, routeKey }) => {
+          const stackNavigationContext: StackNavigationContextPayload = {
+            routeKey,
+            push: navMethods.pushAction,
+            pop: navMethods.popAction,
+            preload: navMethods.preloadAction,
+            batch: navMethods.batchAction,
+          };
 
         return (
           <StackScreenNativeComponent

--- a/src/hooks/useLatestCallback.ts
+++ b/src/hooks/useLatestCallback.ts
@@ -1,0 +1,16 @@
+import React from 'react';
+import { useRef, useEffect, useCallback } from '@lynx-js/react';
+
+export function useLatestCallback<T extends (...args: any[]) => any>(callback: T): T {
+  const callbackRef = useRef(callback);
+
+  // Update the ref every time the component renders.
+  useEffect(() => {
+    callbackRef.current = callback;
+  });
+
+  // Return a stable function that never changes.
+  return useCallback(((...args) => {
+    return callbackRef.current(...args);
+  }) as T, []);
+}

--- a/src/hooks/useParentNavigationEffect.ts
+++ b/src/hooks/useParentNavigationEffect.ts
@@ -13,7 +13,11 @@ export function useParentNavigationEffect(
 ) {
   const parentNavigation = React.useContext(StackNavigationContext);
 
-  // Replacement of React.useEffectEvent
+  /**
+   * Replacement of React.useEffectEvent.
+   * This hook returns a callback with always up-to-date reactive state inside, 
+   * allowing it to be used inside an effect without specifying it as a dependency.
+   */
   const consumeEffect = useLatestCallback((effect: StackNavigationEffect) => {
     if (effect.type !== 'pop-container') {
       throw new Error(`[Stack] Unrecognized effect type: ${effect.type}`);

--- a/src/hooks/useParentNavigationEffect.ts
+++ b/src/hooks/useParentNavigationEffect.ts
@@ -1,0 +1,39 @@
+import React from 'react';
+import { StackNavigationContext } from '../contexts/StackNavigationContext';
+import type {
+  NavigationActionMethods,
+  StackNavigationEffect,
+} from '../types/StackContainer';
+
+export function useParentNavigationEffect(
+  navActionMethods: NavigationActionMethods,
+  effects: StackNavigationEffect[] | undefined,
+) {
+  const parentNavigation = React.useContext(StackNavigationContext);
+
+  const consumeEffect = React.useEffectEvent(
+    (effect: StackNavigationEffect) => {
+      if (effect.type !== 'pop-container') {
+        throw new Error(`[Stack] Unrecognized effect type: ${effect.type}`);
+      }
+      if (parentNavigation) {
+        console.log(
+          `[Stack] Delegating pop action to parent container for key ${parentNavigation.routeKey}`,
+        );
+        parentNavigation.pop(parentNavigation.routeKey);
+      }
+    },
+  );
+
+  const clearEffects = React.useEffectEvent(() => {
+    navActionMethods.clearEffectsAction();
+  });
+
+  // We want to trigger this effect only when effects change.
+  React.useEffect(() => {
+    if (effects && effects.length > 0) {
+      effects.forEach(consumeEffect);
+      clearEffects();
+    }
+  }, [effects]);
+}

--- a/src/hooks/useParentNavigationEffect.ts
+++ b/src/hooks/useParentNavigationEffect.ts
@@ -1,9 +1,11 @@
 import React from 'react';
+import { useEffect } from '@lynx-js/react';
 import { StackNavigationContext } from '../contexts/StackNavigationContext';
 import type {
   NavigationActionMethods,
   StackNavigationEffect,
 } from '../types/StackContainer';
+import { useLatestCallback } from './useLatestCallback'
 
 export function useParentNavigationEffect(
   navActionMethods: NavigationActionMethods,
@@ -11,29 +13,26 @@ export function useParentNavigationEffect(
 ) {
   const parentNavigation = React.useContext(StackNavigationContext);
 
-  const consumeEffect = React.useEffectEvent(
-    (effect: StackNavigationEffect) => {
-      if (effect.type !== 'pop-container') {
-        throw new Error(`[Stack] Unrecognized effect type: ${effect.type}`);
-      }
-      if (parentNavigation) {
-        console.log(
-          `[Stack] Delegating pop action to parent container for key ${parentNavigation.routeKey}`,
-        );
-        parentNavigation.pop(parentNavigation.routeKey);
-      }
-    },
-  );
+  // Replacement of React.useEffectEvent
+  const consumeEffect = useLatestCallback((effect: StackNavigationEffect) => {
+    if (effect.type !== 'pop-container') {
+      throw new Error(`[Stack] Unrecognized effect type: ${effect.type}`);
+    }
+    if (parentNavigation) {
+      parentNavigation.pop(parentNavigation.routeKey);
+    }
+  });
 
-  const clearEffects = React.useEffectEvent(() => {
+  const clearEffects = useLatestCallback(() => {
     navActionMethods.clearEffectsAction();
   });
 
-  // We want to trigger this effect only when effects change.
-  React.useEffect(() => {
+  useEffect(() => {
     if (effects && effects.length > 0) {
       effects.forEach(consumeEffect);
       clearEffects();
     }
+    // 'effects' is the only thing that triggers this re-run.
+    // 'consumeEffect' and 'clearEffects' are stable and don't need to be in deps.
   }, [effects]);
 }

--- a/src/hooks/useParentNavigationEffect.ts
+++ b/src/hooks/useParentNavigationEffect.ts
@@ -23,6 +23,9 @@ export function useParentNavigationEffect(
       throw new Error(`[Stack] Unrecognized effect type: ${effect.type}`);
     }
     if (parentNavigation) {
+      console.log(
+        `[Stack] Delegating pop action to parent container for key ${parentNavigation.routeKey}`,
+      );
       parentNavigation.pop(parentNavigation.routeKey);
     }
   });

--- a/src/hooks/useParentNavigationEffect.ts
+++ b/src/hooks/useParentNavigationEffect.ts
@@ -40,6 +40,7 @@ export function useParentNavigationEffect(
       clearEffects();
     }
     // 'effects' is the only thing that triggers this re-run.
-    // 'consumeEffect' and 'clearEffects' are stable and don't need to be in deps.
+    // 'consumeEffect' and 'clearEffects' are stable and don't need to be in deps
+    // referring to the description of useLatestCallback above.
   }, [effects]);
 }

--- a/src/hooks/useStackOperationMethods.ts
+++ b/src/hooks/useStackOperationMethods.ts
@@ -2,6 +2,7 @@ import React from 'react';
 import type {
   BatchableNavigationAction,
   BatchActionMethod,
+  ClearEffectsActionMethod,
   NavigationAction,
   NavigationActionContext,
   NavigationActionMethods,
@@ -62,7 +63,7 @@ export function useStackOperationMethods(
     [dispatch, actionContext],
   );
 
-    const batchAction: BatchActionMethod = React.useCallback(
+  const batchAction: BatchActionMethod = React.useCallback(
     (actions: BatchableNavigationAction[]) => {
       const actionsWithContext = actions.map(action => ({
         ...action,
@@ -74,6 +75,10 @@ export function useStackOperationMethods(
     [dispatch, actionContext],
   );
 
+  const clearEffectsAction: ClearEffectsActionMethod = React.useCallback(() => {
+    dispatch({ type: 'clear-effects', ctx: actionContext });
+  }, [dispatch, actionContext]);
+
   const aggregateValue = React.useMemo(() => {
     return {
       pushAction,
@@ -82,6 +87,7 @@ export function useStackOperationMethods(
       popNativeAction,
       preloadAction,
       batchAction,
+      clearEffectsAction,
     };
   }, [
     pushAction,
@@ -90,6 +96,7 @@ export function useStackOperationMethods(
     popNativeAction,
     preloadAction,
     batchAction,
+    clearEffectsAction,
   ]);
 
   return aggregateValue;

--- a/src/types/StackContainer.ts
+++ b/src/types/StackContainer.ts
@@ -35,6 +35,8 @@ export type StackScreenProps = {
   onNativeDismiss?: (screenKey: string) => void;
 };
 
+/// Route definition
+
 export type StackRouteOptions = Omit<
   StackScreenProps,
   'children' | 'activityMode' | 'screenKey'
@@ -46,13 +48,15 @@ export type StackRouteConfig = {
   options: StackRouteOptions;
 };
 
-export type StackContainerProps = {
-  routeConfigs: StackRouteConfig[];
-};
-
 export type StackRoute = StackRouteConfig & {
   activityMode: StackScreenProps['activityMode'];
   routeKey: StackScreenProps['screenKey'];
+};
+
+/// StackContainer props
+
+export type StackContainerProps = {
+  routeConfigs: StackRouteConfig[];
 };
 
 export type PushActionMethod = (routeName: string) => void;
@@ -61,6 +65,7 @@ export type PopCompletedActionMethod = (routeKey: string) => void;
 export type PopNativeActionMethod = (routeKey: string) => void;
 export type PreloadActionMethod = (routeName: string) => void;
 export type BatchActionMethod = (actions: BatchableNavigationAction[]) => void;
+export type ClearEffectsActionMethod = () => void;
 
 export type NavigationActionMethods = {
   pushAction: PushActionMethod;
@@ -69,9 +74,21 @@ export type NavigationActionMethods = {
   popNativeAction: PopNativeActionMethod;
   preloadAction: PreloadActionMethod;
   batchAction: BatchActionMethod;
+  clearEffectsAction: ClearEffectsActionMethod;
 };
 
 export type StackState = StackRoute[];
+
+export type StackNavigationState = {
+  stack: StackState;
+  effects: StackNavigationEffect[];
+};
+
+export type StackNavigationEffect = PopContainerStackNavigationEffect;
+
+type PopContainerStackNavigationEffect = {
+  type: 'pop-container';
+};
 
 export type NavigationActionPush = {
   type: 'push';
@@ -108,6 +125,13 @@ export type NavigationActionBatch = {
   actions: Exclude<NavigationAction, NavigationActionBatch>[];
 };
 
+// TODO: We need to separate navigation actions exposed to user from internal
+// state manipulation done in stack container on the type level.
+export type NavigationActionClearEffects = {
+  type: 'clear-effects';
+  ctx: NavigationActionContext;
+};
+
 export type NavigationActionContext = {
   routeConfigs: StackRouteConfig[];
 };
@@ -123,4 +147,5 @@ export type NavigationAction =
   | NavigationActionPopCompleted
   | NavigationActionNativePop
   | NavigationActionPreload
+  | NavigationActionClearEffects
   | NavigationActionBatch;

--- a/src/utils/reducer.ts
+++ b/src/utils/reducer.ts
@@ -1,11 +1,15 @@
 import type {
   NavigationAction,
   NavigationActionBatch,
+  NavigationActionClearEffects,
   NavigationActionNativePop,
   NavigationActionPop,
   NavigationActionPopCompleted,
   NavigationActionPreload,
   NavigationActionPush,
+  StackNavigationEffect,
+  StackNavigationState,
+  StackScreenActivityMode,
   StackRoute,
   StackRouteConfig,
   StackState,
@@ -15,9 +19,9 @@ import { generateID } from './id-generator';
 const NOT_FOUND_INDEX = -1;
 
 export function navigationStateReducer(
-  state: StackState,
+  state: StackNavigationState,
   action: NavigationAction,
-): StackState {
+): StackNavigationState {
   switch (action.type) {
     case 'push': {
       return navigationActionPushHandler(state, action);
@@ -37,6 +41,9 @@ export function navigationStateReducer(
     case 'batch': {
       return navigationActionBatchHandler(state, action);
     }
+    case 'clear-effects': {
+      return navigationActionClearEffectsHandler(state, action);
+    }
   }
 
   // @ts-ignore
@@ -46,9 +53,9 @@ export function navigationStateReducer(
 }
 
 export function navigationStateReducerWithLogging(
-  state: StackState,
+  state: StackNavigationState,
   action: NavigationAction,
-): StackState {
+): StackNavigationState {
   console.debug(`[Stack] Handling action: ${JSON.stringify(action)}`);
   console.debug(`[Stack] BEFORE state: ${JSON.stringify(state, undefined, 2)}`);
   const newState = navigationStateReducer(state, action);
@@ -63,26 +70,27 @@ export function navigationStateReducerWithLogging(
 }
 
 function navigationActionPushHandler(
-  state: StackState,
+  state: StackNavigationState,
   action: NavigationActionPush,
-): StackState {
+): StackNavigationState {
   // 1 - Check whether the route is already rendered
-  const renderedRouteIndex = state.findIndex(
+  const stack = state.stack;
+  const renderedRouteIndex = stack.findIndex(
     route =>
       route.name === action.routeName && route.activityMode === 'detached',
   );
 
   if (renderedRouteIndex !== NOT_FOUND_INDEX) {
-    const route = state[renderedRouteIndex];
+    const route = stack[renderedRouteIndex];
 
     console.info(`[Stack] Route ${route.name} already rendered, attaching it`);
-    const newState = [
-    ...state.slice(0, renderedRouteIndex),
-    ...state.slice(renderedRouteIndex + 1)
-  ];
+    const newStack = [
+      ...stack.slice(0, renderedRouteIndex),
+      ...stack.slice(renderedRouteIndex + 1)
+    ];
     const routeCopy = { ...route };
     routeCopy.activityMode = 'attached';
-    return getNewStateAfterPush(newState, routeCopy);
+    return stackNavStateWithStack(state, applyPush(newStack, routeCopy));
   }
 
   // 2 - Try to render new route
@@ -95,20 +103,20 @@ function navigationActionPushHandler(
     );
   }
 
-  const newRoute = createRouteFromConfig(newRouteConfig);
-  newRoute.activityMode = 'attached';
-
-  return getNewStateAfterPush(state, newRoute);
+  const newRoute = createRouteFromConfig(newRouteConfig, 'attached');
+  return stackNavStateWithStack(state, applyPush(state.stack, newRoute));
 }
 
 function navigationActionPopHandler(
-  state: StackState,
+  state: StackNavigationState,
   action: NavigationActionPop,
-): StackState {
+): StackNavigationState {
   // FIXME: We have a problem here. We can not really determine, which route is currently at the very top!
   // For now let's just accept routeKey as param here.
 
-  const attachedCount = state.reduce((count, route) => {
+  const stack = state.stack;
+
+  const attachedCount = stack.reduce((count, route) => {
     if (route.activityMode === 'attached') {
       return count + 1;
     } else {
@@ -120,10 +128,20 @@ function navigationActionPopHandler(
     console.warn(
       `[Stack] Can not perform pop action on route: ${action.routeKey} - at least one route must be present`,
     );
-    return state;
+    if (
+      state.effects.findIndex(effect => effect.type === 'pop-container') !==
+      NOT_FOUND_INDEX
+    ) {
+      // If there is already a pop-container effect, do nothing
+      return state;
+    }
+    return stackNavStateWithEffects(
+      state,
+      applyEffect(state.effects, { type: 'pop-container' }),
+    );
   }
 
-  const routeIndex = state.findIndex(
+  const routeIndex = stack.findIndex(
     route => route.routeKey === action.routeKey,
   );
   if (routeIndex === NOT_FOUND_INDEX) {
@@ -133,7 +151,7 @@ function navigationActionPopHandler(
     return state;
   }
 
-  const route = state[routeIndex];
+  const route = stack[routeIndex];
 
   if (route.activityMode === 'detached') {
     console.warn(
@@ -142,21 +160,22 @@ function navigationActionPopHandler(
     return state;
   }
 
-  const newState = [...state];
+  const newStack = [...stack];
   // NOTE: This modifies existing state, possibly impacting calculations done before new state is updated.
   // Consider doing deep copy of the state here.
   // EDIT: not sure really whether this is really a problem or not, since the updates are queued
   // and the original state won't be immediatelly affected.
   route.activityMode = 'detached';
 
-  return newState;
+  return stackNavStateWithStack(state, newStack);
 }
 
 function navigationActionPopCompletedHandler(
-  state: StackState,
+  state: StackNavigationState,
   action: NavigationActionPopCompleted,
-): StackState {
-  const routeIndex = state.findIndex(
+): StackNavigationState {
+  const stack = state.stack;
+  const routeIndex = stack.findIndex(
     route => route.routeKey === action.routeKey,
   );
   if (routeIndex === NOT_FOUND_INDEX) {
@@ -166,7 +185,7 @@ function navigationActionPopCompletedHandler(
     return state;
   }
 
-  const route = state[routeIndex];
+  const route = stack[routeIndex];
   if (route.activityMode !== 'detached') {
     console.warn(`[Stack] Popped non-detached route!`);
   }
@@ -175,24 +194,25 @@ function navigationActionPopCompletedHandler(
 
   // Let's remove the route from the state
   // TODO: Consider adding option for keeping it in state.
-  const newState = [
-    ...state.slice(0, routeIndex),
-    ...state.slice(routeIndex + 1)
+  const newStack = [
+    ...stack.slice(0, routeIndex),
+    ...stack.slice(routeIndex + 1)
   ];
-  return newState;
+  return stackNavStateWithStack(state, newStack);
 }
 
 function navigationActionNativePopHandler(
-  state: StackState,
+  state: StackNavigationState,
   action: NavigationActionNativePop,
-): StackState {
-  if (state.length <= 1) {
+): StackNavigationState {
+  const stack = state.stack;
+  if (stack.length <= 1) {
     throw new Error(
       '[Stack] action: "pop-native" can not be performed with less than 2 routes!',
     );
   }
 
-  const routeIndex = state.findIndex(
+  const routeIndex = stack.findIndex(
     route => route.routeKey === action.routeKey,
   );
   if (routeIndex === NOT_FOUND_INDEX) {
@@ -202,22 +222,22 @@ function navigationActionNativePopHandler(
     return state;
   }
 
-  const route = state[routeIndex];
+  const route = stack[routeIndex];
   if (route.activityMode === 'detached') {
     console.warn('[Stack] natively popped route has "detached" state');
   }
 
-  const newState = [
-    ...state.slice(0, routeIndex),
-    ...state.slice(routeIndex + 1)
+  const newStack = [
+    ...stack.slice(0, routeIndex),
+    ...stack.slice(routeIndex + 1)
   ];
-  return newState;
+  return stackNavStateWithStack(state, newStack);
 }
 
 function navigationActionPreloadHandler(
-  state: StackState,
+  state: StackNavigationState,
   action: NavigationActionPreload,
-): StackState {
+): StackNavigationState {
   const routeConfig = action.ctx.routeConfigs.find(
     config => config.name === action.routeName,
   );
@@ -232,30 +252,38 @@ function navigationActionPreloadHandler(
   // Preloaded routes are kept at the end of the list to allow order manipulations
   // that won't result in problems on native platform.
   // More info: https://github.com/software-mansion/react-native-screens/pull/3531.
-  return [...state, createRouteFromConfig(routeConfig)];
+  const newStack = [...state.stack, createRouteFromConfig(routeConfig)];
+  return stackNavStateWithStack(state, newStack);
 }
 
 function navigationActionBatchHandler(
-  state: StackState,
+  state: StackNavigationState,
   action: NavigationActionBatch,
-): StackState {
+): StackNavigationState {
   return action.actions.reduce(navigationStateReducer, state);
 }
 
-function createRouteFromConfig(config: StackRouteConfig): StackRoute {
+function createRouteFromConfig(config: StackRouteConfig, activityMode: StackScreenActivityMode = 'detached',): StackRoute {
   return {
     ...config,
-    activityMode: 'detached',
+    activityMode,
     routeKey: generateRouteKeyForRouteName(config.name),
   };
 }
 
+function navigationActionClearEffectsHandler(
+  state: StackNavigationState,
+  _action: NavigationActionClearEffects,
+): StackNavigationState {
+  if (state.effects.length === 0) {
+    return state;
+  }
+  return stackNavStateWithEffects(state, []);
+}
+
 // Ensures correct order of screens (attached first, detached at the end).
 // This will help with state restoration but WILL NOT help with inspector.
-function getNewStateAfterPush(
-  state: StackState,
-  newRoute: StackRoute,
-): StackState {
+function applyPush(state: StackState, newRoute: StackRoute): StackState {
   // Fix for `TypeError: state.findLastIndex is not a function` which was introduced in ES2023
   let lastAttachedIndex = -1;
   for (let i = state.length - 1; i >= 0; i--) {
@@ -280,14 +308,43 @@ function getNewStateAfterPush(
   ];
 }
 
-export function determineFirstRoute(
+function applyEffect(
+  effects: StackNavigationEffect[],
+  newEffect: StackNavigationEffect,
+): StackNavigationEffect[] {
+  return effects.concat(newEffect);
+}
+
+export function determineInitialNavigationState(
   routeConfigs: StackRouteConfig[],
-): StackState {
-  const firstRoute = createRouteFromConfig(routeConfigs[0]);
-  firstRoute.activityMode = 'attached';
-  return [firstRoute];
+): StackNavigationState {
+  const firstRoute = createRouteFromConfig(routeConfigs[0], 'attached');
+  return {
+    stack: [firstRoute],
+    effects: [],
+  };
 }
 
 function generateRouteKeyForRouteName(routeName: string): string {
   return `r-${routeName}-${generateID()}`;
+}
+
+function stackNavStateWithStack(
+  navState: StackNavigationState,
+  newStack: StackState,
+): StackNavigationState {
+  return {
+    ...navState,
+    stack: newStack,
+  };
+}
+
+function stackNavStateWithEffects(
+  navState: StackNavigationState,
+  newEffects: StackNavigationEffect[],
+): StackNavigationState {
+  return {
+    ...navState,
+    effects: newEffects,
+  };
 }


### PR DESCRIPTION
Related to this commit from RNS: https://github.com/software-mansion/react-native-screens/commit/c72539d598d37ccbcd44a380ce017441fc8b3eed 

### Description

Previously it has not been possible to pop nested container via JS. When there was only a single screen left in the JS stack state, the reducer would deny removing it and would just ignore the operation printing a warning that pop operation requires at least two screens.

Currently, in such scenario the parent `StackContainer` (JS component) will be asked to pop whole screen that hosts the nested container.

Closes: https://github.com/software-mansion/lynx-screens/issues/37

### Differences from RNS

The code was attempting to use `React.useEffectEvent`, which is not available in our current React 17 environment.

I have replaced this with the "Latest Ref Pattern" to achieve the same goal: executing logic inside an effect without requiring the logic's dependencies to trigger the effect itself.

---

### Testing

Use Nested Stack example, both JS and native pop should now work

https://github.com/user-attachments/assets/6cc2b59f-47a8-4aee-9c4d-8fd93f188643