### PR TITLE
fix(Android, Stack): stabilize nested stack teardown and transitions

### DIFF
--- a/android/src/main/java/com/lynxscreens/screens/helpers/FragmentManagerHelper.kt
+++ b/android/src/main/java/com/lynxscreens/screens/helpers/FragmentManagerHelper.kt
@@ -24,9 +24,11 @@ object FragmentManagerHelper {
         // If parent adheres to FragmentProviding interface it means we are inside a nested fragment structure.
         // Otherwise we expect to connect directly with root view and get root fragment manager
         if (parent is FragmentProviding) {
-            return checkNotNull(parent.getAssociatedFragment()) {
-                "[RNScreens] Parent fragment providing view $parent returned nullish fragment"
-            }.childFragmentManager
+            val fragment = parent.getAssociatedFragment() ?: return null
+
+            // A disappearing Fragment view can be temporarily reattached through ViewOverlay after
+            // its Fragment has detached. There is no usable child FragmentManager in that state.
+            return fragment.takeIf { it.isAdded }?.childFragmentManager
         } else {
             // we expect top level view to be of type LynxView, this isn't really necessary but in
             // order to find root view we test if parent is null. This could potentially happen also when

--- a/android/src/main/java/com/lynxscreens/screens/host/StackContainer.kt
+++ b/android/src/main/java/com/lynxscreens/screens/host/StackContainer.kt
@@ -20,6 +20,7 @@ internal class StackContainer(
 ) : FrameLayout(context),
     FragmentManager.OnBackStackChangedListener {
     private var fragmentManager: FragmentManager? = null
+    private var hasResolvedFragmentManager = false
 
     private fun requireFragmentManager(): FragmentManager =
         checkNotNull(fragmentManager) { "[RNScreens] Attempt to use nullish FragmentManager" }
@@ -52,7 +53,10 @@ internal class StackContainer(
         Log.d(TAG, "StackContainer [$id] attached to window")
         super.onAttachedToWindow()
 
-        setupFragmentManger()
+        if (!setupFragmentManager()) {
+            Log.d(TAG, "StackContainer [$id] skipped setup for a detached host fragment")
+            return
+        }
 
         // Following line works with a couple of assumptions.
         // First, that this view is laid out by our parent view, which is a component view.
@@ -70,17 +74,24 @@ internal class StackContainer(
 
     override fun onDetachedFromWindow() {
         super.onDetachedFromWindow()
-        requireFragmentManager().removeOnBackStackChangedListener(this)
+        fragmentManager?.removeOnBackStackChangedListener(this)
         fragmentManager = null
     }
 
-    internal fun setupFragmentManger() {
-        fragmentManager =
-            checkNotNull(FragmentManagerHelper.findFragmentManagerForView(this)) {
-                "[RNScreens] Nullish fragment manager - can't run container operations"
-            }.also {
-                it.addOnBackStackChangedListener(this)
+    private fun setupFragmentManager(): Boolean {
+        val resolvedFragmentManager = FragmentManagerHelper.findFragmentManagerForView(this)
+        if (resolvedFragmentManager == null) {
+            check(hasResolvedFragmentManager) {
+                "[RNScreens] Nullish fragment manager during initial StackContainer attachment"
             }
+            return false
+        }
+
+        hasResolvedFragmentManager = true
+        fragmentManager = resolvedFragmentManager.also {
+            it.addOnBackStackChangedListener(this)
+        }
+        return true
     }
 
     /**
@@ -91,7 +102,8 @@ internal class StackContainer(
         // the call because we don't have valid fragmentManager yet.
         // Update will be eventually executed in onAttachedToWindow().
         if (hasPendingOperations && isAttachedToWindow) {
-            performOperations(requireFragmentManager())
+            val currentFragmentManager = fragmentManager ?: return
+            performOperations(currentFragmentManager)
         }
     }
 

--- a/android/src/main/java/com/lynxscreens/screens/screen/StackScreenFragment.kt
+++ b/android/src/main/java/com/lynxscreens/screens/screen/StackScreenFragment.kt
@@ -67,7 +67,12 @@ internal class StackScreenFragment(
 
     override fun onDestroy() {
         super.onDestroy()
-        stackScreen.onDismiss()
+
+        // Destroying an outer StackScreen also destroys all Fragments in its child manager. Those
+        // nested screens were not independently popped and must not emit another native dismissal.
+        if (parentFragment?.isRemoving != true) {
+            stackScreen.onDismiss()
+        }
         teardownPreventNativeDismissCallback()
     }
 


### PR DESCRIPTION
## Summary

- tolerate temporary `ViewOverlay` reattachment after a parent fragment has detached
- skip fragment-manager setup for teardown-only reattachments after the initial successful attachment
- avoid duplicate dismissal events when an outer screen destroys its nested fragment hierarchy

## Validation

- `LynxExample/android/gradlew :app:assembleDebug -Pkotlin.compiler.execution.strategy=in-process` with JDK 17