### PR TITLE
feat(Android, Stack): Add preventNativeDismiss support

### DIFF
--- a/android/app/src/main/java/com/lynxscreens/screens/host/FragmentOperation.kt
+++ b/android/app/src/main/java/com/lynxscreens/screens/host/FragmentOperation.kt
@@ -59,6 +59,7 @@ internal class FlushNowOp : FragmentOperation() {
 
 internal class SetPrimaryNavFragmentOp(
     val fragment: StackScreenFragment,
+    val onCommitCallback: Runnable? = null,
 ) : FragmentOperation() {
     override fun execute(
         fragmentManager: FragmentManager,

--- a/android/app/src/main/java/com/lynxscreens/screens/host/FragmentOperationExecutor.kt
+++ b/android/app/src/main/java/com/lynxscreens/screens/host/FragmentOperationExecutor.kt
@@ -48,6 +48,9 @@ internal class FragmentOperationExecutor {
     internal fun executeSetPrimaryNavFragmentOp(fragmentManager: FragmentManager, op: SetPrimaryNavFragmentOp) {
         fragmentManager.createTransactionWithReordering().let { tx ->
             tx.setPrimaryNavigationFragment(op.fragment)
+            if (op.onCommitCallback != null) {
+                tx.runOnCommit(op.onCommitCallback)
+            }
             commitTransaction(tx, allowStateLoss = true, flushSync = false)
         }
     }

--- a/android/app/src/main/java/com/lynxscreens/screens/host/StackContainer.kt
+++ b/android/app/src/main/java/com/lynxscreens/screens/host/StackContainer.kt
@@ -133,7 +133,10 @@ internal class StackContainer(
         check(stackModel.isNotEmpty()) { "[RNScreens] Stack should never be empty after updates" }
 
         // Top fragment is the primary navigation fragment.
-        fragmentOps.add(SetPrimaryNavFragmentOp(stackModel.last()))
+        val topStackFragment = stackModel.last()
+        fragmentOps.add(SetPrimaryNavFragmentOp(topStackFragment, {
+            updateTopFragment()
+        }))
 
         pendingPopOperations.clear()
         pendingPushOperations.clear()
@@ -147,14 +150,15 @@ internal class StackContainer(
         check(stackModel.isNotEmpty()) { "[RNScreens] Stack model should not be empty after a native pop" }
 
         val fragmentManager = requireFragmentManager()
-        if (fragmentManager.primaryNavigationFragment === fragment) {
-            // We need to update the primary navigation fragment, otherwise the fragment manager
-            // will have invalid state, pointing to the dismissed fragment.
-            fragmentOpExecutor.executeOperations(
-                fragmentManager,
-                listOf(SetPrimaryNavFragmentOp(stackModel.last())),
-            )
-        }
+        check(fragmentManager.primaryNavigationFragment === fragment) { "[RNScreens] primaryNavFragment should be the one popped" }
+        // We need to update the primary navigation fragment, otherwise the fragment manager
+        // will have invalid state, pointing to the dismissed fragment.
+        fragmentOpExecutor.executeOperations(
+            fragmentManager,
+            listOf(SetPrimaryNavFragmentOp(stackModel.last(), {
+                updateTopFragment()
+            })),
+        )
     }
 
     private fun dumpStackModel() {
@@ -168,6 +172,14 @@ internal class StackContainer(
         StackScreenFragment(screen).also {
             Log.d(TAG, "Created Fragment $it for screen ${screen.screenKey}")
         }
+
+    private fun updateTopFragment() {
+        // We try to handle situation where other fragments might be present.
+        val fragments = requireFragmentManager().fragments.filterIsInstance<StackScreenFragment>()
+        check(fragments.isNotEmpty()) { "[RNScreens] Empty fragment manager while attempting to update top fragment" }
+        fragments.forEach { it.onResignTopFragment() }
+        fragments.last().onBecomeTopFragment()
+    }
 
     // This is called after special effects (animations) are dispatched
     override fun onBackStackChanged() = Unit

--- a/android/app/src/main/java/com/lynxscreens/screens/screen/PreventNativeDismissCallback.kt
+++ b/android/app/src/main/java/com/lynxscreens/screens/screen/PreventNativeDismissCallback.kt
@@ -1,0 +1,72 @@
+package com.lynxscreens.screens.screen
+
+import android.util.Log
+import androidx.activity.OnBackPressedCallback
+import androidx.lifecycle.Lifecycle
+import androidx.lifecycle.LifecycleEventObserver
+import androidx.lifecycle.LifecycleOwner
+
+internal class PreventNativeDismissCallback(
+    lifecycleOwner: LifecycleOwner,
+    private val screen: StackScreenComponent,
+    canBeEnabled: Boolean
+) : OnBackPressedCallback(false),
+    LifecycleEventObserver,
+    PreventNativeDismissChangeObserver {
+    /**
+     * A kill-switch whether this callback can even be enabled or not. If set to false,
+     * no matter other conditions this callback won't be enabled.
+     */
+    internal var canBeEnabled: Boolean = canBeEnabled
+        set(value) {
+            field = value
+            determineEnabledStatus()
+        }
+
+    private val shouldBeEnabled
+        get() = canBeEnabled && screen.isPreventNativeDismissEnabled
+
+    init {
+        lifecycleOwner.lifecycle.addObserver(this)
+    }
+
+    override fun handleOnBackPressed() {
+        Log.i("RNScreens", "PreventNativeDismissCallback called for screen ${screen.screenKey}")
+        screen.onNativeDismissPrevented()
+    }
+
+    override fun onStateChanged(
+        source: LifecycleOwner,
+        event: Lifecycle.Event,
+    ) {
+        when (event) {
+            Lifecycle.Event.ON_CREATE -> {
+                screen.preventNativeDismissChangeObserver = this
+            }
+
+            Lifecycle.Event.ON_START -> {
+                determineEnabledStatus()
+            }
+
+            Lifecycle.Event.ON_STOP -> {
+                this.isEnabled = false
+            }
+
+            Lifecycle.Event.ON_DESTROY -> {
+                source.lifecycle.removeObserver(this)
+                screen.preventNativeDismissChangeObserver = null
+            }
+
+            else -> {
+            }
+        }
+    }
+
+    override fun preventNativeDismissChanged(newValue: Boolean) {
+        determineEnabledStatus()
+    }
+
+    private fun determineEnabledStatus() {
+        this.isEnabled = shouldBeEnabled
+    }
+}

--- a/android/app/src/main/java/com/lynxscreens/screens/screen/PreventNativeDismissChangeObserver.kt
+++ b/android/app/src/main/java/com/lynxscreens/screens/screen/PreventNativeDismissChangeObserver.kt
@@ -1,0 +1,5 @@
+package com.lynxscreens.screens.screen
+
+internal interface PreventNativeDismissChangeObserver {
+    fun preventNativeDismissChanged(newValue: Boolean)
+}

--- a/android/app/src/main/java/com/lynxscreens/screens/screen/StackScreenComponent.kt
+++ b/android/app/src/main/java/com/lynxscreens/screens/screen/StackScreenComponent.kt
@@ -17,6 +17,12 @@ internal class StackScreenComponent(context: LynxContext) : UIGroup<StackScreenV
         ATTACHED,
     }
 
+    internal var isPreventNativeDismissEnabled: Boolean by Delegates.observable(false) { _, oldValue, newValue ->
+        if (oldValue != newValue) {
+            preventNativeDismissChangeObserver?.preventNativeDismissChanged(newValue)
+        }
+    }
+
     internal var isNativelyDismissed = false
         set(value) {
             require(value) {
@@ -38,6 +44,11 @@ internal class StackScreenComponent(context: LynxContext) : UIGroup<StackScreenV
     private val eventEmitter: StackScreenEventEmitter by lazy {
         StackScreenEventEmitter(lynxContext, sign)
     }
+
+    /**
+     * Use this to set/unset the observer.
+     */
+    internal var preventNativeDismissChangeObserver: PreventNativeDismissChangeObserver? = null
 
     internal fun createAppearanceEventsEmitter(viewLifecycleOwner: LifecycleOwner) =
         StackScreenAppearanceEventsEmitter(viewLifecycleOwner.lifecycle, eventEmitter)
@@ -65,10 +76,21 @@ internal class StackScreenComponent(context: LynxContext) : UIGroup<StackScreenV
         screenKey = value
     }
 
+    @LynxProp(name = "preventNativeDismiss")
+    fun setPreventNativeDismiss(
+        value: Boolean?,
+    ) {
+        isPreventNativeDismissEnabled = value == true
+    }
+
     internal fun onDismiss() {
         if (activityMode == ActivityMode.ATTACHED) {
             isNativelyDismissed = true
         }
-        eventEmitter.notifyOnDismiss(isNativelyDismissed)
+        eventEmitter.emitOnDismiss(isNativelyDismissed)
+    }
+
+    internal fun onNativeDismissPrevented() {
+        eventEmitter.emitOnNativeDismissPrevented()
     }
 }

--- a/android/app/src/main/java/com/lynxscreens/screens/screen/StackScreenEventEmitter.kt
+++ b/android/app/src/main/java/com/lynxscreens/screens/screen/StackScreenEventEmitter.kt
@@ -14,6 +14,7 @@ internal class StackScreenEventEmitter(
         private const val EVENT_WILL_DISAPPEAR = "OnWillDisappear"
         private const val EVENT_DID_DISAPPEAR = "OnDidDisappear"
         private const val EVENT_ON_DISMISS = "OnDismiss"
+        private const val EVENT_ON_NATIVE_DISMISS_PREVENTED = "OnNativeDismissPrevented"
     }
 
     override fun emitOnWillAppear() {
@@ -32,8 +33,12 @@ internal class StackScreenEventEmitter(
         emit(EVENT_DID_DISAPPEAR)
     }
 
-    fun notifyOnDismiss(isNativeDismiss: Boolean) {
+    internal fun emitOnDismiss(isNativeDismiss: Boolean) {
         emit(EVENT_ON_DISMISS, mapOf("isNativeDismiss" to isNativeDismiss))
+    }
+
+    internal fun emitOnNativeDismissPrevented() {
+        emit(EVENT_ON_NATIVE_DISMISS_PREVENTED)
     }
 
     private fun emit(name: String, params: Map<String, Any>? = null) {

--- a/android/app/src/main/java/com/lynxscreens/screens/screen/StackScreenFragment.kt
+++ b/android/app/src/main/java/com/lynxscreens/screens/screen/StackScreenFragment.kt
@@ -12,6 +12,24 @@ internal class StackScreenFragment(
 ) : Fragment() {
     private var screenLifecycleEventEmitter: StackScreenAppearanceEventsEmitter? = null
 
+    /**
+     * This holds the screen strongly for now. Beware of retain cycle.
+     *
+     * Since each StackScreenFragment owns a PreventNativeDismissCallback & adds it to the
+     * OnBackPressedDispatcher the callback should be enabled only when the top fragment is this fragment.
+     */
+    private val preventNativeDismissBackPressedCallback =
+        PreventNativeDismissCallback(this, stackScreen, canBeEnabled = true)
+
+    private var isTopFragment: Boolean = false
+
+    override fun onCreate(savedInstanceState: Bundle?) {
+        super.onCreate(savedInstanceState)
+        requireActivity().onBackPressedDispatcher.addCallback(
+            preventNativeDismissBackPressedCallback
+        )
+    }
+
     override fun onCreateView(
         inflater: LayoutInflater,
         container: ViewGroup?,
@@ -35,5 +53,30 @@ internal class StackScreenFragment(
         super.onDestroy()
         Log.i("StackScreenFragment", "onDestroy")
         stackScreen.onDismiss()
+        preventNativeDismissBackPressedCallback.remove()
+    }
+
+    /**
+     * Notifies this fragment that it has become "top fragment" in its fragment manager.
+     *
+     * This function should be idempotent.
+     */
+    internal fun onBecomeTopFragment() {
+        if (isTopFragment) return
+
+        isTopFragment = true
+        preventNativeDismissBackPressedCallback.canBeEnabled = true
+    }
+
+    /**
+     * Notifies this fragment that it is not longer the "top fragment" in its fragment manager.
+     *
+     * This function should be idempotent.
+     */
+    internal fun onResignTopFragment() {
+        if (!isTopFragment) return
+
+        isTopFragment = false
+        preventNativeDismissBackPressedCallback.canBeEnabled = false
     }
 }

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -10,7 +10,7 @@ export function App(props: { onRender?: () => void }) {
         height: '100%',
       }}
     >
-      <Tests.TestNested />
+      <Tests.TestPreventNativeDismissNestedStack />
     </page>
   );
 }

--- a/src/components/StackContainer.tsx
+++ b/src/components/StackContainer.tsx
@@ -59,6 +59,7 @@ export function StackContainer({ routeConfigs }: StackContainerProps) {
         ({ Component, options, activityMode, routeKey }) => {
           const stackNavigationContext: StackNavigationContextPayload = {
             routeKey,
+            routeOptions: { ...options },
             push: navMethods.pushAction,
             pop: navMethods.popAction,
             preload: navMethods.preloadAction,

--- a/src/contexts/StackNavigationContext.ts
+++ b/src/contexts/StackNavigationContext.ts
@@ -3,11 +3,13 @@ import type {
   BatchActionMethod,
   PopActionMethod,
   PreloadActionMethod,
-  PushActionMethod
+  PushActionMethod,
+  StackRouteOptions,
 } from "../types/StackContainer";
 
 export type StackNavigationContextPayload = {
   routeKey: string;
+  routeOptions: StackRouteOptions;
   push: PushActionMethod,
   pop: PopActionMethod,
   preload: PreloadActionMethod,

--- a/src/examples/TestPreventNativeDismissNestedStack.tsx
+++ b/src/examples/TestPreventNativeDismissNestedStack.tsx
@@ -1,0 +1,281 @@
+import React from 'react';
+import { StackContainer } from '../components/StackContainer';
+import { useStackNavigationContext } from '../hooks/useStackNavigationContext';
+
+function StackSetup() {
+  return (
+    <StackContainer
+      routeConfigs={[
+        {
+          name: 'Home',
+          Component: HomeScreen,
+          options: {},
+        },
+        {
+          name: 'A',
+          Component: AScreen,
+          options: {},
+        },
+        {
+          name: 'B',
+          Component: BScreen,
+          options: {
+            preventNativeDismiss: true,
+            onNativeDismissPrevented: () => {
+              console.info('Native dismiss prevented - B');
+            },
+          },
+        },
+        {
+          name: 'NestedStack',
+          Component: NestedStackScreen,
+          options: {
+            // This one is interesting. It will prevent nested stack from being popped.
+            preventNativeDismiss: false,
+          },
+        },
+      ]}
+    />
+  );
+}
+
+function HomeScreen() {
+  return (
+    <view
+      style={{
+        display: 'flex',
+        flexDirection: 'column',
+        justifyContent: 'center',
+        alignItems: 'center',
+        width: '100%',
+        height: '100%',
+        backgroundColor: 'cyan',
+      }}
+    >
+      <RouteInformation routeName="Home" />
+      <NavigationButtons
+        isPopEnabled={false}
+        routeNames={['A', 'B', 'NestedStack']}
+      />
+    </view>
+  );
+}
+
+function AScreen() {
+  return (
+    <view
+      style={{
+        display: 'flex',
+        flexDirection: 'column',
+        justifyContent: 'center',
+        alignItems: 'center',
+        width: '100%',
+        height: '100%',
+        backgroundColor: 'yellow',
+      }}
+    >
+      <RouteInformation routeName="A" />
+      <PreventNativeDismissInfo />
+      <NavigationButtons isPopEnabled routeNames={['A', 'B', 'NestedStack']} />
+    </view>
+  );
+}
+
+function BScreen() {
+  return (
+    <view
+      style={{
+        display: 'flex',
+        flexDirection: 'column',
+        justifyContent: 'center',
+        alignItems: 'center',
+        width: '100%',
+        height: '100%',
+        backgroundColor: 'lightgreen',
+      }}
+    >
+      <RouteInformation routeName="B" />
+      <PreventNativeDismissInfo />
+      <NavigationButtons isPopEnabled routeNames={['A', 'B', 'NestedStack']} />
+    </view>
+  );
+}
+
+function NestedStackScreen() {
+  return (
+    <StackContainer
+      routeConfigs={[
+        {
+          name: 'NestedHome',
+          Component: NestedHomeScreen,
+          options: {
+            // This one will also prevent!
+            preventNativeDismiss: true,
+            onNativeDismissPrevented: () => {
+              console.info('Native dismiss prevented - NestedHome');
+            },
+          },
+        },
+        {
+          name: 'NestedA',
+          Component: NestedAScreen,
+          options: {},
+        },
+        {
+          name: 'NestedB',
+          Component: NestedBScreen,
+          options: {
+            preventNativeDismiss: true,
+            onNativeDismissPrevented: () => {
+              console.info('Native dismiss prevented - NestedB');
+            },
+          },
+        },
+      ]}
+    />
+  );
+}
+
+function NestedHomeScreen() {
+  return (
+    <view
+      style={{
+        display: 'flex',
+        flexDirection: 'column',
+        justifyContent: 'center',
+        alignItems: 'center',
+        width: '100%',
+        height: '100%',
+        backgroundColor: 'cyan',
+      }}
+    >
+      <RouteInformation routeName="NestedHome" />
+      <PreventNativeDismissInfo />
+      <NavigationButtons isPopEnabled routeNames={['NestedA', 'NestedB']} />
+    </view>
+  );
+}
+
+function NestedAScreen() {
+  return (
+    <view
+      style={{
+        display: 'flex',
+        flexDirection: 'column',
+        justifyContent: 'center',
+        alignItems: 'center',
+        width: '100%',
+        height: '100%',
+        backgroundColor: 'cyan',
+      }}
+    >
+      <RouteInformation routeName="NestedA" />
+      <PreventNativeDismissInfo />
+      <NavigationButtons isPopEnabled routeNames={['NestedA', 'NestedB']} />
+    </view>
+  );
+}
+
+function NestedBScreen() {
+  return (
+    <view
+      style={{
+        display: 'flex',
+        flexDirection: 'column',
+        justifyContent: 'center',
+        alignItems: 'center',
+        width: '100%',
+        height: '100%',
+        backgroundColor: 'cyan',
+      }}
+    >
+      <RouteInformation routeName="NestedB" />
+      <PreventNativeDismissInfo />
+      <NavigationButtons isPopEnabled routeNames={['NestedA', 'NestedB']} />
+    </view>
+  );
+}
+
+function RouteInformation(props: { routeName: string }) {
+  const routeKey = useStackNavigationContext().routeKey;
+
+  return (
+    <view>
+      <text style={{ color: 'black', fontSize: 20, fontWeight: 'bold' }}>
+        Name: {props.routeName}
+      </text>
+      <text style={{ color: 'black', fontSize: 20, fontWeight: 'bold' }}>
+        Key: {routeKey}
+      </text>
+    </view>
+  );
+}
+
+function NavigationButtons(props: {
+  routeNames: string[];
+  isPopEnabled: boolean;
+}) {
+  const navigation = useStackNavigationContext();
+
+  return (
+    <>
+      {props.routeNames.map((routeName) => (
+        <Button
+          key={routeName}
+          label={`Push ${routeName}`}
+          onTap={() => navigation.push(routeName)}
+        />
+      ))}
+      {props.isPopEnabled && (
+        <Button
+          label="Pop"
+          onTap={() => navigation.pop(navigation.routeKey)}
+        />
+      )}
+    </>
+  );
+}
+
+function PreventNativeDismissInfo() {
+  const navContext = useStackNavigationContext();
+
+  return (
+    <view>
+      <text style={{ color: 'black', fontSize: 20, fontWeight: 'bold' }}>
+        Prevent native dismiss:{' '}
+        {navContext.routeOptions.preventNativeDismiss ? 'Enabled' : 'Disabled'}
+      </text>
+    </view>
+  );
+}
+
+interface ButtonProps {
+  onTap: () => void;
+  label: string;
+}
+
+const Button = ({ onTap, label }: ButtonProps) => (
+  <view
+    style={{
+      width: '200px',
+      height: '50px',
+      backgroundColor: 'blue',
+      justifyContent: 'center',
+      alignItems: 'center',
+      marginBottom: '10px',
+    }}
+    bindtap={onTap}
+  >
+    <text
+      native-interaction-enabled={false}
+      user-interaction-enabled={false}
+      style={{ color: 'white' }}
+    >
+      {label}
+    </text>
+  </view>
+);
+
+export default function App() {
+  return <StackSetup />;
+}

--- a/src/examples/TestPreventNativeDismissSingleStack.tsx
+++ b/src/examples/TestPreventNativeDismissSingleStack.tsx
@@ -1,0 +1,164 @@
+import React from 'react';
+import { StackContainer } from '../components/StackContainer';
+import { useStackNavigationContext } from '../hooks/useStackNavigationContext';
+
+interface ButtonProps {
+  onTap: () => void;
+  label: string;
+}
+
+const Button = ({ onTap, label }: ButtonProps) => (
+  <view
+    style={{
+      width: '200px',
+      height: '50px',
+      backgroundColor: 'blue',
+      justifyContent: 'center',
+      alignItems: 'center',
+      marginBottom: '10px',
+    }}
+    bindtap={onTap}
+  >
+    <text
+      native-interaction-enabled={false}
+      user-interaction-enabled={false}
+      style={{ color: 'white' }}
+    >
+      {label}
+    </text>
+  </view>
+);
+
+function StackSetup() {
+  return (
+    <StackContainer
+      routeConfigs={[
+        {
+          name: 'Home',
+          Component: HomeScreen,
+          options: {},
+        },
+        {
+          name: 'A',
+          Component: AScreen,
+          options: {},
+        },
+        {
+          name: 'B',
+          Component: BScreen,
+          options: {
+            preventNativeDismiss: true,
+            onNativeDismissPrevented: () => {
+              console.info('Native dismiss prevented');
+            },
+          },
+        },
+      ]}
+    />
+  );
+}
+
+function HomeScreen() {
+  return (
+    <view
+      style={{
+        display: 'flex',
+        flexDirection: 'column',
+        justifyContent: 'center',
+        alignItems: 'center',
+        width: '100%',
+        height: '100%',
+        backgroundColor: 'cyan',
+      }}
+    >
+      <RouteInformation routeName="Home" />
+      <NavigationButtons isPopEnabled={false} />
+    </view>
+  );
+}
+
+function AScreen() {
+  return (
+    <view
+      style={{
+        display: 'flex',
+        flexDirection: 'column',
+        justifyContent: 'center',
+        alignItems: 'center',
+        width: '100%',
+        height: '100%',
+        backgroundColor: 'yellow',
+      }}
+    >
+      <RouteInformation routeName="A" />
+      <PreventNativeDismissInfo />
+      <NavigationButtons isPopEnabled={true} />
+    </view>
+  );
+}
+
+function BScreen() {
+  return (
+    <view
+      style={{
+        display: 'flex',
+        flexDirection: 'column',
+        justifyContent: 'center',
+        alignItems: 'center',
+        width: '100%',
+        height: '100%',
+        backgroundColor: 'lightgreen',
+      }}
+    >
+      <RouteInformation routeName="B" />
+      <PreventNativeDismissInfo />
+      <NavigationButtons isPopEnabled={true} />
+    </view>
+  );
+}
+
+function RouteInformation(props: { routeName: string }) {
+  const routeKey = useStackNavigationContext().routeKey;
+
+  return (
+    <view>
+      <text style={{ color: 'black', fontSize: 20, fontWeight: 'bold' }}>
+        Name: {props.routeName}
+      </text>
+      <text style={{ color: 'black', fontSize: 20, fontWeight: 'bold' }}>
+        Key: {routeKey}
+      </text>
+    </view>
+  );
+}
+
+function NavigationButtons(props: { isPopEnabled: boolean }) {
+  const navigation = useStackNavigationContext();
+
+  return (
+    <>
+      <Button label="Push A" onTap={() => navigation.push('A')} />
+      <Button label="Push B" onTap={() => navigation.push('B')} />
+      {props.isPopEnabled && (
+        <Button label="Pop" onTap={() => navigation.pop(navigation.routeKey)} />
+      )}
+    </>
+  );
+}
+
+function PreventNativeDismissInfo() {
+  const navContext = useStackNavigationContext();
+
+  return (
+    <view>
+      <text style={{ color: 'black', fontSize: 20, fontWeight: 'bold' }}>
+        Prevent native dismiss:{' '}
+        {navContext.routeOptions.preventNativeDismiss ? 'Enabled' : 'Disabled'}
+      </text>
+    </view>
+  );
+}
+
+export default function App() {
+  return <StackSetup />;
+}

--- a/src/examples/index.ts
+++ b/src/examples/index.ts
@@ -1,3 +1,5 @@
 export { default as TestBatch } from './TestBatch';
 export { default as TestBase } from './TestBase';
 export { default as TestNested } from './TestNested';
+export { default as TestPreventNativeDismissNestedStack } from './TestPreventNativeDismissNestedStack';
+export { default as TestPreventNativeDismissSingleStack } from './TestPreventNativeDismissSingleStack';

--- a/src/native_components/StackScreenNativeComponent.tsx
+++ b/src/native_components/StackScreenNativeComponent.tsx
@@ -7,14 +7,19 @@ import type {
 
 export const StackScreenNativeComponent = ({
   children,
+  // Control
   activityMode,
   screenKey,
+  // Events
   onWillAppear,
   onDidAppear,
   onWillDisappear,
   onDidDisappear,
   onDismiss,
   onNativeDismiss,
+  onNativeDismissPrevented,
+  // Configuration
+  preventNativeDismiss,
 }: StackScreenProps) => {
   const onDismissWrapper = React.useCallback(
     (event: Lynx.BaseEventOrig<OnDismissEventPayload>) => {
@@ -47,6 +52,9 @@ export const StackScreenNativeComponent = ({
       bindOnWillDisappear={onWillDisappear}
       bindOnDidDisappear={onDidDisappear}
       bindOnDismiss={onDismissWrapper}
+      bindOnNativeDismissPrevented={onNativeDismissPrevented}
+      // Configuration
+      preventNativeDismiss={preventNativeDismiss}
     >
       {children}
     </stack-screen-native>

--- a/src/rspeedy-env.d.ts
+++ b/src/rspeedy-env.d.ts
@@ -29,13 +29,18 @@ declare module "@lynx-js/types" {
       children: Lynx.Element;
       id?: string;
       style?: string | Lynx.CSSProperties;
+      // Control
       activityMode?: 'detached' | 'attached';
       screenKey?: string;
+      // Events
       bindOnWillAppear?: Lynx.EventHandler<Lynx.BaseEventOrig<EmptyEventPayload>>;
       bindOnDidAppear?: Lynx.EventHandler<Lynx.BaseEventOrig<EmptyEventPayload>>;
       bindOnWillDisappear?: Lynx.EventHandler<Lynx.BaseEventOrig<EmptyEventPayload>>;
       bindOnDidDisappear?: Lynx.EventHandler<Lynx.BaseEventOrig<EmptyEventPayload>>;
       bindOnDismiss?: Lynx.EventHandler<Lynx.BaseEventOrig<OnDismissEventPayload>>;
+      bindOnNativeDismissPrevented?: Lynx.EventHandler<Lynx.BaseEventOrig<EmptyEventPayload>>;
+      // Configuration
+      preventNativeDismiss?: boolean;
     }
   }
 }

--- a/src/types/StackContainer.ts
+++ b/src/types/StackContainer.ts
@@ -33,6 +33,13 @@ export type StackScreenProps = {
 
   onDismiss?: (screenKey: string) => void;
   onNativeDismiss?: (screenKey: string) => void;
+
+  onNativeDismissPrevented?:
+    | Lynx.EventHandler<Lynx.BaseEventOrig<EmptyEventPayload>>
+    | undefined;
+
+  // Configuration
+  preventNativeDismiss?: boolean;
 };
 
 /// Route definition


### PR DESCRIPTION
(The implementation should be really close to the implementation from react-native-screens)
Related commit from RNS: https://github.com/software-mansion/react-native-screens/commit/ed438838a2fdfa938b5bdfe74f6b5e98e84cb83d

### Description

(copied from RNS)

**Add initial implementation of prevent native dismiss on Android** This commit adds support for "prevent native dismiss" behavior on Android for stack screens.

The added interface consists of a prop on `StackScreen`: `preventNativeDismiss` and event `onNativeDismissPrevented`, which lets the programmer react to the native dismiss attempt.

This implementation follows [RFC-0717](https://github.com/software-mansion/react-native-screens-labs/blob/main-issue-tracker/rfcs/0717-stack-prevent-dismiss.md). **It does not handle the JS-side of the mechanism.**

Closes: https://github.com/software-mansion/lynx-screens/issues/38

---

### Testing

Added PreventNativeDismiss examples for single & nested stack

Single stack:

https://github.com/user-attachments/assets/d23c07cb-a82f-4d16-b778-b1e8e9988368

Nested stack:

https://github.com/user-attachments/assets/44b0e8a0-adc5-46b6-b1b5-b9f80e565d31