### PR TITLE
chore(Android): Enable predictive back gesture

### DIFF
--- a/android/app/src/main/AndroidManifest.xml
+++ b/android/app/src/main/AndroidManifest.xml
@@ -7,6 +7,7 @@
         android:name=".MainApplication"
         android:allowBackup="true"
         android:dataExtractionRules="@xml/data_extraction_rules"
+        android:enableOnBackInvokedCallback="true"
         android:fullBackupContent="@xml/backup_rules"
         android:icon="@mipmap/ic_launcher"
         android:label="@string/app_name"


### PR DESCRIPTION
### Description

The predictive back gesture was not being triggered when swiping back from the root screen.

By adding `android:enableOnBackInvokedCallback="true"` to the `<application>` tag in the `AndroidManifest.xml`, we allow the system to intercept the back gesture at the root level of the navigation stack.

Note: Unlike RN, Lynx doesn't override `OnBackPressedCallback`

Closes: https://github.com/software-mansion/lynx-screens/issues/41

### Testing

https://github.com/user-attachments/assets/6d5976ca-e0ab-4dfb-b88c-d2bf886e6781