### PR TITLE
chore(examples): Allow modifying route blueprints passed to `StackContainer`

### DIFF
--- a/src/components/StackContainer.tsx
+++ b/src/components/StackContainer.tsx
@@ -90,7 +90,7 @@ function useSanitizeRouteConfigs(
   routeConfigs?: StackRouteConfig[] | undefined | null,
 ) {
   if (!routeConfigs || routeConfigs.length === 0) {
-    throw new Error('[RNScreens] There must be at least one route configured');
+    throw new Error('[Stack] There must be at least one route configured');
   }
 
   // Do not recompute in case the routeConfigs have not changed
@@ -101,6 +101,6 @@ function useSanitizeRouteConfigs(
   }, [routeConfigs]);
 
   if (!areNamesUnique) {
-    throw new Error('[RNScreens] All routes must have unique names');
+    throw new Error('[Stack] All routes must have unique names');
   }
 }

--- a/src/components/StackContainerWithDynamicRouteConfigs.tsx
+++ b/src/components/StackContainerWithDynamicRouteConfigs.tsx
@@ -1,0 +1,46 @@
+import React from 'react';
+import { StackContainer } from './StackContainer';
+import type { StackContainerProps, StackRouteOptions } from '../types/StackContainer';
+import { StackRouteConfigContext } from '../contexts/StackRouteConfigContext';
+
+/**
+ * StackContainer wrapped in context allowing for modifying options
+ * of route configs.
+ * See StackRouteConfigContext.
+ */
+export function StackContainerWithDynamicRouteConfigs(
+  props: StackContainerProps,
+) {
+  const [routeConfigs, setRouteConfigs] = React.useState(props.routeConfigs);
+
+  const updateRouteConfigWithOptions = React.useCallback(
+    (routeName: string, options: Partial<StackRouteOptions>) => {
+      setRouteConfigs((prevConfigs) => {
+        const routeConfigIndex = prevConfigs.findIndex(
+          (config) => config.name === routeName,
+        );
+
+        if (routeConfigIndex === -1) {
+          throw new Error(`Route with name "${routeName}" not found`);
+        }
+
+        return prevConfigs.toSpliced(routeConfigIndex, 1, {
+          ...prevConfigs[routeConfigIndex],
+          options,
+        });
+      });
+    },
+    [],
+  );
+
+  return (
+    <StackRouteConfigContext.Provider
+      value={{
+        routeConfigs,
+        updateRouteConfigWithOptions,
+      }}
+    >
+      <StackContainer routeConfigs={routeConfigs} />
+    </StackRouteConfigContext.Provider>
+  );
+}

--- a/src/contexts/StackRouteConfigContext.ts
+++ b/src/contexts/StackRouteConfigContext.ts
@@ -1,0 +1,16 @@
+import React from 'react';
+import type {
+  StackRouteConfig,
+  StackRouteOptions,
+} from '../types/StackContainer';
+
+export type StackRouteConfigContextPayload = {
+  routeConfigs: StackRouteConfig[];
+  updateRouteConfigWithOptions: (
+    routeName: string,
+    options: Partial<StackRouteOptions>,
+  ) => void;
+};
+
+export const StackRouteConfigContext =
+  React.createContext<StackRouteConfigContextPayload | null>(null);

--- a/src/examples/TestPreventNativeDismissNestedStack.tsx
+++ b/src/examples/TestPreventNativeDismissNestedStack.tsx
@@ -77,7 +77,6 @@ function AScreen() {
       <RouteInformation routeName="A" />
       <PreventNativeDismissInfo />
       <NavigationButtons isPopEnabled routeNames={['A', 'B', 'NestedStack']} />
-      <TogglePreventNativeDismiss />
     </view>
   );
 }
@@ -175,7 +174,6 @@ function NestedAScreen() {
       <RouteInformation routeName="NestedA" />
       <PreventNativeDismissInfo />
       <NavigationButtons isPopEnabled routeNames={['NestedA', 'NestedB']} />
-      <TogglePreventNativeDismiss />
     </view>
   );
 }

--- a/src/examples/TestPreventNativeDismissSingleStack.tsx
+++ b/src/examples/TestPreventNativeDismissSingleStack.tsx
@@ -93,7 +93,6 @@ function AScreen() {
       <RouteInformation routeName="A" />
       <PreventNativeDismissInfo />
       <NavigationButtons isPopEnabled={true} />
-      <TogglePreventNativeDismiss />
     </view>
   );
 }

--- a/src/hooks/useStackRouteConfigContext.ts
+++ b/src/hooks/useStackRouteConfigContext.ts
@@ -1,0 +1,14 @@
+import React from 'react';
+import { StackRouteConfigContext } from '../contexts/StackRouteConfigContext';
+
+export function useStackRouteConfigContext() {
+  const context = React.useContext(StackRouteConfigContext);
+
+  if (!context) {
+    throw new Error(
+      'useStackRouteConfigContext must be used within a StackContainerWithContext',
+    );
+  }
+
+  return context;
+}


### PR DESCRIPTION
Reference commit from RNScreens: https://github.com/software-mansion/react-native-screens/commit/41688f8e2153c866cc6e5f10e952335774bae090

### Description  

(copied from RNScreens)

**Expose `StackContainerWithDynamicRouteConfigs` component**
It's a wrapper for `StackContainer`. It adds `StackRouteConfigContext`,
which can be used to modify route options stored in route
configurations.

This is different from what
<https://github.com/software-mansion/react-native-screens/pull/3625>
introduced, because this does not impact existing route instances. Only
blueprints.

I created separate component to keep the `StackContainer` logic thin.

Closes: https://github.com/software-mansion/lynx-screens/issues/42