### PR TITLE
chore(examples): allow to set route options in StackContainer

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -10,7 +10,7 @@ export function App(props: { onRender?: () => void }) {
         height: '100%',
       }}
     >
-      <Tests.TestPreventNativeDismissNestedStack />
+      <Tests.TestPreventNativeDismissSingleStack />
     </page>
   );
 }

--- a/src/components/StackContainer.tsx
+++ b/src/components/StackContainer.tsx
@@ -64,6 +64,7 @@ export function StackContainer({ routeConfigs }: StackContainerProps) {
             pop: navMethods.popAction,
             preload: navMethods.preloadAction,
             batch: navMethods.batchAction,
+            setRouteOptions: navMethods.setRouteOptions,
           };
 
         return (

--- a/src/contexts/StackNavigationContext.ts
+++ b/src/contexts/StackNavigationContext.ts
@@ -4,6 +4,7 @@ import type {
   PopActionMethod,
   PreloadActionMethod,
   PushActionMethod,
+  SetRouteOptionsActionMethod,
   StackRouteOptions,
 } from "../types/StackContainer";
 
@@ -14,6 +15,7 @@ export type StackNavigationContextPayload = {
   pop: PopActionMethod,
   preload: PreloadActionMethod,
   batch: BatchActionMethod,
+  setRouteOptions: SetRouteOptionsActionMethod;
 };
 
 export const StackNavigationContext =

--- a/src/examples/TestPreventNativeDismissNestedStack.tsx
+++ b/src/examples/TestPreventNativeDismissNestedStack.tsx
@@ -77,6 +77,7 @@ function AScreen() {
       <RouteInformation routeName="A" />
       <PreventNativeDismissInfo />
       <NavigationButtons isPopEnabled routeNames={['A', 'B', 'NestedStack']} />
+      <TogglePreventNativeDismiss />
     </view>
   );
 }
@@ -97,6 +98,7 @@ function BScreen() {
       <RouteInformation routeName="B" />
       <PreventNativeDismissInfo />
       <NavigationButtons isPopEnabled routeNames={['A', 'B', 'NestedStack']} />
+      <TogglePreventNativeDismiss />
     </view>
   );
 }
@@ -152,6 +154,7 @@ function NestedHomeScreen() {
       <RouteInformation routeName="NestedHome" />
       <PreventNativeDismissInfo />
       <NavigationButtons isPopEnabled routeNames={['NestedA', 'NestedB']} />
+      <TogglePreventNativeDismiss />
     </view>
   );
 }
@@ -172,6 +175,7 @@ function NestedAScreen() {
       <RouteInformation routeName="NestedA" />
       <PreventNativeDismissInfo />
       <NavigationButtons isPopEnabled routeNames={['NestedA', 'NestedB']} />
+      <TogglePreventNativeDismiss />
     </view>
   );
 }
@@ -192,6 +196,7 @@ function NestedBScreen() {
       <RouteInformation routeName="NestedB" />
       <PreventNativeDismissInfo />
       <NavigationButtons isPopEnabled routeNames={['NestedA', 'NestedB']} />
+      <TogglePreventNativeDismiss />
     </view>
   );
 }
@@ -233,6 +238,21 @@ function NavigationButtons(props: {
         />
       )}
     </>
+  );
+}
+
+function TogglePreventNativeDismiss() {
+  const navigation = useStackNavigationContext();
+
+  return (
+    <Button
+      label="Toggle Prevent Native Dismiss"
+      onTap={() =>
+        navigation.setRouteOptions(navigation.routeKey, {
+          preventNativeDismiss: !navigation.routeOptions.preventNativeDismiss,
+        })
+      }
+    />
   );
 }
 

--- a/src/examples/TestPreventNativeDismissSingleStack.tsx
+++ b/src/examples/TestPreventNativeDismissSingleStack.tsx
@@ -93,6 +93,7 @@ function AScreen() {
       <RouteInformation routeName="A" />
       <PreventNativeDismissInfo />
       <NavigationButtons isPopEnabled={true} />
+      <TogglePreventNativeDismiss />
     </view>
   );
 }
@@ -113,6 +114,7 @@ function BScreen() {
       <RouteInformation routeName="B" />
       <PreventNativeDismissInfo />
       <NavigationButtons isPopEnabled={true} />
+      <TogglePreventNativeDismiss />
     </view>
   );
 }
@@ -143,6 +145,21 @@ function NavigationButtons(props: { isPopEnabled: boolean }) {
         <Button label="Pop" onTap={() => navigation.pop(navigation.routeKey)} />
       )}
     </>
+  );
+}
+
+function TogglePreventNativeDismiss() {
+  const navigation = useStackNavigationContext();
+
+  return (
+    <Button
+      label="Toggle Prevent Native Dismiss"
+      onTap={() =>
+        navigation.setRouteOptions(navigation.routeKey, {
+          preventNativeDismiss: !navigation.routeOptions.preventNativeDismiss,
+        })
+      }
+    />
   );
 }
 

--- a/src/hooks/useStackOperationMethods.ts
+++ b/src/hooks/useStackOperationMethods.ts
@@ -11,7 +11,7 @@ import type {
   PopNativeActionMethod,
   PreloadActionMethod,
   PushActionMethod,
-  SetRouteOptionsActionMethod as SetRouteOptionsActionMethod,
+  SetRouteOptionsActionMethod,
   StackRouteConfig,
   StackRouteOptions,
 } from '../types/StackContainer';

--- a/src/hooks/useStackOperationMethods.ts
+++ b/src/hooks/useStackOperationMethods.ts
@@ -11,7 +11,9 @@ import type {
   PopNativeActionMethod,
   PreloadActionMethod,
   PushActionMethod,
+  SetRouteOptionsActionMethod as SetRouteOptionsActionMethod,
   StackRouteConfig,
+  StackRouteOptions,
 } from '../types/StackContainer';
 
 export function useStackOperationMethods(
@@ -79,6 +81,13 @@ export function useStackOperationMethods(
     dispatch({ type: 'clear-effects', ctx: actionContext });
   }, [dispatch, actionContext]);
 
+  const setRouteOptions: SetRouteOptionsActionMethod = React.useCallback(
+    (routeKey: string, options: Partial<StackRouteOptions>) => {
+      dispatch({ type: 'set-options', routeKey, options, ctx: actionContext });
+    },
+    [dispatch, actionContext],
+  );
+
   const aggregateValue = React.useMemo(() => {
     return {
       pushAction,
@@ -88,6 +97,7 @@ export function useStackOperationMethods(
       preloadAction,
       batchAction,
       clearEffectsAction,
+      setRouteOptions,
     };
   }, [
     pushAction,
@@ -97,6 +107,7 @@ export function useStackOperationMethods(
     preloadAction,
     batchAction,
     clearEffectsAction,
+    setRouteOptions,
   ]);
 
   return aggregateValue;

--- a/src/types/StackContainer.ts
+++ b/src/types/StackContainer.ts
@@ -49,6 +49,9 @@ export type StackRouteOptions = Omit<
   'children' | 'activityMode' | 'screenKey'
 >;
 
+/**
+ * Blueprint for a route.
+ */
 export type StackRouteConfig = {
   name: string;
   Component: React.ComponentType;
@@ -72,6 +75,10 @@ export type PopCompletedActionMethod = (routeKey: string) => void;
 export type PopNativeActionMethod = (routeKey: string) => void;
 export type PreloadActionMethod = (routeName: string) => void;
 export type BatchActionMethod = (actions: BatchableNavigationAction[]) => void;
+export type SetRouteOptionsActionMethod = (
+  routeKey: string,
+  options: Partial<StackRouteOptions>,
+) => void;
 export type ClearEffectsActionMethod = () => void;
 
 export type NavigationActionMethods = {
@@ -82,6 +89,12 @@ export type NavigationActionMethods = {
   preloadAction: PreloadActionMethod;
   batchAction: BatchActionMethod;
   clearEffectsAction: ClearEffectsActionMethod;
+  /**
+   * Change options for the current route. This does not modify a blueprint
+   * (StackRouteConfig) for the route. It only modifies options for the
+   * given route instance.
+   */
+  setRouteOptions: SetRouteOptionsActionMethod;
 };
 
 export type StackState = StackRoute[];
@@ -139,6 +152,13 @@ export type NavigationActionClearEffects = {
   ctx: NavigationActionContext;
 };
 
+export type NavigationActionSetRouteOptions = {
+  type: 'set-options';
+  routeKey: string;
+  options: Partial<StackRouteOptions>;
+  ctx: NavigationActionContext;
+};
+
 export type NavigationActionContext = {
   routeConfigs: StackRouteConfig[];
 };
@@ -146,7 +166,8 @@ export type NavigationActionContext = {
 export type BatchableNavigationAction =
   | Omit<NavigationActionPush, 'ctx'>
   | Omit<NavigationActionPop, 'ctx'>
-  | Omit<NavigationActionPreload, 'ctx'>;
+  | Omit<NavigationActionPreload, 'ctx'>
+  | Omit<NavigationActionSetRouteOptions, 'ctx'>;
 
 export type NavigationAction =
   | NavigationActionPush
@@ -155,4 +176,5 @@ export type NavigationAction =
   | NavigationActionNativePop
   | NavigationActionPreload
   | NavigationActionClearEffects
+  | NavigationActionSetRouteOptions
   | NavigationActionBatch;

--- a/src/utils/reducer.ts
+++ b/src/utils/reducer.ts
@@ -7,6 +7,7 @@ import type {
   NavigationActionPopCompleted,
   NavigationActionPreload,
   NavigationActionPush,
+  NavigationActionSetRouteOptions,
   StackNavigationEffect,
   StackNavigationState,
   StackScreenActivityMode,
@@ -43,6 +44,9 @@ export function navigationStateReducer(
     }
     case 'clear-effects': {
       return navigationActionClearEffectsHandler(state, action);
+    }
+    case 'set-options': {
+      return navigationActionSetOptionsHandler(state, action);
     }
   }
 
@@ -90,7 +94,7 @@ function navigationActionPushHandler(
     ];
     const routeCopy = { ...route };
     routeCopy.activityMode = 'attached';
-    return stackNavStateWithStack(state, applyPush(newStack, routeCopy));
+    return stateWithStack(state, applyPush(newStack, routeCopy));
   }
 
   // 2 - Try to render new route
@@ -104,7 +108,7 @@ function navigationActionPushHandler(
   }
 
   const newRoute = createRouteFromConfig(newRouteConfig, 'attached');
-  return stackNavStateWithStack(state, applyPush(state.stack, newRoute));
+  return stateWithStack(state, applyPush(state.stack, newRoute));
 }
 
 function navigationActionPopHandler(
@@ -135,7 +139,7 @@ function navigationActionPopHandler(
       // If there is already a pop-container effect, do nothing
       return state;
     }
-    return stackNavStateWithEffects(
+    return stateWithEffects(
       state,
       applyEffect(state.effects, { type: 'pop-container' }),
     );
@@ -167,7 +171,7 @@ function navigationActionPopHandler(
   // and the original state won't be immediatelly affected.
   route.activityMode = 'detached';
 
-  return stackNavStateWithStack(state, newStack);
+  return stateWithStack(state, newStack);
 }
 
 function navigationActionPopCompletedHandler(
@@ -198,7 +202,7 @@ function navigationActionPopCompletedHandler(
     ...stack.slice(0, routeIndex),
     ...stack.slice(routeIndex + 1)
   ];
-  return stackNavStateWithStack(state, newStack);
+  return stateWithStack(state, newStack);
 }
 
 function navigationActionNativePopHandler(
@@ -231,7 +235,7 @@ function navigationActionNativePopHandler(
     ...stack.slice(0, routeIndex),
     ...stack.slice(routeIndex + 1)
   ];
-  return stackNavStateWithStack(state, newStack);
+  return stateWithStack(state, newStack);
 }
 
 function navigationActionPreloadHandler(
@@ -253,7 +257,7 @@ function navigationActionPreloadHandler(
   // that won't result in problems on native platform.
   // More info: https://github.com/software-mansion/react-native-screens/pull/3531.
   const newStack = [...state.stack, createRouteFromConfig(routeConfig)];
-  return stackNavStateWithStack(state, newStack);
+  return stateWithStack(state, newStack);
 }
 
 function navigationActionBatchHandler(
@@ -278,7 +282,33 @@ function navigationActionClearEffectsHandler(
   if (state.effects.length === 0) {
     return state;
   }
-  return stackNavStateWithEffects(state, []);
+  return stateWithEffects(state, []);
+}
+
+function navigationActionSetOptionsHandler(
+  state: StackNavigationState,
+  action: NavigationActionSetRouteOptions,
+): StackNavigationState {
+  const routeIndex = state.stack.findIndex(
+    route => route.routeKey === action.routeKey,
+  );
+
+  if (routeIndex === NOT_FOUND_INDEX) {
+    throw new Error(
+      `[Stack] Can not set options. Route with key ${action.routeKey} not found`,
+    );
+  }
+
+  const routeCopy = { ...state.stack[routeIndex] };
+  routeCopy.options = {
+    ...routeCopy.options,
+    ...action.options,
+  };
+
+  return stateWithStack(
+    state,
+    stackWithReplacedRoute(state.stack, routeCopy, routeIndex),
+  );
 }
 
 // Ensures correct order of screens (attached first, detached at the end).
@@ -329,7 +359,7 @@ function generateRouteKeyForRouteName(routeName: string): string {
   return `r-${routeName}-${generateID()}`;
 }
 
-function stackNavStateWithStack(
+function stateWithStack(
   navState: StackNavigationState,
   newStack: StackState,
 ): StackNavigationState {
@@ -339,7 +369,7 @@ function stackNavStateWithStack(
   };
 }
 
-function stackNavStateWithEffects(
+function stateWithEffects(
   navState: StackNavigationState,
   newEffects: StackNavigationEffect[],
 ): StackNavigationState {
@@ -347,4 +377,16 @@ function stackNavStateWithEffects(
     ...navState,
     effects: newEffects,
   };
+}
+
+function stackWithReplacedRoute(
+  state: StackState,
+  newRoute: StackRoute,
+  routeIndex: number,
+): StackState {
+  return [
+    ...state.slice(0, routeIndex),
+    newRoute,
+    ...state.slice(routeIndex + 1)
+  ];
 }


### PR DESCRIPTION
reference commit from `react-native-screens`: https://github.com/software-mansion/react-native-screens/commit/4123e4bf185fcc3cd9d052ffc200ad8cc1ae3416 

### Description

Add `SetRouteOptionsActionMethod` allowing to modify route options.

Closes: #40 

---

### Testing

Updated `PreventNativeDismiss` examples for single & nested stack

https://github.com/user-attachments/assets/1e733f1c-8f61-4528-86c8-3fd0c1304473
