### PR TITLE
fix(iOS): Prevent mounting Screen as a direct child of Host

### DIFF
--- a/apple/LynxScreens/screens/host/RNSStackHostView.mm
+++ b/apple/LynxScreens/screens/host/RNSStackHostView.mm
@@ -1,5 +1,6 @@
 #import "RNSStackHostView.h"
 #import "RNSStackHostComponent.h"
+#import "RNSStackScreenView.h"
 
 @implementation RNSStackHostView
 
@@ -9,6 +10,21 @@
     if (self.window) {
         [self.component viewDidMoveToWindow];
     }
+}
+
+- (void)insertSubview:(UIView *)view atIndex:(NSInteger)index
+{
+    /**
+     * `LynxUI.insertChild` method automatically calls `insertSubview`, taking the management over the native hierarchy.
+     * However, we need to intercept and ignore this call when dealing with a `StackHost` - `StackScreen` communication.
+     * While attaching a `StackScreen` as a Lynx child of a `StackHost` is reasonable for Lynx component hierarchy (similarly to `reactSubviews`),
+     * the native hierarchy requires screen management to be realized by `RNStackController` (at the view controller level),
+     * rather than relying on direct insertions.
+     */
+    if ([view isKindOfClass:RNSStackScreenView.class]) {
+        return;
+    }
+    [super insertSubview:view atIndex:index];
 }
 
 @end


### PR DESCRIPTION
### Description

`insertChild` on the Component level automatically calls `insertSubview` on the View level - that means that Screen is temporarily inserted as a child of Host, until `RNSStackController` takes care of it. This breaks the hierarchy when we're pushing many updates in a single batch.

We need to intercept and ignore `insertSubview` on the `StackHostView` level, if the child is a type of `StackScreenView`. This should be considered rather as a workaround, adapting to the method in which Lynx tries to manage the native hierarchy on their side.

Proposed solution: While attaching a `StackScreenComponent` as a Lynx child of a `StackHostComponent` is reasonable for Lynx component hierarchy (similarly to `reactSubviews`), the native hierarchy management should be realized by `RNStackController` (at the view controller level). Therefore, we're ignoring inserting `StackScreenView` as a direct subview of `StackHostView`.

### Testing

Go through the following examples: `TestBase`, `TestNested`, `TestBatch`.

https://github.com/user-attachments/assets/a80188de-00c9-442c-aaea-fbd06a86e772