### PR TITLE
feat(Android): Make transition API work

### DIFF
--- a/android/app/build.gradle.kts
+++ b/android/app/build.gradle.kts
@@ -123,7 +123,6 @@ dependencies {
     implementation("androidx.fragment:fragment-ktx:1.8.9")
     implementation("androidx.appcompat:appcompat:1.7.1")
     implementation("androidx.transition:transition-ktx:1.7.0")
-    implementation("androidx.swiperefreshlayout:swiperefreshlayout:1.1.0")
     implementation("com.google.android.material:material:1.13.0")
     implementation("androidx.core:core-ktx:1.17.0")
 

--- a/android/app/build.gradle.kts
+++ b/android/app/build.gradle.kts
@@ -12,7 +12,7 @@ android {
     defaultConfig {
         applicationId = "com.lynxscreens"
         minSdk = 24
-        targetSdk = 34
+        targetSdk = 36
         versionCode = 1
         versionName = "1.0"
 
@@ -123,6 +123,8 @@ dependencies {
     implementation("androidx.fragment:fragment-ktx:1.8.9")
     implementation("androidx.appcompat:appcompat:1.7.1")
     implementation("androidx.transition:transition-ktx:1.7.0")
+    implementation("androidx.swiperefreshlayout:swiperefreshlayout:1.1.0")
+    implementation("com.google.android.material:material:1.13.0")
     implementation("androidx.core:core-ktx:1.17.0")
 
     kapt("org.lynxsdk.lynx:lynx-processor:3.5.1")

--- a/android/app/build.gradle.kts
+++ b/android/app/build.gradle.kts
@@ -7,7 +7,7 @@ plugins {
 
 android {
     namespace = "com.lynxscreens"
-    compileSdk = 34
+    compileSdk = 36
 
     defaultConfig {
         applicationId = "com.lynxscreens"
@@ -120,8 +120,10 @@ dependencies {
 
     // lynx-screens dependencies
     implementation("androidx.coordinatorlayout:coordinatorlayout:1.2.0")
-    implementation("androidx.fragment:fragment-ktx:1.6.1")
-    implementation("androidx.appcompat:appcompat:1.6.1")
+    implementation("androidx.fragment:fragment-ktx:1.8.9")
+    implementation("androidx.appcompat:appcompat:1.7.1")
+    implementation("androidx.transition:transition-ktx:1.7.0")
+    implementation("androidx.core:core-ktx:1.17.0")
 
     kapt("org.lynxsdk.lynx:lynx-processor:3.5.1")
     compileOnly("org.lynxsdk.lynx:lynx-processor:3.5.1")

--- a/android/app/src/main/java/com/lynxscreens/screens/ext/ViewExt.kt
+++ b/android/app/src/main/java/com/lynxscreens/screens/ext/ViewExt.kt
@@ -10,3 +10,9 @@ internal fun View.findFragmentOrNull(): Fragment? =
     } catch (_: IllegalStateException) {
         null
     }
+
+/**
+ * This will fail in case the view has been measured with (0, 0) dimensions and laid out
+ * before being attached to window.
+ */
+internal fun View.isMeasured(): Boolean = this.measuredWidth != 0 || this.measuredHeight != 0 || this.isLaidOut

--- a/android/app/src/main/java/com/lynxscreens/screens/host/FragmentOperation.kt
+++ b/android/app/src/main/java/com/lynxscreens/screens/host/FragmentOperation.kt
@@ -10,7 +10,7 @@ internal sealed class FragmentOperation {
     )
 }
 
-internal class AddOp(
+internal class AddAndSetAsPrimaryOp(
     val fragment: StackScreenFragment,
     val containerViewId: Int,
     val addToBackStack: Boolean,
@@ -20,7 +20,7 @@ internal class AddOp(
         fragmentManager: FragmentManager,
         executor: FragmentOperationExecutor,
     ) {
-        executor.executeAddOp(fragmentManager, this)
+        executor.executeAddAndSetAsPrimaryOp(fragmentManager, this)
     }
 }
 
@@ -57,14 +57,15 @@ internal class FlushNowOp : FragmentOperation() {
     }
 }
 
-internal class SetPrimaryNavFragmentOp(
-    val fragment: StackScreenFragment,
-    val onCommitCallback: Runnable? = null,
+internal class OnCommitCallbackOp(
+    val onCommitCallback: Runnable,
+    val allowStateLoss: Boolean = true,
+    val flushSync: Boolean = false,
 ) : FragmentOperation() {
     override fun execute(
         fragmentManager: FragmentManager,
         executor: FragmentOperationExecutor,
     ) {
-        executor.executeSetPrimaryNavFragmentOp(fragmentManager, this)
+        executor.executeOnCommitCallbackOp(fragmentManager, this)
     }
 }

--- a/android/app/src/main/java/com/lynxscreens/screens/host/FragmentOperationExecutor.kt
+++ b/android/app/src/main/java/com/lynxscreens/screens/host/FragmentOperationExecutor.kt
@@ -17,12 +17,16 @@ internal class FragmentOperationExecutor {
         }
     }
 
-    internal fun executeAddOp(fragmentManager: FragmentManager, op: AddOp) {
+    internal fun executeAddAndSetAsPrimaryOp(
+        fragmentManager: FragmentManager,
+        op: AddAndSetAsPrimaryOp,
+    ) {
         fragmentManager.createTransactionWithReordering().let { tx ->
-            tx.add(op.containerViewId, op.fragment)
             if (op.addToBackStack) {
                 tx.addToBackStack(op.fragment.stackScreen.screenKey)
             }
+            tx.add(op.containerViewId, op.fragment)
+            tx.setPrimaryNavigationFragment(op.fragment)
             commitTransaction(tx, op.allowStateLoss)
         }
     }
@@ -45,14 +49,17 @@ internal class FragmentOperationExecutor {
         fragmentManager.executePendingTransactions()
     }
 
-    internal fun executeSetPrimaryNavFragmentOp(fragmentManager: FragmentManager, op: SetPrimaryNavFragmentOp) {
-        fragmentManager.createTransactionWithReordering().let { tx ->
-            tx.setPrimaryNavigationFragment(op.fragment)
-            if (op.onCommitCallback != null) {
-                tx.runOnCommit(op.onCommitCallback)
-            }
-            commitTransaction(tx, allowStateLoss = true, flushSync = false)
-        }
+    internal fun executeOnCommitCallbackOp(
+        fragmentManager: FragmentManager,
+        op: OnCommitCallbackOp,
+    ) {
+        commitTransaction(
+            fragmentManager
+                .createTransactionWithReordering()
+                .runOnCommit(op.onCommitCallback),
+            allowStateLoss = op.allowStateLoss,
+            flushSync = op.flushSync,
+        )
     }
 
     private fun commitTransaction(

--- a/android/app/src/main/java/com/lynxscreens/screens/host/StackContainer.kt
+++ b/android/app/src/main/java/com/lynxscreens/screens/host/StackContainer.kt
@@ -6,6 +6,7 @@ import android.util.Log
 import androidx.coordinatorlayout.widget.CoordinatorLayout
 import androidx.fragment.app.Fragment
 import androidx.fragment.app.FragmentManager
+import com.lynxscreens.screens.ext.isMeasured
 import com.lynxscreens.screens.helpers.FragmentManagerHelper
 import com.lynxscreens.screens.helpers.ViewIdGenerator
 import com.lynxscreens.screens.screen.StackScreenComponent
@@ -24,6 +25,11 @@ internal class StackContainer(
         checkNotNull(fragmentManager) { "[RNScreens] Attempt to use nullish FragmentManager" }
 
     /**
+     * Will crash in case parent does not implement StackContainerParent interface.
+     */
+    private fun containerParentOrNull(): StackContainerParent? = this.parent as StackContainerParent?
+
+    /**
      * Describes most up-to-date view of the stack. It might be different from
      * state kept by FragmentManager as this data structure is updated immediately,
      * while operations on fragment manager are scheduled.
@@ -36,6 +42,7 @@ internal class StackContainer(
         get() = pendingPushOperations.isNotEmpty() || pendingPopOperations.isNotEmpty()
 
     private val fragmentOpExecutor: FragmentOperationExecutor = FragmentOperationExecutor()
+    private val fragmentOps: MutableList<FragmentOperation> = arrayListOf()
 
     init {
         id = ViewIdGenerator.generateViewId()
@@ -46,6 +53,15 @@ internal class StackContainer(
         super.onAttachedToWindow()
 
         setupFragmentManger()
+
+        // Following line works with a couple of assumptions.
+        // First, that this view is laid out by our parent view, which is a component view.
+        // Component views on new architecture receive their first layout after the view hierarchy is
+        // assembled and attached to window. Note, that in case of screen views & their subtrees
+        // (including nested containers) this does not hold. The container is updated later, therefore
+        // the views are attached to window much later ==> their isLaidOut returns false, breaking
+        // transitions & animations.
+        updateLaidOutFlagIfNeededAndPossible()
 
         // We run container update to handle any pending updates requested before container was
         // attached to window.
@@ -88,18 +104,38 @@ internal class StackContainer(
     }
 
     private fun performOperations(fragmentManager: FragmentManager) {
-        val fragmentOps = applyOperationsAndComputeFragmentManagerOperations()
+        applyOperationsAndComputeFragmentManagerOperations()
         fragmentOpExecutor.executeOperations(fragmentManager, fragmentOps, flushSync = false)
 
         dumpStackModel()
     }
 
-    private fun applyOperationsAndComputeFragmentManagerOperations(): List<FragmentOperation> {
-        val fragmentOps = mutableListOf<FragmentOperation>()
+    private fun applyOperationsAndComputeFragmentManagerOperations() {
+        fragmentOps.clear()
 
         // Handle pop operations first.
         // We don't care about pop/push duplicates, as long as we don't let the main loop progress
         // before we commit all the transactions, FragmentManager will handle that for us.
+
+        if (hasPendingOperations) {
+            // Top fragment is the primary navigation fragment. If we're going to change anything
+            // in stack model, then we also should update top fragment.
+            //
+            // This is added before other operations, to make sure that they are correctly classified
+            // as pop/non-pop by fragment manager.
+            // This relies on Fragment Manager internal behavior obviously. It classifies
+            // whole batch of transactions as "pop" (argument later passed to `onBackStackChange` commited)
+            // when last operation of the batch is "pop". Empty commit with only onCommit callback
+            // attached is not a "pop" commit, therefore JS-pop commits have not been properly
+            // recognized.
+            fragmentOps.add(
+                OnCommitCallbackOp(
+                    { updateTopFragment() },
+                    allowStateLoss = true,
+                    flushSync = false,
+                ),
+            )
+        }
 
         pendingPopOperations.forEach { operation ->
             val fragment =
@@ -121,7 +157,7 @@ internal class StackContainer(
         pendingPushOperations.forEach { operation ->
             val newFragment = createFragmentForScreen(operation.screen)
             fragmentOps.add(
-                AddOp(
+                AddAndSetAsPrimaryOp(
                     newFragment,
                     containerViewId = this.id,
                     addToBackStack = stackModel.isNotEmpty(),
@@ -132,33 +168,20 @@ internal class StackContainer(
 
         check(stackModel.isNotEmpty()) { "[RNScreens] Stack should never be empty after updates" }
 
-        // Top fragment is the primary navigation fragment.
-        val topStackFragment = stackModel.last()
-        fragmentOps.add(SetPrimaryNavFragmentOp(topStackFragment, {
-            updateTopFragment()
-        }))
-
         pendingPopOperations.clear()
         pendingPushOperations.clear()
-
-        return fragmentOps
     }
 
     private fun onNativeFragmentPop(fragment: StackScreenFragment) {
-        Log.d(TAG, "StackContainer [$id] natively removed fragment ${fragment.stackScreen.screenKey}")
         require(stackModel.remove(fragment)) { "[RNScreens] onNativeFragmentPop must be called with the fragment present in stack model" }
         check(stackModel.isNotEmpty()) { "[RNScreens] Stack model should not be empty after a native pop" }
 
-        val fragmentManager = requireFragmentManager()
-        check(fragmentManager.primaryNavigationFragment === fragment) { "[RNScreens] primaryNavFragment should be the one popped" }
-        // We need to update the primary navigation fragment, otherwise the fragment manager
-        // will have invalid state, pointing to the dismissed fragment.
-        fragmentOpExecutor.executeOperations(
-            fragmentManager,
-            listOf(SetPrimaryNavFragmentOp(stackModel.last(), {
-                updateTopFragment()
-            })),
-        )
+        // The primary navigation fragment should be updated when popping backstack by FragmentManager
+        // reversing the back stack record. At this point we need to just update the top fragment.
+        check(requireFragmentManager().primaryNavigationFragment !== fragment) {
+            "[RNScreens] Primary navigation fragment not updated by native pop"
+        }
+        updateTopFragment()
     }
 
     private fun dumpStackModel() {
@@ -175,10 +198,27 @@ internal class StackContainer(
 
     private fun updateTopFragment() {
         // We try to handle situation where other fragments might be present.
-        val fragments = requireFragmentManager().fragments.filterIsInstance<StackScreenFragment>()
+        val fragmentManager = requireFragmentManager()
+        val fragments = fragmentManager.fragments.filterIsInstance<StackScreenFragment>()
         check(fragments.isNotEmpty()) { "[RNScreens] Empty fragment manager while attempting to update top fragment" }
         fragments.forEach { it.onResignTopFragment() }
         fragments.last().onBecomeTopFragment()
+
+        // This assumes that the updateTopFragment is called already after primary nav frag. is updated.
+        // If this needs to be changed in the future, just remove this assertion.
+        check(fragmentManager.primaryNavigationFragment === fragments.last()) {
+            "[RNScreens] Top fragment different from primary navigation fragment"
+        }
+    }
+
+    /**
+     * If this.isLaidOut == false, then SpecialEffectsController won't perform animations / transitions.
+     * This function tries to ensure that the container is laid out if it already has layout information.
+     */
+    private fun updateLaidOutFlagIfNeededAndPossible() {
+        if (isAttachedToWindow && isMeasured() && !isLaidOut && !isInLayout) {
+            containerParentOrNull()?.layoutContainerNow()
+        }
     }
 
     // This is called after special effects (animations) are dispatched
@@ -195,8 +235,13 @@ internal class StackContainer(
             Log.w(TAG, "[RNScreens] Unexpected type of fragment: ${fragment.javaClass.simpleName}")
             return
         }
-        if (pop) {
-            delegate.get()?.onScreenDismiss(fragment.stackScreen)
+        // This callback is called for every fragment involved in the back stack change, even
+        // if its not added or removed, but e.g. set as a primary navigation fragment, hence
+        // we need to check whether the fragment is actually being removed.
+        // I avoid using `pop` parameter here, because transaction might not be classified as `pop`
+        // and still include fragment removal operations.
+        if (fragment.isRemoving) {
+            delegate.get()?.onScreenDismissCommitted(fragment.stackScreen)
             if (stackModel.contains(fragment)) {
                 onNativeFragmentPop(fragment)
             }

--- a/android/app/src/main/java/com/lynxscreens/screens/host/StackContainerDelegate.kt
+++ b/android/app/src/main/java/com/lynxscreens/screens/host/StackContainerDelegate.kt
@@ -3,5 +3,5 @@ package com.lynxscreens.screens.host
 import com.lynxscreens.screens.screen.StackScreenComponent
 
 internal interface StackContainerDelegate {
-    fun onScreenDismiss(stackScreen: StackScreenComponent)
+    fun onScreenDismissCommitted(stackScreen: StackScreenComponent)
 }

--- a/android/app/src/main/java/com/lynxscreens/screens/host/StackContainerParent.kt
+++ b/android/app/src/main/java/com/lynxscreens/screens/host/StackContainerParent.kt
@@ -1,0 +1,8 @@
+package com.lynxscreens.screens.host
+
+/**
+ * Parent view of `StackContainer` is expected to implement this interface.
+ */
+internal interface StackContainerParent {
+    fun layoutContainerNow()
+}

--- a/android/app/src/main/java/com/lynxscreens/screens/host/StackHostComponent.kt
+++ b/android/app/src/main/java/com/lynxscreens/screens/host/StackHostComponent.kt
@@ -2,6 +2,7 @@ package com.lynxscreens.screens.host
 
 import android.content.Context
 import android.util.Log
+import android.view.View
 import com.lynx.tasm.behavior.LynxContext
 import com.lynx.tasm.behavior.PatchFinishListener
 import com.lynx.tasm.behavior.ui.LynxBaseUI
@@ -128,7 +129,7 @@ internal class StackHostComponent(context: LynxContext) : UIGroup<StackHostView>
         }
     }
 
-    override fun onScreenDismiss(stackScreen: StackScreenComponent) {
+    override fun onScreenDismissCommitted(stackScreen: StackScreenComponent) {
         if (stackScreen.activityMode == StackScreenComponent.ActivityMode.ATTACHED) {
             stackScreen.isNativelyDismissed = true
         }

--- a/android/app/src/main/java/com/lynxscreens/screens/host/StackHostView.kt
+++ b/android/app/src/main/java/com/lynxscreens/screens/host/StackHostView.kt
@@ -2,6 +2,7 @@ package com.lynxscreens.screens.host
 
 import android.annotation.SuppressLint
 import android.util.Log
+import android.view.View
 import android.view.ViewGroup
 import com.lynx.tasm.behavior.LynxContext
 
@@ -9,7 +10,7 @@ import com.lynx.tasm.behavior.LynxContext
 internal class StackHostView(
     private val lynxContext: LynxContext,
     private val container: StackContainer,
-) : ViewGroup(lynxContext) {
+) : ViewGroup(lynxContext), StackContainerParent {
     init {
         addView(container)
     }
@@ -35,6 +36,16 @@ internal class StackHostView(
         b: Int,
     ) {
         container.layout(l, t, r, b)
+    }
+
+    override fun layoutContainerNow() {
+        if (measuredWidth != container.measuredWidth || measuredHeight != container.measuredHeight) {
+            container.measure(
+                View.MeasureSpec.makeMeasureSpec(measuredWidth, MeasureSpec.EXACTLY),
+                View.MeasureSpec.makeMeasureSpec(measuredHeight, MeasureSpec.EXACTLY),
+            )
+        }
+        container.layout(left, top, right, bottom)
     }
 
     companion object {

--- a/android/app/src/main/java/com/lynxscreens/screens/screen/StackScreenFragment.kt
+++ b/android/app/src/main/java/com/lynxscreens/screens/screen/StackScreenFragment.kt
@@ -1,13 +1,12 @@
 package com.lynxscreens.screens.screen
 
 import android.os.Bundle
-import android.transition.Slide
-import android.util.Log
 import android.view.Gravity
 import android.view.LayoutInflater
 import android.view.View
 import android.view.ViewGroup
 import androidx.fragment.app.Fragment
+import androidx.transition.Slide
 
 internal class StackScreenFragment(
     internal val stackScreen: StackScreenComponent,

--- a/android/app/src/main/java/com/lynxscreens/screens/screen/StackScreenFragment.kt
+++ b/android/app/src/main/java/com/lynxscreens/screens/screen/StackScreenFragment.kt
@@ -1,7 +1,9 @@
 package com.lynxscreens.screens.screen
 
 import android.os.Bundle
+import android.transition.Slide
 import android.util.Log
+import android.view.Gravity
 import android.view.LayoutInflater
 import android.view.View
 import android.view.ViewGroup
@@ -26,7 +28,16 @@ internal class StackScreenFragment(
 
     override fun onCreate(savedInstanceState: Bundle?) {
         super.onCreate(savedInstanceState)
+
         setupPreventNativeDismissCallback()
+
+        allowEnterTransitionOverlap = true
+        allowReturnTransitionOverlap = true
+
+        enterTransition = Slide(Gravity.RIGHT)
+        exitTransition = Slide(Gravity.LEFT)
+        returnTransition = Slide(Gravity.RIGHT)
+        reenterTransition = Slide(Gravity.LEFT)
     }
 
     override fun onCreateView(
@@ -50,7 +61,6 @@ internal class StackScreenFragment(
 
     override fun onDestroy() {
         super.onDestroy()
-        Log.i("StackScreenFragment", "onDestroy")
         stackScreen.onDismiss()
         teardownPreventNativeDismissCallback()
     }

--- a/android/app/src/main/java/com/lynxscreens/screens/screen/StackScreenView.kt
+++ b/android/app/src/main/java/com/lynxscreens/screens/screen/StackScreenView.kt
@@ -11,6 +11,12 @@ import com.lynxscreens.screens.ext.findFragmentOrNull
 class StackScreenView(
     private val lynxContext: LynxContext,
 ) : AndroidView(lynxContext), FragmentProviding {
+    init {
+        // Needed when Transition API is in use to ensure that shadows do not disappear,
+        // views do not jump around the screen and whole sub-tree is animated as a whole.
+        isTransitionGroup = true
+    }
+
     override fun getAssociatedFragment(): Fragment? = this.findFragmentOrNull()?.also {
         check(it is StackScreenFragment) { "[RNScreens] Unexpected fragment type: ${it.javaClass.simpleName}"}
     }

--- a/android/gradle/libs.versions.toml
+++ b/android/gradle/libs.versions.toml
@@ -1,5 +1,5 @@
 [versions]
-agp = "8.5.0"
+agp = "8.9.1"
 kotlin = "1.9.0"
 coreKtx = "1.13.1"
 junit = "4.13.2"

--- a/android/gradle/wrapper/gradle-wrapper.properties
+++ b/android/gradle/wrapper/gradle-wrapper.properties
@@ -1,6 +1,6 @@
 #Fri Feb 14 16:04:54 CST 2025
 distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-8.7-bin.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-8.12-bin.zip
 zipStoreBase=GRADLE_USER_HOME
 zipStorePath=wrapper/dists

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -10,7 +10,7 @@ export function App(props: { onRender?: () => void }) {
         height: '100%',
       }}
     >
-      <Tests.TestPreventNativeDismissSingleStack />
+      <Tests.TestAnimationAndroid />
     </page>
   );
 }

--- a/src/components/StackNavigationButtons.tsx
+++ b/src/components/StackNavigationButtons.tsx
@@ -1,0 +1,50 @@
+import { useStackNavigationContext } from '../hooks/useStackNavigationContext';
+
+interface ButtonProps {
+  onTap: () => void;
+  label: string;
+}
+
+const Button = ({ onTap, label }: ButtonProps) => (
+  <view
+    style={{
+      width: '200px',
+      height: '50px',
+      backgroundColor: 'blue',
+      justifyContent: 'center',
+      alignItems: 'center',
+      marginBottom: '10px',
+    }}
+    bindtap={onTap}
+  >
+    <text
+      native-interaction-enabled={false}
+      user-interaction-enabled={false}
+      style={{ color: 'white' }}
+    >
+      {label}
+    </text>
+  </view>
+);
+
+export function StackNavigationButtons(props: {
+  routeNames: string[];
+  isPopEnabled: boolean;
+}) {
+  const navigation = useStackNavigationContext();
+
+  return (
+    <>
+      {props.routeNames.map((routeName) => (
+        <Button
+          key={routeName}
+          label={`Push ${routeName}`}
+          onTap={() => navigation.push(routeName)}
+        />
+      ))}
+      {props.isPopEnabled && (
+        <Button label="Pop" onTap={() => navigation.pop(navigation.routeKey)} />
+      )}
+    </>
+  );
+}

--- a/src/examples/TestAnimationAndroid.tsx
+++ b/src/examples/TestAnimationAndroid.tsx
@@ -1,0 +1,185 @@
+import { StackNavigationButtons } from '../components/StackNavigationButtons';
+import { StackContainer } from '../components/StackContainer';
+
+export default function App() {
+  return <StackSetup />;
+}
+
+function StackSetup() {
+  return (
+    <StackContainer
+      routeConfigs={[
+        {
+          name: 'Home',
+          Component: HomeScreen,
+          options: {},
+        },
+        {
+          name: 'Blue',
+          Component: BlueScreen,
+          options: {},
+        },
+        {
+          name: 'Red',
+          Component: RedScreen,
+          options: {},
+        },
+        {
+          name: 'NestedHost',
+          Component: NestedHostScreen,
+          options: {},
+        },
+      ]}
+    />
+  );
+}
+
+function HomeScreen() {
+  return (
+    <view
+      style={{
+        display: 'flex',
+        flexDirection: 'column',
+        justifyContent: 'center',
+        alignItems: 'center',
+        width: '100%',
+        height: '100%',
+        backgroundColor: 'yellow',
+      }}
+    >
+      <StackNavigationButtons
+        isPopEnabled={false}
+        routeNames={['Blue', 'Red', 'NestedHost']}
+      />
+    </view>
+  );
+}
+
+function BlueScreen() {
+  return (
+    <view
+      style={{
+        display: 'flex',
+        flexDirection: 'column',
+        justifyContent: 'center',
+        alignItems: 'center',
+        width: '100%',
+        height: '100%',
+        backgroundColor: 'cyan',
+      }}
+    >
+      <StackNavigationButtons
+        isPopEnabled={true}
+        routeNames={['Red', 'Blue', 'NestedHost']}
+      />
+    </view>
+  );
+}
+
+function RedScreen() {
+  return (
+    <view
+      style={{
+        display: 'flex',
+        flexDirection: 'column',
+        justifyContent: 'center',
+        alignItems: 'center',
+        width: '100%',
+        height: '100%',
+        backgroundColor: 'red',
+      }}
+    >
+      <StackNavigationButtons
+        isPopEnabled={true}
+        routeNames={['Blue', 'Red', 'NestedHost']}
+      />
+    </view>
+  );
+}
+
+function NestedHostScreen() {
+  return (
+    <StackContainer
+      routeConfigs={[
+        {
+          name: 'NestedHome',
+          Component: NestedHomeScreen,
+          options: {},
+        },
+        {
+          name: 'NestedBlue',
+          Component: NestedBlueScreen,
+          options: {},
+        },
+        {
+          name: 'NestedRed',
+          Component: NestedRedScreen,
+          options: {},
+        },
+      ]}
+    />
+  );
+}
+
+function NestedHomeScreen() {
+  return (
+    <view
+      style={{
+        display: 'flex',
+        flexDirection: 'column',
+        justifyContent: 'center',
+        alignItems: 'center',
+        width: '100%',
+        height: '100%',
+        backgroundColor: 'yellow',
+      }}
+    >
+      <StackNavigationButtons
+        isPopEnabled={true}
+        routeNames={['NestedBlue', 'NestedRed']}
+      />
+    </view>
+  );
+}
+
+function NestedBlueScreen() {
+  return (
+    <view
+      style={{
+        display: 'flex',
+        flexDirection: 'column',
+        justifyContent: 'center',
+        alignItems: 'center',
+        width: '100%',
+        height: '100%',
+        backgroundColor: 'cyan',
+      }}
+    >
+      <StackNavigationButtons
+        isPopEnabled={true}
+        routeNames={['NestedRed', 'NestedBlue']}
+      />
+    </view>
+  );
+}
+
+function NestedRedScreen() {
+  return (
+    <view
+      style={{
+        display: 'flex',
+        flexDirection: 'column',
+        justifyContent: 'center',
+        alignItems: 'center',
+        width: '100%',
+        height: '100%',
+        backgroundColor: 'red',
+      }}
+    >
+      <StackNavigationButtons
+        isPopEnabled={true}
+        routeNames={['NestedBlue', 'NestedRed']}
+      />
+    </view>
+  );
+}

--- a/src/examples/TestPreventNativeDismissNestedStack.tsx
+++ b/src/examples/TestPreventNativeDismissNestedStack.tsx
@@ -1,6 +1,7 @@
 import React from 'react';
 import { StackContainer } from '../components/StackContainer';
 import { useStackNavigationContext } from '../hooks/useStackNavigationContext';
+import { StackNavigationButtons } from '../components/StackNavigationButtons';
 
 function StackSetup() {
   return (
@@ -53,7 +54,7 @@ function HomeScreen() {
       }}
     >
       <RouteInformation routeName="Home" />
-      <NavigationButtons
+      <StackNavigationButtons
         isPopEnabled={false}
         routeNames={['A', 'B', 'NestedStack']}
       />
@@ -76,7 +77,7 @@ function AScreen() {
     >
       <RouteInformation routeName="A" />
       <PreventNativeDismissInfo />
-      <NavigationButtons isPopEnabled routeNames={['A', 'B', 'NestedStack']} />
+      <StackNavigationButtons isPopEnabled routeNames={['A', 'B', 'NestedStack']} />
     </view>
   );
 }
@@ -96,7 +97,7 @@ function BScreen() {
     >
       <RouteInformation routeName="B" />
       <PreventNativeDismissInfo />
-      <NavigationButtons isPopEnabled routeNames={['A', 'B', 'NestedStack']} />
+      <StackNavigationButtons isPopEnabled routeNames={['A', 'B', 'NestedStack']} />
       <TogglePreventNativeDismiss />
     </view>
   );
@@ -152,7 +153,7 @@ function NestedHomeScreen() {
     >
       <RouteInformation routeName="NestedHome" />
       <PreventNativeDismissInfo />
-      <NavigationButtons isPopEnabled routeNames={['NestedA', 'NestedB']} />
+      <StackNavigationButtons isPopEnabled routeNames={['NestedA', 'NestedB']} />
       <TogglePreventNativeDismiss />
     </view>
   );
@@ -173,7 +174,7 @@ function NestedAScreen() {
     >
       <RouteInformation routeName="NestedA" />
       <PreventNativeDismissInfo />
-      <NavigationButtons isPopEnabled routeNames={['NestedA', 'NestedB']} />
+      <StackNavigationButtons isPopEnabled routeNames={['NestedA', 'NestedB']} />
     </view>
   );
 }
@@ -193,7 +194,7 @@ function NestedBScreen() {
     >
       <RouteInformation routeName="NestedB" />
       <PreventNativeDismissInfo />
-      <NavigationButtons isPopEnabled routeNames={['NestedA', 'NestedB']} />
+      <StackNavigationButtons isPopEnabled routeNames={['NestedA', 'NestedB']} />
       <TogglePreventNativeDismiss />
     </view>
   );
@@ -211,31 +212,6 @@ function RouteInformation(props: { routeName: string }) {
         Key: {routeKey}
       </text>
     </view>
-  );
-}
-
-function NavigationButtons(props: {
-  routeNames: string[];
-  isPopEnabled: boolean;
-}) {
-  const navigation = useStackNavigationContext();
-
-  return (
-    <>
-      {props.routeNames.map((routeName) => (
-        <Button
-          key={routeName}
-          label={`Push ${routeName}`}
-          onTap={() => navigation.push(routeName)}
-        />
-      ))}
-      {props.isPopEnabled && (
-        <Button
-          label="Pop"
-          onTap={() => navigation.pop(navigation.routeKey)}
-        />
-      )}
-    </>
   );
 }
 

--- a/src/examples/TestPreventNativeDismissSingleStack.tsx
+++ b/src/examples/TestPreventNativeDismissSingleStack.tsx
@@ -1,6 +1,7 @@
 import React from 'react';
 import { StackContainer } from '../components/StackContainer';
 import { useStackNavigationContext } from '../hooks/useStackNavigationContext';
+import { StackNavigationButtons } from '../components/StackNavigationButtons';
 
 interface ButtonProps {
   onTap: () => void;
@@ -72,7 +73,7 @@ function HomeScreen() {
       }}
     >
       <RouteInformation routeName="Home" />
-      <NavigationButtons isPopEnabled={false} />
+      <StackNavigationButtons isPopEnabled={false} routeNames={['A', 'B']} />
     </view>
   );
 }
@@ -92,7 +93,7 @@ function AScreen() {
     >
       <RouteInformation routeName="A" />
       <PreventNativeDismissInfo />
-      <NavigationButtons isPopEnabled={true} />
+      <StackNavigationButtons isPopEnabled={true} routeNames={['A', 'B']} />
     </view>
   );
 }
@@ -112,7 +113,7 @@ function BScreen() {
     >
       <RouteInformation routeName="B" />
       <PreventNativeDismissInfo />
-      <NavigationButtons isPopEnabled={true} />
+      <StackNavigationButtons isPopEnabled={true} routeNames={['A', 'B']} />
       <TogglePreventNativeDismiss />
     </view>
   );
@@ -130,20 +131,6 @@ function RouteInformation(props: { routeName: string }) {
         Key: {routeKey}
       </text>
     </view>
-  );
-}
-
-function NavigationButtons(props: { isPopEnabled: boolean }) {
-  const navigation = useStackNavigationContext();
-
-  return (
-    <>
-      <Button label="Push A" onTap={() => navigation.push('A')} />
-      <Button label="Push B" onTap={() => navigation.push('B')} />
-      {props.isPopEnabled && (
-        <Button label="Pop" onTap={() => navigation.pop(navigation.routeKey)} />
-      )}
-    </>
   );
 }
 

--- a/src/examples/index.ts
+++ b/src/examples/index.ts
@@ -1,3 +1,4 @@
+export { default as TestAnimationAndroid } from './TestAnimationAndroid';
 export { default as TestBatch } from './TestBatch';
 export { default as TestBase } from './TestBase';
 export { default as TestNested } from './TestNested';


### PR DESCRIPTION
Related commit from RNScreens: https://github.com/software-mansion/react-native-screens/commit/0893e0dbf94c22de9b1f8c3b9b446315a5bdbf42

### Description

The `predictiveBackGesture` wasn't supported in Lynx template by default - I'm making a setup in this PR: https://github.com/software-mansion/lynx-screens/pull/47 

It requires some polishing, and updating app setup, so we start diverging from the community template - that's bad, because until we have a solution that allows linking the library, the additional setup must be done in the example app as the installation step.

Changes that were required to sync dependencies versions with RNScreens:
- I updated compileSdk to 36
- I aligned androidx dependencies
- gradle-wrapper was updated to 8.12 for compatibility
- agp was updated to 8.9 for compatibility

The content should be similar to RNScreens - the only important change is that `StackHostView` will implement `StackContainerParent` interface, whereas the rest of the logic regarding Component lifecycle (intermediatelly View lifecycle) is on the `StackHostComponent` level.

Closes: https://github.com/software-mansion/lynx-screens/issues/45

---

### Testing

Added a new example

https://github.com/user-attachments/assets/0076197e-aaef-4c01-9f9f-85438902846f

