### PR TITLE
feat: extend lower-platform support

### DIFF
--- a/android/build.gradle.kts
+++ b/android/build.gradle.kts
@@ -9,7 +9,7 @@ android {
     compileSdk = 36
 
     defaultConfig {
-        minSdk = 24
+        minSdk = 21
     }
 
     compileOptions {
@@ -29,7 +29,7 @@ dependencies {
     implementation("androidx.coordinatorlayout:coordinatorlayout:1.2.0")
     // Image engine of Lynx's standard image-service setup; used by helpers/ImageLoader.
     implementation("com.facebook.fresco:fresco:2.3.0")
-    implementation("androidx.fragment:fragment-ktx:1.8.9")
+    implementation("androidx.fragment:fragment-ktx:1.1.0")
     implementation("androidx.appcompat:appcompat:1.7.1")
     implementation("androidx.transition:transition-ktx:1.7.0")
     implementation("com.google.android.material:material:1.13.0")

--- a/android/src/main/java/com/lynxscreens/screens/ext/ViewExt.kt
+++ b/android/src/main/java/com/lynxscreens/screens/ext/ViewExt.kt
@@ -1,16 +1,54 @@
 package com.lynxscreens.screens.ext
 
+import android.content.ContextWrapper
 import android.view.View
 import android.view.ViewGroup
 import androidx.fragment.app.Fragment
-import androidx.fragment.app.findFragment
+import androidx.fragment.app.FragmentActivity
+import androidx.fragment.app.FragmentManager
 
-internal fun View.findFragmentOrNull(): Fragment? =
-    try {
-        this.findFragment()
-    } catch (_: IllegalStateException) {
-        null
+/**
+ * Fragment KTX 1.1.0 does not provide View.findFragment(). Resolve the closest owning Fragment by
+ * walking the Fragment hierarchy and matching Fragment root views against the target view tree.
+ */
+internal fun View.findFragmentOrNull(): Fragment? {
+    var currentContext = context
+    while (currentContext !is FragmentActivity && currentContext is ContextWrapper) {
+        currentContext = currentContext.baseContext
     }
+
+    return (currentContext as? FragmentActivity)
+        ?.supportFragmentManager
+        ?.findClosestFragmentForView(this)
+}
+
+private fun FragmentManager.findClosestFragmentForView(target: View): Fragment? {
+    fragments.asReversed().forEach { fragment ->
+        val fragmentView = fragment.view ?: return@forEach
+        if (!target.isSelfOrDescendantOf(fragmentView)) {
+            return@forEach
+        }
+
+        val childFragment =
+            fragment
+                .takeIf { it.isAdded }
+                ?.childFragmentManager
+                ?.findClosestFragmentForView(target)
+        return childFragment ?: fragment
+    }
+    return null
+}
+
+private fun View.isSelfOrDescendantOf(ancestor: View): Boolean {
+    var current: View? = this
+    while (current != null) {
+        if (current === ancestor) {
+            return true
+        }
+        current = current.parent as? View
+    }
+    return false
+}
 
 /**
  * This will fail in case the view has been measured with (0, 0) dimensions and laid out

--- a/android/src/main/java/com/lynxscreens/screens/helpers/FragmentManagerHelper.kt
+++ b/android/src/main/java/com/lynxscreens/screens/helpers/FragmentManagerHelper.kt
@@ -3,12 +3,12 @@ package com.lynxscreens.screens.helpers
 import android.content.ContextWrapper
 import android.view.ViewGroup
 import android.view.ViewParent
-import androidx.fragment.app.Fragment
 import androidx.fragment.app.FragmentActivity
 import androidx.fragment.app.FragmentManager
 import androidx.fragment.app.FragmentTransaction
 import com.lynx.tasm.LynxView
 import com.lynxscreens.screens.common.FragmentProviding
+import com.lynxscreens.screens.ext.findFragmentOrNull
 
 object FragmentManagerHelper {
     fun findFragmentManagerForView(view: ViewGroup): FragmentManager? {
@@ -63,15 +63,12 @@ object FragmentManagerHelper {
             context.supportFragmentManager
         } else {
             // We are in some custom setup & we want to use the closest fragment manager in hierarchy.
-            // `findFragment` method throws IllegalStateException when it fails to resolve appropriate
-            // fragment. It might happen when e.g. Lynx is loaded directly in Activity
-            // but some custom fragments are still used. Such use case seems highly unlikely
-            // so, as for now we fallback to activity's FragmentManager in hope for the best.
-            try {
-                FragmentManager.findFragment<Fragment>(rootView).childFragmentManager
-            } catch (ex: IllegalStateException) {
-                context.supportFragmentManager
-            }
+            // Fragment KTX 1.1.0 does not provide `findFragment`, so the compatibility resolver
+            // returns null when it cannot resolve an appropriate fragment. It might happen when e.g.
+            // Lynx is loaded directly in Activity but some custom fragments are still used. Such use
+            // case seems highly unlikely so, as for now we fallback to activity's FragmentManager in
+            // hope for the best.
+            rootView.findFragmentOrNull()?.childFragmentManager ?: context.supportFragmentManager
         }
     }
 }

--- a/android/src/main/java/com/lynxscreens/screens/host/StackContainer.kt
+++ b/android/src/main/java/com/lynxscreens/screens/host/StackContainer.kt
@@ -4,7 +4,6 @@ import android.annotation.SuppressLint
 import android.content.Context
 import android.util.Log
 import android.widget.FrameLayout
-import androidx.fragment.app.Fragment
 import androidx.fragment.app.FragmentManager
 import com.lynxscreens.screens.ext.isMeasured
 import com.lynxscreens.screens.helpers.FragmentManagerHelper
@@ -224,30 +223,22 @@ internal class StackContainer(
         }
     }
 
-    // This is called after special effects (animations) are dispatched
-    override fun onBackStackChanged() = Unit
+    /**
+     * Fragment 1.3 only exposes this coarse back-stack callback. JS-driven pops update stackModel
+     * before the transaction, while a native pop leaves the removed top Fragment in stackModel.
+     */
+    override fun onBackStackChanged() {
+        val currentFragmentManager = fragmentManager ?: return
+        val addedFragments = currentFragmentManager.fragments
 
-    // This is called before the special effects (animations) are dispatched, however mid transaction!
-    // Therefore make sure to not execute any action that might cause synchronous transaction synchronously
-    // from this callback.
-    override fun onBackStackChangeCommitted(
-        fragment: Fragment,
-        pop: Boolean,
-    ) {
-        if (fragment !is StackScreenFragment) {
-            Log.w(TAG, "[RNScreens] Unexpected type of fragment: ${fragment.javaClass.simpleName}")
-            return
-        }
-        // This callback is called for every fragment involved in the back stack change, even
-        // if its not added or removed, but e.g. set as a primary navigation fragment, hence
-        // we need to check whether the fragment is actually being removed.
-        // I avoid using `pop` parameter here, because transaction might not be classified as `pop`
-        // and still include fragment removal operations.
-        if (fragment.isRemoving) {
-            delegate.get()?.onScreenDismissCommitted(fragment.stackScreen)
-            if (stackModel.contains(fragment)) {
-                onNativeFragmentPop(fragment)
+        while (stackModel.size > 1) {
+            val topFragment = stackModel.last()
+            if (addedFragments.contains(topFragment)) {
+                return
             }
+
+            delegate.get()?.onScreenDismissCommitted(topFragment.stackScreen)
+            onNativeFragmentPop(topFragment)
         }
     }
 

--- a/ios/host/RNSStackHostComponent.mm
+++ b/ios/host/RNSStackHostComponent.mm
@@ -15,6 +15,9 @@
     BOOL _isMountingTransactionPending;
 }
 
+// Self-register for hosts that do not invoke the generated library registry.
+LYNX_LAZY_REGISTER_UI("stack-host-native")
+
 #pragma mark - Init
 
 - (instancetype)init

--- a/ios/screen/RNSStackScreenComponent.mm
+++ b/ios/screen/RNSStackScreenComponent.mm
@@ -16,6 +16,9 @@
     BOOL _hasUpdatedActivityMode;
 }
 
+// Self-register for hosts that do not invoke the generated library registry.
+LYNX_LAZY_REGISTER_UI("stack-screen-native")
+
 - (instancetype)init
 {
     self = [super init];


### PR DESCRIPTION
## Summary

- lower the Android minimum SDK from 24 to 21
- replace Fragment 1.8-only lookup and back-stack APIs with Fragment 1.3-compatible implementations
- keep the current AppCompat and Material versions required by the latest header implementation
- self-register the iOS stack components for hosts that do not invoke the generated library registry

## Validation

- `npm --prefix LynxExample run build`
- `LynxExample/android/gradlew :app:assembleDebug -Pkotlin.compiler.execution.strategy=in-process` with JDK 17
- CocoaPods install and `xcodebuild` for the `LynxScreens` scheme on a generic iOS Simulator

`npm run lint` still reports the existing example/generated-file lint failures on `main`; this change does not add TypeScript or JavaScript lint findings.