### PR TITLE
feat(Android, iOS): add FormSheet support

### DIFF
--- a/LynxExample/ios/Podfile.lock
+++ b/LynxExample/ios/Podfile.lock
@@ -231,7 +231,7 @@ SPEC CHECKSUMS:
   LynxBase: 5ca5092517e6460e0df6ad9b49fca76396c058d8
   LynxDevtool: 953bfc73918a0eec65f6a5bf60a3e6f52a4134c4
   LynxLibraryRegistry: b2017f1b3dd04bcac00caacc69d28fddcd6c9043
-  LynxScreens: a1584c950f5f8378fededaa6d55270773d0d260a
+  LynxScreens: 640305359fb83e24fef69b2c3a711479a6a7b515
   LynxService: f447c67687d3ea66eec94e10b7564996e67c06dc
   LynxServiceAPI: 67ae06f77e45c80f0ecaa6705d126ac3b4b8dff4
   LynxTextra: e1a22775e880e000605091aad8dec614ca2ca79a

--- a/LynxExample/src/components/StackContainer.tsx
+++ b/LynxExample/src/components/StackContainer.tsx
@@ -4,7 +4,6 @@ import type {
   StackContainerProps,
   StackNavigationState,
   StackRouteConfig,
-  StackState,
 } from '../types/StackContainer';
 import {
   determineInitialNavigationState,
@@ -16,6 +15,7 @@ import {
   type StackNavigationContextPayload,
 } from '../contexts/StackNavigationContext';
 import {
+  FormSheet,
   StackHeaderConfigNativeComponent,
   StackHostNativeComponent,
   StackScreenNativeComponent,
@@ -59,49 +59,123 @@ export function StackContainer({ routeConfigs }: StackContainerProps) {
     [navMethods],
   );
 
-  return (
-    <StackHostNativeComponent>
-      {stackNavState.stack.map(
-        ({ options: { headerConfig, headerConfigRef, ...options }, activityMode, routeKey, name }) => {
-          const stackNavigationContext: StackNavigationContextPayload = {
-            routeKey,
-            routeOptions: { ...options },
-            push: navMethods.pushAction,
-            pop: navMethods.popAction,
-            preload: navMethods.preloadAction,
-            batch: navMethods.batchAction,
-            setRouteOptions: navMethods.setRouteOptions,
-          };
+  const routes = stackNavState.stack.map((route) => {
+    const Component = componentsByName.get(route.name);
+    if (!Component) {
+      throw new Error(
+        `[Stack] No config matches the "${route.name}" route name`,
+      );
+    }
 
-          const Component = componentsByName.get(name);
-          if (!Component) {
-            throw new Error(
-              `[Stack] No config matches the "${name}" route name`,
+    return {
+      ...route,
+      Component,
+      navigationContext: {
+        routeKey: route.routeKey,
+        routeOptions: { ...route.options },
+        push: navMethods.pushAction,
+        pop: navMethods.popAction,
+        preload: navMethods.preloadAction,
+        batch: navMethods.batchAction,
+        setRouteOptions: navMethods.setRouteOptions,
+      } satisfies StackNavigationContextPayload,
+    };
+  });
+
+  return (
+    <>
+      <StackHostNativeComponent>
+        {routes.map(
+          ({
+            Component,
+            options: routeOptions,
+            activityMode,
+            routeKey,
+            navigationContext,
+          }) => {
+            if (routeOptions.presentation === 'formSheet') {
+              return null;
+            }
+
+            const { headerConfig, headerConfigRef, ...options } = routeOptions;
+
+            return (
+              <StackScreenNativeComponent
+                key={routeKey}
+                {...options}
+                activityMode={activityMode}
+                screenKey={routeKey}
+                onDismiss={onDismiss}
+                onNativeDismiss={onNativeDismiss}
+              >
+                <StackNavigationContext.Provider value={navigationContext}>
+                  <Component />
+                  {headerConfig !== undefined && (
+                    <StackHeaderConfigNativeComponent
+                      ref={headerConfigRef}
+                      {...headerConfig}
+                    />
+                  )}
+                </StackNavigationContext.Provider>
+              </StackScreenNativeComponent>
             );
+          },
+        )}
+      </StackHostNativeComponent>
+
+      {routes.map(
+        ({ Component, options, activityMode, routeKey, navigationContext }) => {
+          if (options.presentation !== 'formSheet') {
+            return null;
           }
 
-        return (
-          <StackScreenNativeComponent
-            key={routeKey}
-            {...options}
-            activityMode={activityMode}
-            screenKey={routeKey}
-            onDismiss={onDismiss}
-            onNativeDismiss={onNativeDismiss}
-          >
-            <StackNavigationContext.Provider value={stackNavigationContext}>
-              <Component />
-              {headerConfig !== undefined && (
-                <StackHeaderConfigNativeComponent
-                  ref={headerConfigRef}
-                  {...headerConfig}
-                />
-              )}
-            </StackNavigationContext.Provider>
-          </StackScreenNativeComponent>
-        );
-      })}
-    </StackHostNativeComponent>
+          const handleDidDisappear: NonNullable<
+            typeof options.onDidDisappear
+          > = (event) => {
+            'background only';
+            if (activityMode === 'detached') {
+              navMethods.popCompletedAction(routeKey);
+            }
+            options.onDidDisappear?.(event);
+          };
+
+          const handleNativeDismiss: NonNullable<
+            typeof options.onNativeDismiss
+          > = (event) => {
+            'background only';
+            navMethods.popNativeAction(routeKey);
+            options.onNativeDismiss?.(event);
+          };
+
+          const handleDetentChanged: NonNullable<
+            typeof options.onDetentChanged
+          > = (event) => {
+            'background only';
+            if (options.selectedDetentIndex !== undefined) {
+              navMethods.setRouteOptions(routeKey, {
+                selectedDetentIndex: event.detail.index,
+              });
+            }
+            options.onDetentChanged?.(event);
+          };
+
+          return (
+            <FormSheet
+              key={routeKey}
+              {...options}
+              isOpen={activityMode === 'attached'}
+              onDidDisappear={handleDidDisappear}
+              onNativeDismiss={handleNativeDismiss}
+              onDetentChanged={handleDetentChanged}
+            >
+              <StackNavigationContext.Provider value={navigationContext}>
+                <Component />
+              </StackNavigationContext.Provider>
+            </FormSheet>
+          );
+        },
+      )}
+    </>
   );
 }
 
@@ -110,6 +184,10 @@ function useSanitizeRouteConfigs(
 ) {
   if (!routeConfigs || routeConfigs.length === 0) {
     throw new Error('[Stack] There must be at least one route configured');
+  }
+
+  if (routeConfigs[0].options.presentation === 'formSheet') {
+    throw new Error('[Stack] The initial route can not be a FormSheet');
   }
 
   // Do not recompute in case the routeConfigs have not changed

--- a/LynxExample/src/components/StackContainerWithDynamicRouteConfigs.tsx
+++ b/LynxExample/src/components/StackContainerWithDynamicRouteConfigs.tsx
@@ -26,7 +26,10 @@ export function StackContainerWithDynamicRouteConfigs(
 
         return prevConfigs.toSpliced(routeConfigIndex, 1, {
           ...prevConfigs[routeConfigIndex],
-          options,
+          options: {
+            ...prevConfigs[routeConfigIndex].options,
+            ...options,
+          } as StackRouteOptions,
         });
       });
     },

--- a/LynxExample/src/examples/TestAnimationAndroid.tsx
+++ b/LynxExample/src/examples/TestAnimationAndroid.tsx
@@ -1,5 +1,9 @@
 import { StackNavigationButtons } from '../components/StackNavigationButtons';
 import { StackContainer } from '../components/StackContainer';
+import { useStackNavigationContext } from '../hooks/useStackNavigationContext';
+
+const FORM_SHEET_DETENTS = [0.3, 0.6, 1.0];
+const SCROLL_TEST_ITEMS = Array.from({ length: 20 }, (_, index) => index + 1);
 
 export default function App() {
   return <StackSetup />;
@@ -29,6 +33,20 @@ function StackSetup() {
           Component: NestedHostScreen,
           options: {},
         },
+        {
+          name: 'FormSheet',
+          Component: FormSheetScreen,
+          options: {
+            presentation: 'formSheet',
+            detents: FORM_SHEET_DETENTS,
+            selectedDetentIndex: 1,
+            largestUndimmedDetentIndex: 0,
+            prefersGrabberVisible: false,
+            preferredCornerRadius: 10,
+            preventNativeDismiss: ['back', 'drag', 'backdrop'],
+            preventNativeDismissDragFeedback: true,
+          },
+        },
       ]}
     />
   );
@@ -49,8 +67,208 @@ function HomeScreen() {
     >
       <StackNavigationButtons
         isPopEnabled={false}
-        routeNames={['Blue', 'Red', 'NestedHost']}
+        routeNames={['Blue', 'Red', 'NestedHost', 'FormSheet']}
       />
+    </view>
+  );
+}
+
+function FormSheetScreen() {
+  const navigation = useStackNavigationContext();
+  if (navigation.routeOptions.presentation !== 'formSheet') {
+    throw new Error('[FormSheet] Expected a FormSheet route');
+  }
+
+  const selectedDetentIndex =
+    navigation.routeOptions.selectedDetentIndex === 'last'
+      ? FORM_SHEET_DETENTS.length - 1
+      : (navigation.routeOptions.selectedDetentIndex ?? 0);
+
+  return (
+    <view
+      style={{
+        position: 'absolute',
+        top: 0,
+        right: 0,
+        bottom: 0,
+        left: 0,
+        padding: '20px',
+        backgroundColor: '#e8e7e1',
+        borderWidth: '2px',
+        borderColor: '#171717',
+        borderRadius: '10px',
+        display: 'flex',
+        flexDirection: 'column',
+        height: SystemInfo.pixelHeight + 'ppx',
+        width: '100%',
+      }}
+    >
+      <view
+        style={{
+          display: 'flex',
+          flexDirection: 'row',
+          justifyContent: 'space-between',
+          paddingBottom: '12px',
+          marginBottom: '18px',
+          borderBottomWidth: '1px',
+          borderColor: '#171717',
+        }}
+      >
+        <text style={{ color: '#171717', fontSize: '12px' }}>
+          FORM SHEET / 01
+        </text>
+        <text style={{ color: '#171717', fontSize: '12px' }}>
+          LEVEL {selectedDetentIndex + 1} / 3
+        </text>
+      </view>
+
+      <text
+        style={{
+          color: '#171717',
+          fontSize: '24px',
+          fontWeight: '700',
+          marginBottom: '18px',
+        }}
+      >
+        SELECT HEIGHT
+      </text>
+
+      <view
+        style={{
+          width: '100%',
+          display: 'flex',
+          flexDirection: 'row',
+          justifyContent: 'space-between',
+          marginBottom: '12px',
+        }}
+      >
+        {FORM_SHEET_DETENTS.map((detent, index) => (
+          <view
+            key={detent}
+            style={{
+              width: '31%',
+              height: '42px',
+              justifyContent: 'center',
+              alignItems: 'center',
+              borderWidth: '1px',
+              borderColor: '#171717',
+              backgroundColor:
+                selectedDetentIndex === index ? '#171717' : '#e8e7e1',
+            }}
+            bindtap={() =>
+              navigation.setRouteOptions(navigation.routeKey, {
+                selectedDetentIndex: index,
+              })
+            }
+          >
+            <text
+              native-interaction-enabled={false}
+              user-interaction-enabled={false}
+              style={{
+                color: selectedDetentIndex === index ? '#f5f5f0' : '#171717',
+                fontSize: '13px',
+                fontWeight: '600',
+              }}
+            >
+              {Math.round(detent * 100)}%
+            </text>
+          </view>
+        ))}
+      </view>
+
+      <view
+        style={{
+          width: '100%',
+          flex: 1,
+          display: 'flex',
+          flexDirection: 'row',
+          justifyContent: 'space-between',
+          marginBottom: '12px',
+        }}
+      >
+        <scroll-view
+          scroll-orientation="vertical"
+          enable-scroll={true}
+          style={{
+            width: '48%',
+            height: '100%',
+            borderWidth: '1px',
+            borderColor: '#171717',
+          }}
+        >
+          {SCROLL_TEST_ITEMS.map((item) => (
+            <view
+              key={item}
+              style={{
+                height: '44px',
+                justifyContent: 'center',
+                paddingLeft: '12px',
+                borderBottomWidth: '1px',
+                borderColor: '#aaa9a4',
+              }}
+            >
+              <text style={{ color: '#171717', fontSize: '12px' }}>
+                SCROLL VIEW / {item}
+              </text>
+            </view>
+          ))}
+        </scroll-view>
+
+        <list
+          list-type="single"
+          scroll-orientation="vertical"
+          enable-scroll={true}
+          enable-nested-scroll={true}
+          style={{
+            width: '48%',
+            height: '100%',
+            borderWidth: '1px',
+            borderColor: '#171717',
+          }}
+        >
+          {SCROLL_TEST_ITEMS.map((item) => (
+            <list-item
+              key={item}
+              item-key={String(item)}
+              style={{ height: '44px' }}
+            >
+              <view
+                style={{
+                  height: '44px',
+                  justifyContent: 'center',
+                  paddingLeft: '12px',
+                  borderBottomWidth: '1px',
+                  borderColor: '#aaa9a4',
+                }}
+              >
+                <text style={{ color: '#171717', fontSize: '12px' }}>
+                  LIST / {item}
+                </text>
+              </view>
+            </list-item>
+          ))}
+        </list>
+      </view>
+
+      <view
+        style={{
+          width: '100%',
+          height: '42px',
+          justifyContent: 'center',
+          alignItems: 'center',
+          borderWidth: '1px',
+          borderColor: '#171717',
+        }}
+        bindtap={() => navigation.pop(navigation.routeKey)}
+      >
+        <text
+          native-interaction-enabled={false}
+          user-interaction-enabled={false}
+          style={{ color: '#171717', fontSize: '13px', fontWeight: '600' }}
+        >
+          CLOSE
+        </text>
+      </view>
     </view>
   );
 }

--- a/LynxExample/src/types/StackContainer.ts
+++ b/LynxExample/src/types/StackContainer.ts
@@ -1,5 +1,6 @@
 import React from 'react';
 import type {
+  FormSheetProps,
   StackHeaderConfigProps,
   StackHeaderConfigRef,
   StackScreenProps,
@@ -14,13 +15,20 @@ export type {
 
 /// Route definition
 
-export type StackRouteOptions = Omit<
+type StackScreenRouteOptions = Omit<
   StackScreenProps,
   'children' | 'activityMode' | 'screenKey'
 > & {
+  presentation?: 'stack' | undefined;
   headerConfig?: StackHeaderConfigProps | undefined;
   headerConfigRef?: React.Ref<StackHeaderConfigRef> | undefined;
 };
+
+type FormSheetRouteOptions = Omit<FormSheetProps, 'children' | 'isOpen'> & {
+  presentation: 'formSheet';
+};
+
+export type StackRouteOptions = StackScreenRouteOptions | FormSheetRouteOptions;
 
 /**
  * Blueprint for a route.

--- a/LynxExample/src/utils/reducer.ts
+++ b/LynxExample/src/utils/reducer.ts
@@ -13,6 +13,7 @@ import type {
   StackScreenActivityMode,
   StackRoute,
   StackRouteConfig,
+  StackRouteOptions,
   StackState,
 } from '../types/StackContainer';
 import { generateID } from './id-generator';
@@ -321,7 +322,7 @@ function navigationActionSetOptionsHandler(
   routeCopy.options = {
     ...routeCopy.options,
     ...action.options,
-  };
+  } as StackRouteOptions;
 
   return stateWithStack(
     state,

--- a/README.md
+++ b/README.md
@@ -53,6 +53,7 @@ Already ported to Lynx and working:
 | `preventNativeDismiss` (+ `onNativeDismissPrevented`) | ✅ | ❌ |
 | Predictive back gesture support (internal) | ✅ | N/A |
 | Transition API / screen transitions (internal) | ✅ | ❌ |
+| FormSheet | ✅ | ✅ |
 
 ### 2. Able to port from RNScreens
 

--- a/android/build.gradle.kts
+++ b/android/build.gradle.kts
@@ -34,4 +34,6 @@ dependencies {
     implementation("androidx.transition:transition-ktx:1.7.0")
     implementation("com.google.android.material:material:1.13.0")
     implementation("androidx.core:core-ktx:1.17.0")
+
+    testImplementation("junit:junit:4.13.2")
 }

--- a/android/src/main/java/com/lynxscreens/screens/common/BaseTransferShadowNode.kt
+++ b/android/src/main/java/com/lynxscreens/screens/common/BaseTransferShadowNode.kt
@@ -1,0 +1,84 @@
+package com.lynxscreens.screens.common
+
+import com.lynx.tasm.behavior.shadow.AlignContext
+import com.lynx.tasm.behavior.shadow.AlignParam
+import com.lynx.tasm.behavior.shadow.CustomLayoutShadowNode
+import com.lynx.tasm.behavior.shadow.CustomMeasureFunc
+import com.lynx.tasm.behavior.shadow.MeasureContext
+import com.lynx.tasm.behavior.shadow.MeasureMode
+import com.lynx.tasm.behavior.shadow.MeasureParam
+import com.lynx.tasm.behavior.shadow.MeasureResult
+import com.lynx.tasm.behavior.shadow.NativeLayoutNodeRef
+
+/**
+ * Base ShadowNode that measures and aligns Lynx children with constraints from a native receiver.
+ */
+internal abstract class BaseTransferShadowNode : CustomLayoutShadowNode(), CustomMeasureFunc {
+    private var hasHostConstraints = false
+    private var hostWidth = 0f
+    private var hostWidthMode = MeasureMode.UNDEFINED
+    private var hostHeight = 0f
+    private var hostHeightMode = MeasureMode.UNDEFINED
+
+    override fun attachNativePtr(ptr: Long) {
+        setCustomMeasureFunc(this)
+        super.attachNativePtr(ptr)
+    }
+
+    /** Updates the native receiver constraints used for the next Lynx child layout pass. */
+    internal fun updateHostConstraints(
+        width: Float,
+        widthMode: MeasureMode,
+        height: Float,
+        heightMode: MeasureMode,
+    ) {
+        if (hasHostConstraints &&
+            hostWidth == width &&
+            hostWidthMode == widthMode &&
+            hostHeight == height &&
+            hostHeightMode == heightMode
+        ) {
+            return
+        }
+
+        hasHostConstraints = true
+        hostWidth = width
+        hostWidthMode = widthMode
+        hostHeight = height
+        hostHeightMode = heightMode
+        markDirty()
+    }
+
+    override fun measure(
+        param: MeasureParam?,
+        context: MeasureContext?,
+    ): MeasureResult {
+        if (!hasHostConstraints) {
+            return MeasureResult(0f, 0f)
+        }
+
+        val sourceParam = param ?: MeasureParam()
+        val childParam =
+            MeasureParam().apply {
+                mWidth = if (hostWidthMode == MeasureMode.UNDEFINED) sourceParam.mWidth else hostWidth
+                mWidthMode =
+                    if (hostWidthMode == MeasureMode.UNDEFINED) sourceParam.mWidthMode else hostWidthMode
+                mHeight = if (hostHeightMode == MeasureMode.UNDEFINED) sourceParam.mHeight else hostHeight
+                mHeightMode =
+                    if (hostHeightMode == MeasureMode.UNDEFINED) sourceParam.mHeightMode else hostHeightMode
+            }
+        for (index in 0 until childCount) {
+            (getChildAt(index) as? NativeLayoutNodeRef)?.measureNativeNode(context, childParam)
+        }
+        return MeasureResult(0f, 0f)
+    }
+
+    override fun align(
+        param: AlignParam?,
+        context: AlignContext?,
+    ) {
+        for (index in 0 until childCount) {
+            (getChildAt(index) as? NativeLayoutNodeRef)?.alignNativeNode(context, AlignParam())
+        }
+    }
+}

--- a/android/src/main/java/com/lynxscreens/screens/common/BaseUITransfer.kt
+++ b/android/src/main/java/com/lynxscreens/screens/common/BaseUITransfer.kt
@@ -1,0 +1,134 @@
+package com.lynxscreens.screens.common
+
+import android.content.Context
+import android.view.View
+import android.view.ViewGroup
+import com.lynx.tasm.behavior.LynxContext
+import com.lynx.tasm.behavior.shadow.MeasureMode
+import com.lynx.tasm.behavior.ui.UIGroup
+import com.lynx.tasm.behavior.ui.view.AndroidView
+
+/**
+ * Base Lynx UI for native components that render their Lynx children in another native hierarchy.
+ */
+internal abstract class BaseUITransfer<T : BaseUITransfer.BaseTransferView>(
+    context: LynxContext,
+) : UIGroup<T>(context) {
+    private var hostWidth = 0f
+    private var hostWidthMode = MeasureMode.UNDEFINED
+    private var hostHeight = 0f
+    private var hostHeightMode = MeasureMode.UNDEFINED
+
+    override fun canHaveFlattenChild(): Boolean = false
+
+    private fun updateHostConstraints(
+        widthMeasureSpec: Int,
+        heightMeasureSpec: Int,
+    ) {
+        val widthMode = MeasureMode.fromInt(MeasureMode.fromMeasureSpec(widthMeasureSpec))
+        val heightMode = MeasureMode.fromInt(MeasureMode.fromMeasureSpec(heightMeasureSpec))
+        val width =
+            if (widthMode == MeasureMode.UNDEFINED) 0f else View.MeasureSpec.getSize(widthMeasureSpec).toFloat()
+        val height =
+            if (heightMode == MeasureMode.UNDEFINED) 0f else View.MeasureSpec.getSize(heightMeasureSpec).toFloat()
+        if (hostWidth == width &&
+            hostWidthMode == widthMode &&
+            hostHeight == height &&
+            hostHeightMode == heightMode
+        ) {
+            return
+        }
+
+        hostWidth = width
+        hostWidthMode = widthMode
+        hostHeight = height
+        hostHeightMode = heightMode
+        lynxContext.findShadowNodeAndRunTask(sign) { shadowNode ->
+            if (shadowNode is BaseTransferShadowNode) {
+                shadowNode.updateHostConstraints(width, widthMode, height, heightMode)
+            }
+        }
+    }
+
+    /**
+     * Host view that forwards Lynx child view operations to [transferReceiver].
+     */
+    internal abstract class BaseTransferView(
+        context: Context,
+    ) : AndroidView(context) {
+        /** Native ViewGroup that receives the transferred Lynx child views. */
+        protected abstract val transferReceiver: ViewGroup
+
+        /** Returns the native receiver that can be mounted outside the Lynx view hierarchy. */
+        internal val transferredView: ViewGroup
+            get() = transferReceiver
+
+        /** Returns the transferred child at [index], or null when the index is out of bounds. */
+        internal fun getTransferredChildAt(index: Int): View? =
+            if (index in 0 until transferReceiver.childCount) {
+                transferReceiver.getChildAt(index)
+            } else {
+                null
+            }
+
+        override fun addView(
+            child: View,
+            index: Int,
+            params: ViewGroup.LayoutParams,
+        ) {
+            transferReceiver.addView(child, index, params)
+        }
+
+        override fun removeView(view: View) {
+            transferReceiver.removeView(view)
+        }
+
+        override fun removeViewAt(index: Int) {
+            transferReceiver.removeViewAt(index)
+        }
+
+        override fun removeAllViews() {
+            transferReceiver.removeAllViews()
+        }
+    }
+
+    /**
+     * Receiver view that feeds native measure constraints back to the transfer ShadowNode and Lynx
+     * subtree.
+     */
+    internal open class BaseTransferContentView(
+        context: Context,
+        private val transfer: BaseUITransfer<*>,
+    ) : AndroidView(context) {
+        override fun onMeasure(
+            widthMeasureSpec: Int,
+            heightMeasureSpec: Int,
+        ) {
+            transfer.updateHostConstraints(widthMeasureSpec, heightMeasureSpec)
+            transfer.measure()
+            setMeasuredDimension(
+                if (View.MeasureSpec.getMode(widthMeasureSpec) == View.MeasureSpec.UNSPECIFIED) {
+                    transfer.width
+                } else {
+                    View.MeasureSpec.getSize(widthMeasureSpec)
+                },
+                if (View.MeasureSpec.getMode(heightMeasureSpec) == View.MeasureSpec.UNSPECIFIED) {
+                    transfer.height
+                } else {
+                    View.MeasureSpec.getSize(heightMeasureSpec)
+                },
+            )
+        }
+
+        override fun onLayout(
+            changed: Boolean,
+            left: Int,
+            top: Int,
+            right: Int,
+            bottom: Int,
+        ) {
+            super.onLayout(changed, left, top, right, bottom)
+            transfer.layout()
+        }
+    }
+}

--- a/android/src/main/java/com/lynxscreens/screens/formsheet/FormSheetAnchors.kt
+++ b/android/src/main/java/com/lynxscreens/screens/formsheet/FormSheetAnchors.kt
@@ -1,0 +1,45 @@
+package com.lynxscreens.screens.formsheet
+
+internal fun resolveFormSheetAnchorTops(
+    parentHeight: Int,
+    sheetHeight: Int,
+    detentHeights: List<Int>,
+    fitToContents: Boolean,
+): List<Int> {
+    val heights =
+        if (fitToContents) {
+            listOf(sheetHeight)
+        } else {
+            detentHeights
+        }
+    val rawTops =
+        heights
+        .map { height -> parentHeight - height.coerceIn(0, parentHeight) }
+        .sorted()
+    if (parentHeight < rawTops.lastIndex) {
+        return rawTops
+    }
+    val resolvedTops = ArrayList<Int>(rawTops.size)
+    rawTops.forEachIndexed { index, top ->
+        val minimumTop = if (index == 0) 0 else resolvedTops.last() + 1
+        val maximumTop = parentHeight - (rawTops.lastIndex - index)
+        resolvedTops += top.coerceIn(minimumTop, maximumTop)
+    }
+    return resolvedTops
+}
+
+internal fun selectFormSheetAnchorTop(
+    anchorTops: List<Int>,
+    currentTop: Int,
+    verticalVelocity: Float,
+    minimumFlingVelocity: Float,
+): Int {
+    require(anchorTops.isNotEmpty())
+    return when {
+        verticalVelocity < 0f && -verticalVelocity >= minimumFlingVelocity ->
+            anchorTops.lastOrNull { it < currentTop } ?: anchorTops.first()
+        verticalVelocity > 0f && verticalVelocity >= minimumFlingVelocity ->
+            anchorTops.firstOrNull { it > currentTop } ?: anchorTops.last()
+        else -> anchorTops.minByOrNull { top -> kotlin.math.abs(top - currentTop) } ?: anchorTops.first()
+    }
+}

--- a/android/src/main/java/com/lynxscreens/screens/formsheet/FormSheetBehavior.kt
+++ b/android/src/main/java/com/lynxscreens/screens/formsheet/FormSheetBehavior.kt
@@ -1,0 +1,565 @@
+package com.lynxscreens.screens.formsheet
+
+import android.content.Context
+import android.util.AttributeSet
+import android.view.MotionEvent
+import android.view.View
+import android.view.ViewConfiguration
+import android.view.ViewGroup
+import androidx.coordinatorlayout.widget.CoordinatorLayout
+import androidx.core.view.ViewCompat
+import androidx.customview.widget.ViewDragHelper
+import java.lang.ref.WeakReference
+import kotlin.math.abs
+
+internal class FormSheetBehavior<V : View> : CoordinatorLayout.Behavior<V> {
+    internal abstract class Callback {
+        abstract fun onStateChanged(
+            bottomSheet: View,
+            newState: Int,
+        )
+
+        abstract fun onSlide(
+            bottomSheet: View,
+            slideOffset: Float,
+        )
+    }
+
+    constructor() : super()
+
+    constructor(
+        context: Context,
+        attrs: AttributeSet?,
+    ) : super(context, attrs)
+
+    private var viewRef: WeakReference<V>? = null
+    private var nestedScrollingChildRef: WeakReference<View>? = null
+    private var viewDragHelper: ViewDragHelper? = null
+    private var callback: Callback? = null
+    private var parentHeight = 0
+    private var sheetHeight = 0
+    private var detentHeights: List<Int> = emptyList()
+    private var anchorTops: List<Int> = emptyList()
+    private var fitToContents = false
+    private var activePointerId = ViewDragHelper.INVALID_POINTER
+    private var initialY = 0
+    private var touchingScrollingChild = false
+    private var ignoreEvents = false
+    private var nestedScrolled = false
+    private var nestedFlingHandled = false
+    private var minimumVelocity = 0f
+    private var maximumVelocity = 0f
+    private var internalState = STATE_COLLAPSED
+    private var settleGeneration = 0
+    private var settlingTargetState: Int? = null
+
+    var isHideable: Boolean = false
+        set(value) {
+            field = value
+            if (!value && (settlingTargetState == STATE_HIDDEN || internalState == STATE_HIDDEN)) {
+                viewRef?.get()?.let { settleToState(it, stateForTop(collapsedTop())) }
+            }
+        }
+
+    var state: Int
+        get() = internalState
+        set(value) {
+            require(value in STABLE_STATES) { "Invalid FormSheet state: $value" }
+            val child = viewRef?.get()
+            if (child == null || !child.isLaidOut) {
+                internalState = value
+                return
+            }
+            settleToState(child, normalizeState(value))
+        }
+
+    fun setCallback(callback: Callback) {
+        this.callback = callback
+    }
+
+    fun setDetents(
+        detentHeights: List<Int>,
+        fitToContents: Boolean,
+    ) {
+        this.detentHeights = detentHeights
+        this.fitToContents = fitToContents
+        if (parentHeight > 0) {
+            anchorTops =
+                resolveFormSheetAnchorTops(
+                    parentHeight = parentHeight,
+                    sheetHeight = sheetHeight,
+                    detentHeights = detentHeights,
+                    fitToContents = fitToContents,
+                )
+        }
+        viewRef?.get()?.requestLayout()
+    }
+
+    override fun onLayoutChild(
+        parent: CoordinatorLayout,
+        child: V,
+        layoutDirection: Int,
+    ): Boolean {
+        val savedTop = child.top
+        val previousAnchorTops = anchorTops
+        parent.onLayoutChild(child, layoutDirection)
+        parentHeight = parent.height
+        sheetHeight = child.height
+        anchorTops =
+            resolveFormSheetAnchorTops(
+                parentHeight = parentHeight,
+                sheetHeight = sheetHeight,
+                detentHeights = detentHeights,
+                fitToContents = fitToContents,
+            )
+        if (anchorTops.isEmpty()) {
+            anchorTops = listOf((parentHeight - sheetHeight).coerceAtLeast(0))
+        }
+        viewRef = WeakReference(child)
+        nestedScrollingChildRef = WeakReference(findScrollingChild(child))
+        if (viewDragHelper == null) {
+            viewDragHelper = ViewDragHelper.create(parent, dragCallback)
+            ViewConfiguration.get(parent.context).let { configuration ->
+                minimumVelocity = configuration.scaledMinimumFlingVelocity.toFloat()
+                maximumVelocity = configuration.scaledMaximumFlingVelocity.toFloat()
+            }
+        }
+
+        val anchorsChanged = previousAnchorTops != anchorTops
+        val normalizedState = normalizeState(internalState)
+        var completedRelayoutState: Int? = null
+        val targetTop =
+            when (internalState) {
+                STATE_DRAGGING,
+                -> savedTop.coerceIn(expandedTop(), maximumDragTop())
+                STATE_SETTLING -> {
+                    val targetState = settlingTargetState?.let(::normalizeState)
+                    if (anchorsChanged && targetState != null) {
+                        settleGeneration++
+                        viewDragHelper?.abort()
+                        settlingTargetState = null
+                        completedRelayoutState = targetState
+                        topForState(targetState)
+                    } else {
+                        savedTop.coerceIn(expandedTop(), maximumDragTop())
+                    }
+                }
+                STATE_HIDDEN -> parentHeight
+                else -> {
+                    if (normalizedState != internalState) {
+                        setStateInternal(normalizedState)
+                    }
+                    topForState(normalizedState)
+                }
+            }
+        ViewCompat.offsetTopAndBottom(child, targetTop - child.top)
+        completedRelayoutState?.let { completedState ->
+            dispatchOnSlide(child, targetTop)
+            setStateInternal(completedState)
+        }
+        return true
+    }
+
+    override fun onInterceptTouchEvent(
+        parent: CoordinatorLayout,
+        child: V,
+        event: MotionEvent,
+    ): Boolean {
+        if (!child.isShown) {
+            ignoreEvents = true
+            return false
+        }
+        when (event.actionMasked) {
+            MotionEvent.ACTION_DOWN -> {
+                resetTouch()
+                initialY = event.y.toInt()
+                findScrollingChildUnder(child, event.rawX.toInt(), event.rawY.toInt())?.let {
+                    nestedScrollingChildRef = WeakReference(it)
+                }
+                val touchedScrollingChild = nestedScrollingChildRef?.get()
+                touchingScrollingChild =
+                    touchedScrollingChild != null &&
+                    isPointInside(touchedScrollingChild, event.rawX.toInt(), event.rawY.toInt())
+                if (touchingScrollingChild) {
+                    activePointerId = event.getPointerId(event.actionIndex)
+                }
+                ignoreEvents = !parent.isPointInChildBounds(child, event.x.toInt(), event.y.toInt())
+            }
+            MotionEvent.ACTION_UP,
+            MotionEvent.ACTION_CANCEL,
+            -> {
+                touchingScrollingChild = false
+                activePointerId = ViewDragHelper.INVALID_POINTER
+                if (ignoreEvents) {
+                    ignoreEvents = false
+                    return false
+                }
+            }
+        }
+        if (!ignoreEvents && viewDragHelper?.shouldInterceptTouchEvent(event) == true) {
+            return true
+        }
+        val scrollingChild = nestedScrollingChildRef?.get()
+        return event.actionMasked == MotionEvent.ACTION_MOVE &&
+            !ignoreEvents &&
+            scrollingChild != null &&
+            !parent.isPointInChildBounds(scrollingChild, event.x.toInt(), event.y.toInt()) &&
+            abs(event.y - initialY) > (viewDragHelper?.touchSlop ?: 0)
+    }
+
+    override fun onTouchEvent(
+        parent: CoordinatorLayout,
+        child: V,
+        event: MotionEvent,
+    ): Boolean {
+        if (!child.isShown || ignoreEvents) {
+            return false
+        }
+        viewDragHelper?.processTouchEvent(event)
+        return true
+    }
+
+    override fun onStartNestedScroll(
+        coordinatorLayout: CoordinatorLayout,
+        child: V,
+        directTargetChild: View,
+        target: View,
+        axes: Int,
+        type: Int,
+    ): Boolean {
+        nestedScrolled = false
+        nestedFlingHandled = false
+        nestedScrollingChildRef = WeakReference(target)
+        return axes and ViewCompat.SCROLL_AXIS_VERTICAL != 0
+    }
+
+    override fun onNestedPreScroll(
+        coordinatorLayout: CoordinatorLayout,
+        child: V,
+        target: View,
+        dx: Int,
+        dy: Int,
+        consumed: IntArray,
+        type: Int,
+    ) {
+        if (type == ViewCompat.TYPE_NON_TOUCH || target !== nestedScrollingChildRef?.get()) {
+            return
+        }
+        val currentTop = child.top
+        val nextTop = currentTop - dy
+        when {
+            dy > 0 && nextTop < expandedTop() -> {
+                consumed[1] = currentTop - expandedTop()
+                beginDragging()
+                moveTo(child, expandedTop())
+                setStateInternal(stateForTop(expandedTop()))
+            }
+            dy > 0 -> {
+                consumed[1] = dy
+                moveTo(child, nextTop)
+                beginDragging()
+            }
+            dy < 0 && !target.canScrollVertically(-1) -> {
+                val clampedTop = nextTop.coerceAtMost(maximumDragTop())
+                consumed[1] = currentTop - clampedTop
+                moveTo(child, clampedTop)
+                beginDragging()
+            }
+            else -> return
+        }
+        nestedScrolled = true
+    }
+
+    override fun onStopNestedScroll(
+        coordinatorLayout: CoordinatorLayout,
+        child: V,
+        target: View,
+        type: Int,
+    ) {
+        if (nestedFlingHandled) {
+            nestedFlingHandled = false
+            nestedScrolled = false
+            return
+        }
+        if (!nestedScrolled || target !== nestedScrollingChildRef?.get()) {
+            return
+        }
+        settleAfterRelease(child, verticalVelocity = 0f)
+        nestedScrolled = false
+    }
+
+    override fun onNestedPreFling(
+        coordinatorLayout: CoordinatorLayout,
+        child: V,
+        target: View,
+        velocityX: Float,
+        velocityY: Float,
+    ): Boolean {
+        if (target !== nestedScrollingChildRef?.get() || internalState == stateForTop(expandedTop())) {
+            return false
+        }
+        if (velocityY < 0f && target.canScrollVertically(-1)) {
+            return false
+        }
+        nestedFlingHandled = true
+        settleAfterRelease(child, verticalVelocity = -velocityY)
+        return true
+    }
+
+    private val dragCallback =
+        object : ViewDragHelper.Callback() {
+            override fun tryCaptureView(
+                child: View,
+                pointerId: Int,
+            ): Boolean {
+                if (internalState == STATE_DRAGGING || touchingScrollingChild) {
+                    return false
+                }
+                if (internalState == stateForTop(expandedTop()) && activePointerId == pointerId) {
+                    val scrollingChild = nestedScrollingChildRef?.get()
+                    if (scrollingChild?.canScrollVertically(-1) == true) {
+                        return false
+                    }
+                }
+                return viewRef?.get() === child
+            }
+
+            override fun onViewDragStateChanged(state: Int) {
+                if (state == ViewDragHelper.STATE_DRAGGING) {
+                    beginDragging()
+                }
+            }
+
+            override fun onViewPositionChanged(
+                changedView: View,
+                left: Int,
+                top: Int,
+                dx: Int,
+                dy: Int,
+            ) {
+                dispatchOnSlide(changedView, top)
+            }
+
+            override fun onViewReleased(
+                releasedChild: View,
+                xvel: Float,
+                yvel: Float,
+            ) {
+                @Suppress("UNCHECKED_CAST")
+                settleAfterRelease(releasedChild as V, yvel)
+            }
+
+            override fun clampViewPositionVertical(
+                child: View,
+                top: Int,
+                dy: Int,
+            ): Int = top.coerceIn(expandedTop(), maximumDragTop())
+
+            override fun clampViewPositionHorizontal(
+                child: View,
+                left: Int,
+                dx: Int,
+            ): Int = child.left
+
+            override fun getViewVerticalDragRange(child: View): Int = maximumDragTop() - expandedTop()
+        }
+
+    private fun settleAfterRelease(
+        child: V,
+        verticalVelocity: Float,
+    ) {
+        val shouldHide =
+            isHideable &&
+                verticalVelocity >= 0f &&
+                child.top > collapsedTop() &&
+                (child.top + verticalVelocity.coerceAtMost(maximumVelocity) * HIDE_FRICTION) >
+                collapsedTop() + (parentHeight - collapsedTop()) * HIDE_THRESHOLD
+        val targetState =
+            if (shouldHide) {
+                STATE_HIDDEN
+            } else {
+                stateForTop(
+                    selectFormSheetAnchorTop(
+                        anchorTops = anchorTops,
+                        currentTop = child.top,
+                        verticalVelocity = verticalVelocity,
+                        minimumFlingVelocity = minimumVelocity,
+                    ),
+                )
+            }
+        settleToState(child, targetState)
+    }
+
+    private fun settleToState(
+        child: V,
+        targetState: Int,
+    ) {
+        val generation = ++settleGeneration
+        settlingTargetState = targetState
+        val targetTop = if (targetState == STATE_HIDDEN) parentHeight else topForState(targetState)
+        if (viewDragHelper?.smoothSlideViewTo(child, child.left, targetTop) == true) {
+            setStateInternal(STATE_SETTLING)
+            child.postOnAnimation(SettleRunnable(child, targetState, generation))
+        } else {
+            moveTo(child, targetTop)
+            settlingTargetState = null
+            setStateInternal(targetState)
+        }
+    }
+
+    private fun moveTo(
+        child: V,
+        top: Int,
+    ) {
+        ViewCompat.offsetTopAndBottom(child, top - child.top)
+        dispatchOnSlide(child, top)
+    }
+
+    private fun setStateInternal(newState: Int) {
+        if (internalState == newState) {
+            return
+        }
+        internalState = newState
+        viewRef?.get()?.let { callback?.onStateChanged(it, newState) }
+    }
+
+    private fun beginDragging() {
+        if (internalState != STATE_DRAGGING) {
+            settleGeneration++
+            settlingTargetState = null
+            setStateInternal(STATE_DRAGGING)
+        }
+    }
+
+    private fun dispatchOnSlide(
+        child: View,
+        top: Int,
+    ) {
+        val collapsedTop = collapsedTop()
+        val expandedTop = expandedTop()
+        val slideOffset =
+            when {
+                collapsedTop == expandedTop -> 1f
+                top <= collapsedTop -> (collapsedTop - top).toFloat() / (collapsedTop - expandedTop)
+                parentHeight == collapsedTop -> 0f
+                else -> (collapsedTop - top).toFloat() / (parentHeight - collapsedTop)
+            }
+        callback?.onSlide(child, slideOffset)
+    }
+
+    private fun normalizeState(state: Int): Int =
+        if (state == STATE_HIDDEN) {
+            STATE_HIDDEN
+        } else {
+            when (anchorTops.size) {
+                1 -> STATE_EXPANDED
+                2 -> if (state == STATE_COLLAPSED) STATE_COLLAPSED else STATE_EXPANDED
+                else -> state
+            }
+        }
+
+    private fun topForState(state: Int): Int =
+        when (state) {
+            STATE_COLLAPSED -> anchorTops.last()
+            STATE_HALF_EXPANDED -> anchorTops.getOrElse(1) { anchorTops.first() }
+            STATE_EXPANDED -> anchorTops.first()
+            STATE_HIDDEN -> parentHeight
+            else -> error("No stable top for state $state")
+        }
+
+    private fun stateForTop(top: Int): Int {
+        val index = anchorTops.indexOf(top).coerceAtLeast(0)
+        return when (anchorTops.size) {
+            1 -> STATE_EXPANDED
+            2 -> if (index == 0) STATE_EXPANDED else STATE_COLLAPSED
+            else ->
+                when (index) {
+                    0 -> STATE_EXPANDED
+                    1 -> STATE_HALF_EXPANDED
+                    else -> STATE_COLLAPSED
+                }
+        }
+    }
+
+    private fun expandedTop(): Int = anchorTops.firstOrNull() ?: 0
+
+    private fun collapsedTop(): Int = anchorTops.lastOrNull() ?: parentHeight
+
+    private fun maximumDragTop(): Int = if (isHideable) parentHeight else collapsedTop()
+
+    private fun resetTouch() {
+        activePointerId = ViewDragHelper.INVALID_POINTER
+        touchingScrollingChild = false
+    }
+
+    private fun findScrollingChild(view: View): View? {
+        if (ViewCompat.isNestedScrollingEnabled(view)) {
+            return view
+        }
+        if (view is ViewGroup) {
+            for (index in 0 until view.childCount) {
+                findScrollingChild(view.getChildAt(index))?.let { return it }
+            }
+        }
+        return null
+    }
+
+    private fun findScrollingChildUnder(
+        view: View,
+        rawX: Int,
+        rawY: Int,
+    ): View? {
+        if (!isPointInside(view, rawX, rawY)) {
+            return null
+        }
+        if (view is ViewGroup) {
+            for (index in view.childCount - 1 downTo 0) {
+                findScrollingChildUnder(view.getChildAt(index), rawX, rawY)?.let { return it }
+            }
+        }
+        return view.takeIf(ViewCompat::isNestedScrollingEnabled)
+    }
+
+    private fun isPointInside(
+        view: View,
+        rawX: Int,
+        rawY: Int,
+    ): Boolean {
+        val location = IntArray(2)
+        view.getLocationOnScreen(location)
+        return rawX >= location[0] &&
+            rawX < location[0] + view.width &&
+            rawY >= location[1] &&
+            rawY < location[1] + view.height
+    }
+
+    private inner class SettleRunnable(
+        private val child: V,
+        private val targetState: Int,
+        private val generation: Int,
+    ) : Runnable {
+        override fun run() {
+            if (generation != settleGeneration) {
+                return
+            }
+            if (viewDragHelper?.continueSettling(true) == true) {
+                child.postOnAnimation(this)
+            } else {
+                settlingTargetState = null
+                setStateInternal(targetState)
+            }
+        }
+    }
+
+    companion object {
+        const val STATE_DRAGGING = 1
+        const val STATE_SETTLING = 2
+        const val STATE_EXPANDED = 3
+        const val STATE_COLLAPSED = 4
+        const val STATE_HIDDEN = 5
+        const val STATE_HALF_EXPANDED = 6
+        private const val HIDE_THRESHOLD = 0.5f
+        private const val HIDE_FRICTION = 0.1f
+        private val STABLE_STATES = setOf(STATE_EXPANDED, STATE_COLLAPSED, STATE_HIDDEN, STATE_HALF_EXPANDED)
+    }
+}

--- a/android/src/main/java/com/lynxscreens/screens/formsheet/FormSheetComponent.kt
+++ b/android/src/main/java/com/lynxscreens/screens/formsheet/FormSheetComponent.kt
@@ -1,0 +1,142 @@
+package com.lynxscreens.screens.formsheet
+
+import android.content.Context
+import android.graphics.Color
+import com.lynx.react.bridge.Dynamic
+import com.lynx.react.bridge.ReadableArray
+import com.lynx.react.bridge.ReadableType
+import com.lynx.tasm.behavior.LynxContext
+import com.lynx.tasm.behavior.LynxElement
+import com.lynx.tasm.behavior.LynxProp
+import com.lynx.tasm.behavior.PatchFinishListener
+import com.lynxscreens.screens.common.BaseUITransfer
+
+@LynxElement(name = "form-sheet-native")
+internal class FormSheetComponent(
+    context: LynxContext,
+) : BaseUITransfer<FormSheetHostView>(context),
+    PatchFinishListener {
+    private var isOpen = false
+    private var rawDetents: List<Double> = emptyList()
+    private var prefersGrabberVisible = false
+    private var preferredCornerRadius = -1f
+    private var initialDetentIndex = 0
+    private var selectedDetentIndex = -2
+    private var nativeContainerBackgroundColor: Int? = null
+    private var preventNativeDismissChannels = emptySet<FormSheetDismissChannel>()
+    private var preventNativeDismissDragFeedback = false
+    private var largestUndimmedDetentIndex = -1
+
+    private val eventEmitter by lazy { FormSheetEventEmitter(lynxContext, sign) }
+
+    override fun createView(context: Context?): FormSheetHostView =
+        FormSheetHostView(context as LynxContext, this).also {
+            it.setLynxRootUi(this)
+        }
+
+    @LynxProp(name = "isOpen")
+    fun setIsOpen(value: Boolean?) {
+        isOpen = value == true
+    }
+
+    @LynxProp(name = "detents")
+    fun setDetents(value: ReadableArray?) {
+        rawDetents =
+            if (value == null) {
+                emptyList()
+            } else {
+                List(value.size()) { index -> value.getDouble(index) }
+            }
+    }
+
+    @LynxProp(name = "prefersGrabberVisible")
+    fun setPrefersGrabberVisible(value: Boolean?) {
+        prefersGrabberVisible = value == true
+    }
+
+    @LynxProp(name = "preferredCornerRadius", defaultDouble = -1.0)
+    fun setPreferredCornerRadius(value: Double) {
+        preferredCornerRadius = value.toFloat()
+    }
+
+    @LynxProp(name = "initialDetentIndex")
+    fun setInitialDetentIndex(value: Int) {
+        initialDetentIndex = value
+    }
+
+    @LynxProp(name = "selectedDetentIndex", defaultInt = -2)
+    fun setSelectedDetentIndex(value: Int) {
+        selectedDetentIndex = value
+    }
+
+    @LynxProp(name = "largestUndimmedDetentIndex", defaultInt = -1)
+    fun setLargestUndimmedDetentIndex(value: Int) {
+        largestUndimmedDetentIndex = value
+    }
+
+    @LynxProp(name = "prefersScrollingExpandsWhenScrolledToEdge")
+    @Suppress("UNUSED_PARAMETER")
+    fun setPrefersScrollingExpandsWhenScrolledToEdge(value: Boolean?) = Unit
+
+    @LynxProp(name = "preventNativeDismiss")
+    fun setPreventNativeDismiss(value: Dynamic?) {
+        preventNativeDismissChannels = parsePreventNativeDismissChannels(value)
+    }
+
+    @LynxProp(name = "preventNativeDismissDragFeedback")
+    fun setPreventNativeDismissDragFeedback(value: Boolean?) {
+        preventNativeDismissDragFeedback = value == true
+    }
+
+    @LynxProp(name = "nativeContainerBackgroundColor")
+    fun setNativeContainerBackgroundColor(value: String?) {
+        nativeContainerBackgroundColor =
+            value?.let {
+                try {
+                    Color.parseColor(it)
+                } catch (_: IllegalArgumentException) {
+                    null
+                }
+            }
+    }
+
+    override fun onPatchFinish() {
+        view.setEventEmitter(eventEmitter)
+        view.applyConfig(
+            FormSheetConfig(
+                isOpen = isOpen,
+                detents = FormSheetDetents.parse(rawDetents),
+                prefersGrabberVisible = prefersGrabberVisible,
+                preferredCornerRadius = preferredCornerRadius,
+                initialDetentIndex = initialDetentIndex,
+                selectedDetentIndex = selectedDetentIndex,
+                nativeContainerBackgroundColor = nativeContainerBackgroundColor,
+                preventNativeDismissChannels = preventNativeDismissChannels,
+                preventNativeDismissDragFeedback = preventNativeDismissDragFeedback,
+                largestUndimmedDetentIndex = largestUndimmedDetentIndex,
+            ),
+        )
+    }
+}
+
+internal fun parsePreventNativeDismissChannels(value: Dynamic?): Set<FormSheetDismissChannel> =
+    when (value?.type) {
+        ReadableType.Boolean -> {
+            if (value.asBoolean()) {
+                FormSheetDismissChannel.values().toSet()
+            } else {
+                emptySet()
+            }
+        }
+        ReadableType.Array -> {
+            val channels = value.asArray()
+            buildSet {
+                for (index in 0 until channels.size()) {
+                    if (channels.getType(index) == ReadableType.String) {
+                        FormSheetDismissChannel.fromValue(channels.getString(index))?.let(::add)
+                    }
+                }
+            }
+        }
+        else -> emptySet()
+    }

--- a/android/src/main/java/com/lynxscreens/screens/formsheet/FormSheetConfig.kt
+++ b/android/src/main/java/com/lynxscreens/screens/formsheet/FormSheetConfig.kt
@@ -1,0 +1,31 @@
+package com.lynxscreens.screens.formsheet
+
+internal data class FormSheetConfig(
+    val isOpen: Boolean,
+    val detents: FormSheetDetents,
+    val prefersGrabberVisible: Boolean,
+    val preferredCornerRadius: Float,
+    val initialDetentIndex: Int,
+    val selectedDetentIndex: Int,
+    val nativeContainerBackgroundColor: Int?,
+    val preventNativeDismissChannels: Set<FormSheetDismissChannel>,
+    val preventNativeDismissDragFeedback: Boolean,
+    val largestUndimmedDetentIndex: Int,
+) {
+    fun preventsNativeDismiss(channel: FormSheetDismissChannel): Boolean =
+        channel in preventNativeDismissChannels
+}
+
+internal enum class FormSheetDismissChannel(
+    val eventValue: String,
+) {
+    BACK("back"),
+    DRAG("drag"),
+    BACKDROP("backdrop"),
+    ;
+
+    companion object {
+        fun fromValue(value: String): FormSheetDismissChannel? =
+            values().firstOrNull { it.eventValue == value }
+    }
+}

--- a/android/src/main/java/com/lynxscreens/screens/formsheet/FormSheetDetents.kt
+++ b/android/src/main/java/com/lynxscreens/screens/formsheet/FormSheetDetents.kt
@@ -1,0 +1,69 @@
+package com.lynxscreens.screens.formsheet
+
+internal class FormSheetDetents private constructor(
+    private val values: List<Double>,
+) {
+    val count: Int
+        get() = values.size
+
+    val isFitToContents: Boolean
+        get() = values == listOf(FIT_TO_CONTENTS)
+
+    fun heightAt(
+        index: Int,
+        availableHeight: Int,
+    ): Int = (values[index] * availableHeight).toInt()
+
+    fun largestHeight(availableHeight: Int): Int = heightAt(values.lastIndex, availableHeight)
+
+    companion object {
+        private const val FIT_TO_CONTENTS = -1.0
+        private const val MAX_DETENTS = 3
+
+        fun parse(rawValues: List<Double>): FormSheetDetents {
+            val values = if (rawValues.isEmpty()) listOf(1.0) else rawValues
+            return try {
+                require(values.size <= MAX_DETENTS) {
+                    "Maximum of $MAX_DETENTS detents supported, got ${values.size}."
+                }
+                val isFitToContents = values == listOf(FIT_TO_CONTENTS)
+                if (!isFitToContents) {
+                    require(values.all { it in 0.0..1.0 }) {
+                        "Detent values must be within 0.0 and 1.0."
+                    }
+                    require(values == values.distinct().sorted()) {
+                        "Detents must be sorted in strictly ascending order."
+                    }
+                }
+                FormSheetDetents(values)
+            } catch (error: IllegalArgumentException) {
+                android.util.Log.e("RNScreens", "[RNScreens] Invalid FormSheet detents: ${error.message} Falling back to [1.0].")
+                FormSheetDetents(listOf(1.0))
+            }
+        }
+    }
+}
+
+internal data class FormSheetDetentGeometry(
+    val availableHeight: Int,
+    val sheetHeights: List<Int>,
+)
+
+internal fun FormSheetDetents.resolveGeometry(
+    windowHeight: Int,
+): FormSheetDetentGeometry {
+    val availableHeight = windowHeight.coerceAtLeast(1)
+    val sheetHeights =
+        if (isFitToContents) {
+            emptyList()
+        } else {
+            List(count) { index -> heightAt(index, availableHeight) }
+        }
+    return FormSheetDetentGeometry(availableHeight, sheetHeights)
+}
+
+internal fun visibleSheetSurfaceHeight(
+    parentHeight: Int,
+    sheetTop: Int,
+    maximumHeight: Int,
+): Int = (parentHeight - sheetTop).coerceIn(0, maximumHeight.coerceAtLeast(0))

--- a/android/src/main/java/com/lynxscreens/screens/formsheet/FormSheetDimming.kt
+++ b/android/src/main/java/com/lynxscreens/screens/formsheet/FormSheetDimming.kt
@@ -1,0 +1,47 @@
+package com.lynxscreens.screens.formsheet
+
+internal fun resolveFormSheetDimHeight(
+    visibleSheetHeight: Int,
+    detentHeights: List<Int>,
+    presentationTargetDetentIndex: Int?,
+): Int = detentHeights.getOrNull(presentationTargetDetentIndex ?: -1) ?: visibleSheetHeight
+
+internal fun calculateFormSheetDimAmount(
+    visibleSheetHeight: Int,
+    detentHeights: List<Int>,
+    largestUndimmedDetentIndex: Int,
+    maximumDimAmount: Float,
+): Float {
+    val baseAmount =
+        when {
+            largestUndimmedDetentIndex == FORM_SHEET_NEVER_DIMMED -> 0f
+            largestUndimmedDetentIndex == FORM_SHEET_ALWAYS_DIMMED -> maximumDimAmount
+            detentHeights.isEmpty() -> 0f
+            else -> {
+                val index = largestUndimmedDetentIndex.coerceIn(0, detentHeights.lastIndex)
+                val threshold = detentHeights[index]
+                if (visibleSheetHeight <= threshold) {
+                    0f
+                } else {
+                    val upper = detentHeights[(index + 1).coerceAtMost(detentHeights.lastIndex)]
+                    if (upper <= threshold) {
+                        maximumDimAmount
+                    } else {
+                        val progress =
+                            ((visibleSheetHeight - threshold).toFloat() / (upper - threshold))
+                                .coerceIn(0f, 1f)
+                        maximumDimAmount * progress
+                    }
+                }
+            }
+        }
+
+    if (detentHeights.isEmpty() || largestUndimmedDetentIndex != FORM_SHEET_ALWAYS_DIMMED) {
+        return baseAmount
+    }
+    val fadeStartHeight = detentHeights.firstOrNull { it > 0 } ?: return 0f
+    return baseAmount * (visibleSheetHeight.toFloat() / fadeStartHeight).coerceIn(0f, 1f)
+}
+
+private const val FORM_SHEET_ALWAYS_DIMMED = -1
+private const val FORM_SHEET_NEVER_DIMMED = -2

--- a/android/src/main/java/com/lynxscreens/screens/formsheet/FormSheetEventEmitter.kt
+++ b/android/src/main/java/com/lynxscreens/screens/formsheet/FormSheetEventEmitter.kt
@@ -1,0 +1,46 @@
+package com.lynxscreens.screens.formsheet
+
+import com.lynx.tasm.behavior.LynxContext
+import com.lynx.tasm.event.LynxCustomEvent
+
+internal class FormSheetEventEmitter(
+    private val lynxContext: LynxContext,
+    private val sign: Int,
+) {
+    internal fun emitOnWillAppear() = emit(EVENT_WILL_APPEAR)
+
+    internal fun emitOnDidAppear() = emit(EVENT_DID_APPEAR)
+
+    internal fun emitOnWillDisappear() = emit(EVENT_WILL_DISAPPEAR)
+
+    internal fun emitOnDidDisappear() = emit(EVENT_DID_DISAPPEAR)
+
+    internal fun emitOnDismiss() = emit(EVENT_DISMISS)
+
+    internal fun emitOnNativeDismiss() = emit(EVENT_NATIVE_DISMISS)
+
+    internal fun emitOnNativeDismissPrevented(channel: FormSheetDismissChannel) =
+        emit(EVENT_NATIVE_DISMISS_PREVENTED, mapOf("channel" to channel.eventValue))
+
+    internal fun emitOnDetentChanged(index: Int) = emit(EVENT_DETENT_CHANGED, mapOf("index" to index))
+
+    private fun emit(
+        name: String,
+        detail: Map<String, Any>? = null,
+    ) {
+        val event = LynxCustomEvent(sign, name)
+        detail?.forEach { (key, value) -> event.addDetail(key, value) }
+        lynxContext.eventEmitter.sendCustomEvent(event)
+    }
+
+    private companion object {
+        const val EVENT_WILL_APPEAR = "OnWillAppear"
+        const val EVENT_DID_APPEAR = "OnDidAppear"
+        const val EVENT_WILL_DISAPPEAR = "OnWillDisappear"
+        const val EVENT_DID_DISAPPEAR = "OnDidDisappear"
+        const val EVENT_DISMISS = "OnDismiss"
+        const val EVENT_NATIVE_DISMISS = "OnNativeDismiss"
+        const val EVENT_NATIVE_DISMISS_PREVENTED = "OnNativeDismissPrevented"
+        const val EVENT_DETENT_CHANGED = "OnDetentChanged"
+    }
+}

--- a/android/src/main/java/com/lynxscreens/screens/formsheet/FormSheetHostView.kt
+++ b/android/src/main/java/com/lynxscreens/screens/formsheet/FormSheetHostView.kt
@@ -1,0 +1,1020 @@
+package com.lynxscreens.screens.formsheet
+
+import android.animation.Animator
+import android.animation.AnimatorListenerAdapter
+import android.animation.ValueAnimator
+import android.annotation.SuppressLint
+import android.content.res.ColorStateList
+import android.graphics.Color
+import android.graphics.Rect
+import android.graphics.drawable.Drawable
+import android.graphics.drawable.GradientDrawable
+import android.os.Build
+import android.view.GestureDetector
+import android.view.Gravity
+import android.view.KeyEvent
+import android.view.MotionEvent
+import android.view.View
+import android.view.ViewGroup
+import android.view.ViewConfiguration
+import android.view.Window
+import android.view.WindowManager
+import android.view.animation.AccelerateDecelerateInterpolator
+import android.widget.FrameLayout
+import androidx.coordinatorlayout.widget.CoordinatorLayout
+import androidx.core.view.ViewCompat
+import androidx.core.view.WindowCompat
+import com.google.android.material.bottomsheet.BottomSheetDialog
+import com.lynx.tasm.behavior.LynxContext
+import com.lynx.tasm.behavior.ui.UIGroup
+import com.lynxscreens.screens.common.BaseUITransfer
+import kotlin.math.abs
+import kotlin.math.roundToInt
+
+@SuppressLint("ViewConstructor")
+internal class FormSheetHostView(
+    context: LynxContext,
+    transfer: BaseUITransfer<*>,
+) : BaseUITransfer.BaseTransferView(context) {
+    private val sheetContent = SheetContentView(context, transfer)
+    override val transferReceiver: ViewGroup
+        get() = sheetContent
+
+    private val sheetContainer =
+        object : FrameLayout(context) {
+            override fun dispatchTouchEvent(event: MotionEvent): Boolean {
+                trackPotentialDismissDrag(event)
+                val originX = event.x
+                val originY = event.y
+                context.EnsureEventDispatcher()
+                val dispatcher = context.touchEventDispatcher
+                val consumedByLynx = dispatcher?.onTouchEvent(event, lynxRootUi) == true
+                event.setLocation(originX, originY)
+
+                if (consumedByLynx && dispatcher?.blockNativeEvent(event) == true) {
+                    parent?.requestDisallowInterceptTouchEvent(true)
+                }
+                if (consumedByLynx && dispatcher?.consumeSlideEvent(event) == true) {
+                    return true
+                }
+                return super.dispatchTouchEvent(event) || consumedByLynx
+            }
+        }
+    private val grabber = View(context)
+
+    private lateinit var lynxRootUi: UIGroup<*>
+    private var dialog: BottomSheetDialog? = null
+    private var sheetBehavior: FormSheetBehavior<FrameLayout>? = null
+    private var eventEmitter: FormSheetEventEmitter? = null
+    private var latestConfig: FormSheetConfig? = null
+    private var isPresented = false
+    private var nativeDismissedForCurrentRequest = false
+    private var previousRequestedOpen = false
+    private var suppressDismissEvents = false
+    private var lastEmittedDetentIndex = -1
+    private var currentDetentsCount = 1
+    private var hasEmittedWillDisappear = false
+    private var defaultBottomSheetBackground: Drawable? = null
+    private var stateBeforeDrag = -1
+    private var maxOffsetDuringDrag = Float.MIN_VALUE
+    private var pendingDismissPreventedEmission = false
+    private var recoveringPreventedDragDismiss = false
+    private var dismissDragStartRawY = Float.NaN
+    private var maxDownwardDismissDragDistance = 0f
+    private val dismissDragDistanceThreshold = ViewConfiguration.get(context).scaledTouchSlop.toFloat()
+    private var currentDetentHeights: List<Int> = emptyList()
+    private var presentationAnimationPending = false
+    private var presentationAnimationRunning = false
+    private var dismissAnimationRunning = false
+    private var pendingBackdropAlpha = 0f
+    private var presentationTargetDetentIndex: Int? = null
+    private var hasEmittedDidAppear = false
+    private var nativeDismissEventEmitted = false
+    private var programmaticDismissPending = false
+    private var dismissAnimator: ValueAnimator? = null
+    private var presentationAnimationStartedAt = 0L
+
+    private val bottomSheetCallback =
+        object : FormSheetBehavior.Callback() {
+            override fun onStateChanged(
+                bottomSheet: View,
+                newState: Int,
+            ) {
+                if (newState == FormSheetBehavior.STATE_HIDDEN) {
+                    dialog?.cancel()
+                    return
+                }
+                when (newState) {
+                    FormSheetBehavior.STATE_DRAGGING -> {
+                        stateBeforeDrag = lastEmittedDetentIndex
+                        maxOffsetDuringDrag = Float.MIN_VALUE
+                        pendingDismissPreventedEmission = false
+                    }
+                    FormSheetBehavior.STATE_SETTLING -> Unit
+                    else -> {
+                        val index = stateToDetentIndex(newState, currentDetentsCount)
+                        if (index >= 0 && index != lastEmittedDetentIndex) {
+                            lastEmittedDetentIndex = index
+                            eventEmitter?.emitOnDetentChanged(index)
+                        }
+                        maybeMarkDismissAttempt(index)
+                        if (index >= 0 && pendingDismissPreventedEmission) {
+                            pendingDismissPreventedEmission = false
+                            eventEmitter?.emitOnNativeDismissPrevented(FormSheetDismissChannel.DRAG)
+                        }
+                        if (index == 0) {
+                            recoveringPreventedDragDismiss = false
+                        }
+                    }
+                }
+                updateSheetSurfaceLayout(bottomSheet)
+                updateDimming(bottomSheet)
+            }
+
+            override fun onSlide(
+                bottomSheet: View,
+                slideOffset: Float,
+            ) {
+                val config = latestConfig
+                if (config?.preventsNativeDismiss(FormSheetDismissChannel.DRAG) == true &&
+                    config.preventNativeDismissDragFeedback
+                ) {
+                    maxOffsetDuringDrag = maxOf(maxOffsetDuringDrag, slideOffset)
+                }
+                updateSheetSurfaceLayout(bottomSheet)
+                updateDimming(bottomSheet)
+            }
+        }
+
+    init {
+        sheetContainer.addView(
+            sheetContent,
+            FrameLayout.LayoutParams(
+                LayoutParams.MATCH_PARENT,
+                LayoutParams.MATCH_PARENT,
+            ),
+        )
+
+        val grabberHeight = dp(4)
+        val grabberWidth = dp(32)
+        grabber.background =
+            GradientDrawable().apply {
+                shape = GradientDrawable.RECTANGLE
+                cornerRadius = grabberHeight / 2f
+                setColor(Color.argb(90, 80, 80, 80))
+            }
+        sheetContainer.addView(
+            grabber,
+            FrameLayout.LayoutParams(grabberWidth, grabberHeight, Gravity.TOP or Gravity.CENTER_HORIZONTAL).apply {
+                topMargin = dp(8)
+            },
+        )
+
+    }
+
+    internal fun setEventEmitter(eventEmitter: FormSheetEventEmitter) {
+        this.eventEmitter = eventEmitter
+    }
+
+    internal fun setLynxRootUi(rootUi: UIGroup<*>) {
+        lynxRootUi = rootUi
+    }
+
+    internal fun applyConfig(config: FormSheetConfig) {
+        latestConfig = config
+
+        val requestedOpen = !previousRequestedOpen && config.isOpen
+        previousRequestedOpen = config.isOpen
+        if (requestedOpen || !config.isOpen) {
+            nativeDismissedForCurrentRequest = false
+        }
+
+        when {
+            dismissAnimationRunning -> {
+                if (requestedOpen && isPresented) {
+                    cancelDismissAndPresent(config)
+                }
+            }
+            config.isOpen && !isPresented && !nativeDismissedForCurrentRequest && isAttachedToWindow -> present(config)
+            !config.isOpen && isPresented -> dismissProgrammatically()
+            config.isOpen && isPresented -> configurePresentedSheet(config, applyInitialDetent = false)
+        }
+    }
+
+    override fun onAttachedToWindow() {
+        super.onAttachedToWindow()
+        latestConfig?.let(::applyConfig)
+    }
+
+    override fun onDetachedFromWindow() {
+        if (dismissAnimationRunning && nativeDismissEventEmitted) {
+            super.onDetachedFromWindow()
+            return
+        }
+        suppressDismissEvents = true
+        dialog?.dismiss()
+        dismissAnimator?.cancel()
+        dismissAnimator = null
+        dialog = null
+        sheetBehavior = null
+        presentationTargetDetentIndex = null
+        isPresented = false
+        suppressDismissEvents = false
+        super.onDetachedFromWindow()
+    }
+
+    override fun onMeasure(
+        widthMeasureSpec: Int,
+        heightMeasureSpec: Int,
+    ) {
+        setMeasuredDimension(
+            MeasureSpec.getSize(widthMeasureSpec),
+            MeasureSpec.getSize(heightMeasureSpec),
+        )
+    }
+
+    override fun onLayout(
+        changed: Boolean,
+        left: Int,
+        top: Int,
+        right: Int,
+        bottom: Int,
+    ) = Unit
+
+    private fun present(config: FormSheetConfig) {
+        val newDialog =
+            object : BottomSheetDialog(context) {
+                override fun cancel() {
+                    val behavior = sheetBehavior
+                    if (dialog === this &&
+                        isPresented &&
+                        behavior?.state == FormSheetBehavior.STATE_HIDDEN &&
+                        latestConfig?.preventsNativeDismiss(FormSheetDismissChannel.DRAG) == true
+                    ) {
+                        recoverPreventedDragDismiss(behavior)
+                        return
+                    }
+                    super.cancel()
+                }
+            }
+        dialog = newDialog
+        hasEmittedWillDisappear = false
+        lastEmittedDetentIndex = -1
+        defaultBottomSheetBackground = null
+        recoveringPreventedDragDismiss = false
+        presentationAnimationPending = true
+        presentationAnimationRunning = false
+        dismissAnimationRunning = false
+        pendingBackdropAlpha = 0f
+        presentationTargetDetentIndex = null
+        hasEmittedDidAppear = false
+        nativeDismissEventEmitted = false
+        programmaticDismissPending = false
+        dismissAnimator = null
+
+        (sheetContainer.parent as? ViewGroup)?.removeView(sheetContainer)
+        newDialog.setContentView(sheetContainer)
+        val bottomSheet =
+            newDialog.findViewById<FrameLayout>(com.google.android.material.R.id.design_bottom_sheet)
+                ?: run {
+                    dialog = null
+                    return
+                }
+        val layoutParams = bottomSheet.layoutParams as CoordinatorLayout.LayoutParams
+        sheetBehavior = FormSheetBehavior<FrameLayout>().also { layoutParams.behavior = it }
+        bottomSheet.layoutParams = layoutParams
+        // Material couples cancelable, outside taps, back and drag-to-hide. Keep
+        // its user cancellation disabled and route each channel explicitly.
+        newDialog.setCancelable(false)
+        newDialog.setCanceledOnTouchOutside(false)
+        newDialog.window?.let(::configureDialogWindow)
+        installBackdrop(newDialog)
+        bottomSheet.translationY = resources.displayMetrics.heightPixels.toFloat()
+        newDialog.setOnCancelListener {
+            nativeDismissedForCurrentRequest = true
+            if (!suppressDismissEvents && !nativeDismissEventEmitted) {
+                eventEmitter?.emitOnNativeDismiss()
+            }
+            emitOnWillDisappearIfNeeded()
+        }
+        newDialog.setOnDismissListener {
+            if (dialog !== newDialog || !isPresented) {
+                return@setOnDismissListener
+            }
+            emitOnWillDisappearIfNeeded()
+            isPresented = false
+            val emitProgrammaticDismiss = programmaticDismissPending
+            programmaticDismissPending = false
+            if (dialog === newDialog) {
+                dialog = null
+                sheetBehavior = null
+                presentationAnimationPending = false
+                presentationAnimationRunning = false
+                presentationTargetDetentIndex = null
+                dismissAnimationRunning = false
+                dismissAnimator?.cancel()
+                dismissAnimator = null
+            }
+            eventEmitter?.emitOnDidDisappear()
+            if (emitProgrammaticDismiss && !suppressDismissEvents) {
+                eventEmitter?.emitOnDismiss()
+            }
+        }
+        newDialog.setOnKeyListener { _, keyCode, keyEvent ->
+            if (keyCode != KeyEvent.KEYCODE_BACK || keyEvent.action != KeyEvent.ACTION_UP) {
+                false
+            } else {
+                requestNativeDismiss(FormSheetDismissChannel.BACK, newDialog)
+                true
+            }
+        }
+
+        eventEmitter?.emitOnWillAppear()
+        val currentConfig = latestConfig ?: config
+        if (!currentConfig.isOpen) {
+            dialog = null
+            sheetBehavior = null
+            return
+        }
+        configurePresentedSheet(currentConfig, applyInitialDetent = true)
+        isPresented = true
+        newDialog.show()
+        newDialog.window?.let(::configureDialogWindow)
+        installWindowInsetsListener(newDialog)
+        newDialog.window?.decorView?.post {
+            if (dialog === newDialog && isPresented) {
+                if (latestConfig?.isOpen == true && !dismissAnimationRunning) {
+                    startPresentationAnimation(newDialog)
+                }
+            }
+        }
+    }
+
+    private fun dismissProgrammatically() {
+        dialog?.let { dismissWithAnimation(it, isNativeDismiss = false) }
+    }
+
+    private fun configurePresentedSheet(
+        config: FormSheetConfig,
+        applyInitialDetent: Boolean,
+    ) {
+        val currentDialog = dialog ?: return
+        val bottomSheet =
+            currentDialog.findViewById<FrameLayout>(com.google.android.material.R.id.design_bottom_sheet)
+                ?: return
+        val windowHeight = currentDialog.window?.decorView?.height?.takeIf { it > 0 }
+            ?: resources.displayMetrics.heightPixels
+        val geometry =
+            config.detents.resolveGeometry(
+                windowHeight = windowHeight,
+            )
+        val sheetDetentHeights = geometry.sheetHeights
+        currentDetentHeights = sheetDetentHeights
+
+        grabber.visibility = if (config.prefersGrabberVisible) View.VISIBLE else View.GONE
+        applyAppearance(bottomSheet, config)
+
+        val behavior = sheetBehavior ?: return
+        currentDialog.setCancelable(false)
+        currentDialog.setCanceledOnTouchOutside(false)
+        behavior.isHideable =
+            !config.preventsNativeDismiss(FormSheetDismissChannel.DRAG) ||
+            !config.preventNativeDismissDragFeedback
+        behavior.setCallback(bottomSheetCallback)
+        currentDetentsCount = config.detents.count
+
+        if (config.detents.isFitToContents) {
+            if (presentationAnimationPending || presentationAnimationRunning) {
+                presentationTargetDetentIndex = 0
+            }
+            bottomSheet.layoutParams.height = LayoutParams.WRAP_CONTENT
+            sheetContainer.layoutParams.height = LayoutParams.WRAP_CONTENT
+            sheetContent.layoutParams.height = LayoutParams.WRAP_CONTENT
+            behavior.setDetents(emptyList(), fitToContents = true)
+            behavior.state = FormSheetBehavior.STATE_EXPANDED
+            lastEmittedDetentIndex = 0
+            updateDimming(bottomSheet)
+            requestSheetLayoutUpdate(bottomSheet)
+            return
+        }
+
+        val largestSheetHeight = sheetDetentHeights.last().coerceAtLeast(1)
+        bottomSheet.layoutParams.height = largestSheetHeight
+        sheetContainer.layoutParams.height = largestSheetHeight
+        sheetContent.layoutParams.height = LayoutParams.MATCH_PARENT
+        behavior.setDetents(sheetDetentHeights, fitToContents = false)
+        val requestedIndex = requestedDetentIndex(config, applyInitialDetent)
+        val targetIndex =
+            requestedIndex?.let {
+                (if (it == -1) config.detents.count - 1 else it).coerceIn(0, config.detents.count - 1)
+            }
+        if (presentationAnimationPending || presentationAnimationRunning) {
+            presentationTargetDetentIndex = targetIndex
+        }
+        if (config.detents.count == 1) {
+            if (presentationAnimationPending || presentationAnimationRunning) {
+                presentationTargetDetentIndex = 0
+            }
+            behavior.state = FormSheetBehavior.STATE_EXPANDED
+        } else {
+            requestedIndex?.let {
+                behavior.state = stateForIndex(it, config.detents.count)
+            }
+        }
+        val appliedIndex = stateToDetentIndex(behavior.state, config.detents.count)
+        if (appliedIndex >= 0) {
+            lastEmittedDetentIndex = appliedIndex
+        }
+        updateDimming(bottomSheet)
+        bottomSheet.requestLayout()
+        requestSheetLayoutUpdate(bottomSheet)
+    }
+
+    private fun updateDimming(bottomSheet: View) {
+        val currentDialog = dialog ?: return
+        val backdrop =
+            currentDialog.findViewById<View>(com.google.android.material.R.id.touch_outside)
+                ?: return
+        val window = currentDialog.window ?: return
+        val visibleHeight =
+            resolveFormSheetDimHeight(
+                visibleSheetHeight = visibleSheetHeight(bottomSheet, window.decorView.height),
+                detentHeights = currentDetentHeights,
+                presentationTargetDetentIndex = presentationTargetDetentIndex,
+            )
+        val dimAmount =
+            calculateFormSheetDimAmount(
+                visibleSheetHeight = visibleHeight,
+                detentHeights = currentDetentHeights,
+                largestUndimmedDetentIndex = latestConfig?.largestUndimmedDetentIndex ?: -1,
+                maximumDimAmount = DEFAULT_DIM_AMOUNT,
+            )
+
+        if (presentationAnimationPending || presentationAnimationRunning) {
+            val targetChanged = abs(pendingBackdropAlpha - dimAmount) > DIM_AMOUNT_EPSILON
+            pendingBackdropAlpha = dimAmount
+            if (presentationAnimationRunning && targetChanged) {
+                val elapsed = android.os.SystemClock.uptimeMillis() - presentationAnimationStartedAt
+                val remaining = (SHEET_ANIMATION_DURATION_MS - elapsed).coerceAtLeast(0L)
+                backdrop.animate()
+                    .alpha(dimAmount)
+                    .setDuration(remaining)
+                    .setInterpolator(SHEET_ANIMATION_INTERPOLATOR)
+                    .start()
+            }
+            return
+        }
+        if (dismissAnimationRunning) {
+            return
+        }
+        if (abs(backdrop.alpha - dimAmount) > DIM_AMOUNT_EPSILON) {
+            backdrop.alpha = dimAmount
+        }
+    }
+
+    private fun applyAppearance(
+        bottomSheet: FrameLayout,
+        config: FormSheetConfig,
+    ) {
+        if (defaultBottomSheetBackground == null) {
+            defaultBottomSheetBackground = bottomSheet.background
+        }
+        val backgroundColor = config.nativeContainerBackgroundColor ?: Color.TRANSPARENT
+        sheetContainer.setBackgroundColor(Color.TRANSPARENT)
+        sheetContent.setBackgroundColor(backgroundColor)
+        bottomSheet.backgroundTintList = ColorStateList.valueOf(Color.TRANSPARENT)
+
+        if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.TIRAMISU && config.preferredCornerRadius >= 0) {
+            val cornerRadius = config.preferredCornerRadius * resources.displayMetrics.density
+            bottomSheet.background =
+                GradientDrawable().apply {
+                    shape = GradientDrawable.RECTANGLE
+                    cornerRadii =
+                        floatArrayOf(
+                            cornerRadius,
+                            cornerRadius,
+                            cornerRadius,
+                            cornerRadius,
+                            0f,
+                            0f,
+                            0f,
+                            0f,
+                        )
+                    setColor(Color.TRANSPARENT)
+                }
+            bottomSheet.clipToOutline = true
+        } else if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.TIRAMISU) {
+            bottomSheet.background = defaultBottomSheetBackground
+            bottomSheet.clipToOutline = false
+        }
+    }
+
+    private fun stateForIndex(
+        rawIndex: Int,
+        count: Int,
+    ): Int {
+        val index = (if (rawIndex == -1) count - 1 else rawIndex).coerceIn(0, count - 1)
+        return when (count) {
+            2 -> if (index == 0) FormSheetBehavior.STATE_COLLAPSED else FormSheetBehavior.STATE_EXPANDED
+            3 ->
+                when (index) {
+                    0 -> FormSheetBehavior.STATE_COLLAPSED
+                    1 -> FormSheetBehavior.STATE_HALF_EXPANDED
+                    else -> FormSheetBehavior.STATE_EXPANDED
+                }
+            else -> FormSheetBehavior.STATE_EXPANDED
+        }
+    }
+
+    private fun requestedDetentIndex(
+        config: FormSheetConfig,
+        applyInitialDetent: Boolean,
+    ): Int? =
+        when {
+            config.selectedDetentIndex >= -1 -> config.selectedDetentIndex
+            applyInitialDetent -> config.initialDetentIndex
+            else -> null
+        }
+
+    private fun stateToDetentIndex(
+        state: Int,
+        count: Int,
+    ): Int =
+        when (count) {
+            1 ->
+                if (state == FormSheetBehavior.STATE_EXPANDED || state == FormSheetBehavior.STATE_COLLAPSED) {
+                    0
+                } else {
+                    -1
+                }
+            2 ->
+                when (state) {
+                    FormSheetBehavior.STATE_COLLAPSED -> 0
+                    FormSheetBehavior.STATE_EXPANDED -> 1
+                    else -> -1
+                }
+            3 ->
+                when (state) {
+                    FormSheetBehavior.STATE_COLLAPSED -> 0
+                    FormSheetBehavior.STATE_HALF_EXPANDED -> 1
+                    FormSheetBehavior.STATE_EXPANDED -> 2
+                    else -> -1
+                }
+            else -> -1
+        }
+
+    private fun emitOnWillDisappearIfNeeded() {
+        if (!hasEmittedWillDisappear) {
+            hasEmittedWillDisappear = true
+            eventEmitter?.emitOnWillDisappear()
+        }
+    }
+
+    /**
+     * A downward drag that starts at the lowest detent and settles back at the
+     * lowest detent (without having been dragged upward first) is treated as a
+     * native dismiss attempt. With `isHideable = false` the sheet cannot drop
+     * below its lowest detent, so this is the only reliable signal.
+     */
+    private fun maybeMarkDismissAttempt(settledIndex: Int) {
+        val config = latestConfig
+        if (config?.preventsNativeDismiss(FormSheetDismissChannel.DRAG) != true ||
+            !config.preventNativeDismissDragFeedback ||
+            pendingDismissPreventedEmission
+        ) {
+            return
+        }
+        val lowestIndex = 0
+        if (stateBeforeDrag != lowestIndex || settledIndex != lowestIndex) {
+            return
+        }
+        if (maxDownwardDismissDragDistance <= dismissDragDistanceThreshold) {
+            return
+        }
+        val lowestOffset = lowestDetentOffset()
+        if (maxOffsetDuringDrag > lowestOffset + DISMISS_ATTEMPT_OFFSET_THRESHOLD) {
+            return
+        }
+        pendingDismissPreventedEmission = true
+    }
+
+    private fun requestNativeDismiss(
+        channel: FormSheetDismissChannel,
+        sourceDialog: BottomSheetDialog,
+    ) {
+        if (dialog !== sourceDialog || !isPresented) {
+            return
+        }
+        if (latestConfig?.preventsNativeDismiss(channel) == true) {
+            eventEmitter?.emitOnNativeDismissPrevented(channel)
+        } else {
+            dismissWithAnimation(sourceDialog, isNativeDismiss = true)
+        }
+    }
+
+    @Suppress("DEPRECATION")
+    private fun configureDialogWindow(window: Window) {
+        WindowCompat.setDecorFitsSystemWindows(window, false)
+        window.addFlags(WindowManager.LayoutParams.FLAG_LAYOUT_IN_SCREEN)
+        window.clearFlags(WindowManager.LayoutParams.FLAG_DIM_BEHIND)
+        window.statusBarColor = Color.TRANSPARENT
+        window.navigationBarColor = Color.TRANSPARENT
+        if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.Q) {
+            window.isNavigationBarContrastEnforced = false
+        }
+        val attributes = window.attributes
+        if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.R) {
+            attributes.setFitInsetsTypes(0)
+        }
+        if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.P) {
+            attributes.layoutInDisplayCutoutMode =
+                if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.R) {
+                    WindowManager.LayoutParams.LAYOUT_IN_DISPLAY_CUTOUT_MODE_ALWAYS
+                } else {
+                    WindowManager.LayoutParams.LAYOUT_IN_DISPLAY_CUTOUT_MODE_SHORT_EDGES
+                }
+        }
+        attributes.windowAnimations = 0
+        window.attributes = attributes
+    }
+
+    private fun startPresentationAnimation(
+        sourceDialog: BottomSheetDialog,
+        startOffscreen: Boolean = true,
+    ) {
+        val bottomSheet =
+            sourceDialog.findViewById<View>(com.google.android.material.R.id.design_bottom_sheet)
+                ?: return finishPresentationWithoutAnimation(sourceDialog)
+        val backdrop =
+            sourceDialog.findViewById<View>(com.google.android.material.R.id.touch_outside)
+                ?: return finishPresentationWithoutAnimation(sourceDialog)
+        val parentHeight = (bottomSheet.parent as? View)?.height?.takeIf { it > 0 }
+            ?: sourceDialog.window?.decorView?.height?.takeIf { it > 0 }
+            ?: resources.displayMetrics.heightPixels
+
+        bottomSheet.animate().cancel()
+        backdrop.animate().cancel()
+        if (startOffscreen) {
+            bottomSheet.translationY = (parentHeight - bottomSheet.top).coerceAtLeast(0).toFloat()
+            backdrop.alpha = 0f
+        }
+        presentationAnimationPending = false
+        presentationAnimationRunning = true
+        presentationAnimationStartedAt = android.os.SystemClock.uptimeMillis()
+
+        backdrop.animate()
+            .alpha(pendingBackdropAlpha)
+            .setDuration(SHEET_ANIMATION_DURATION_MS)
+            .setInterpolator(SHEET_ANIMATION_INTERPOLATOR)
+            .start()
+        bottomSheet.animate()
+            .translationY(0f)
+            .setDuration(SHEET_ANIMATION_DURATION_MS)
+            .setInterpolator(SHEET_ANIMATION_INTERPOLATOR)
+            .withEndAction {
+                if (dialog === sourceDialog && isPresented && !dismissAnimationRunning) {
+                    presentationAnimationRunning = false
+                    presentationTargetDetentIndex = null
+                    backdrop.animate().cancel()
+                    backdrop.alpha = pendingBackdropAlpha
+                    emitOnDidAppearIfNeeded()
+                }
+            }
+            .start()
+    }
+
+    private fun finishPresentationWithoutAnimation(sourceDialog: BottomSheetDialog) {
+        presentationAnimationPending = false
+        presentationAnimationRunning = false
+        presentationTargetDetentIndex = null
+        if (dialog === sourceDialog && isPresented) {
+            emitOnDidAppearIfNeeded()
+        }
+    }
+
+    private fun emitOnDidAppearIfNeeded() {
+        if (!hasEmittedDidAppear && latestConfig?.isOpen == true) {
+            hasEmittedDidAppear = true
+            eventEmitter?.emitOnDidAppear()
+        }
+    }
+
+    private fun dismissWithAnimation(
+        sourceDialog: BottomSheetDialog,
+        isNativeDismiss: Boolean,
+    ) {
+        if (dialog !== sourceDialog || !isPresented || dismissAnimationRunning) {
+            return
+        }
+        dismissAnimationRunning = true
+        presentationAnimationPending = false
+        presentationAnimationRunning = false
+        presentationTargetDetentIndex = null
+        if (isNativeDismiss) {
+            nativeDismissedForCurrentRequest = true
+        }
+        programmaticDismissPending = !isNativeDismiss
+        if (!dismissAnimationRunning || dialog !== sourceDialog || !isPresented) {
+            return
+        }
+        emitOnWillDisappearIfNeeded()
+        if (!dismissAnimationRunning || dialog !== sourceDialog || !isPresented) {
+            return
+        }
+
+        val bottomSheet =
+            sourceDialog.findViewById<View>(com.google.android.material.R.id.design_bottom_sheet)
+        val backdrop = sourceDialog.findViewById<View>(com.google.android.material.R.id.touch_outside)
+        if (bottomSheet == null || backdrop == null) {
+            emitNativeDismissEventIfNeeded(isNativeDismiss)
+            sourceDialog.dismiss()
+            return
+        }
+        val parentHeight = (bottomSheet.parent as? View)?.height?.takeIf { it > 0 }
+            ?: sourceDialog.window?.decorView?.height?.takeIf { it > 0 }
+            ?: resources.displayMetrics.heightPixels
+
+        bottomSheet.animate().cancel()
+        backdrop.animate().cancel()
+        val startVisualTop = bottomSheet.top + bottomSheet.translationY
+        val startBackdropAlpha = backdrop.alpha
+        dismissAnimator =
+            ValueAnimator.ofFloat(0f, 1f).apply {
+                duration = SHEET_ANIMATION_DURATION_MS
+                interpolator = SHEET_ANIMATION_INTERPOLATOR
+                addUpdateListener { animator ->
+                    val progress = animator.animatedValue as Float
+                    val visualTop = startVisualTop + (parentHeight - startVisualTop) * progress
+                    bottomSheet.translationY = visualTop - bottomSheet.top
+                    backdrop.alpha = startBackdropAlpha * (1f - progress)
+                }
+                addListener(
+                    object : AnimatorListenerAdapter() {
+                        private var wasCancelled = false
+
+                        override fun onAnimationCancel(animation: Animator) {
+                            wasCancelled = true
+                        }
+
+                        override fun onAnimationEnd(animation: Animator) {
+                            if (!wasCancelled &&
+                                dialog === sourceDialog &&
+                                isPresented &&
+                                dismissAnimationRunning
+                            ) {
+                                emitNativeDismissEventIfNeeded(isNativeDismiss)
+                                sourceDialog.dismiss()
+                            }
+                        }
+                    },
+                )
+                start()
+            }
+    }
+
+    private fun emitNativeDismissEventIfNeeded(isNativeDismiss: Boolean) {
+        if (isNativeDismiss && !nativeDismissEventEmitted) {
+            nativeDismissEventEmitted = true
+            if (!suppressDismissEvents) {
+                eventEmitter?.emitOnNativeDismiss()
+            }
+        }
+    }
+
+    private fun cancelDismissAndPresent(config: FormSheetConfig) {
+        val sourceDialog = dialog ?: return
+        val bottomSheet =
+            sourceDialog.findViewById<View>(com.google.android.material.R.id.design_bottom_sheet)
+                ?: return
+        val visualTop = bottomSheet.top + bottomSheet.translationY
+
+        dismissAnimator?.cancel()
+        dismissAnimator = null
+        dismissAnimationRunning = false
+        nativeDismissedForCurrentRequest = false
+        nativeDismissEventEmitted = false
+        programmaticDismissPending = false
+        hasEmittedWillDisappear = false
+        presentationAnimationPending = true
+        configurePresentedSheet(config, applyInitialDetent = false)
+        bottomSheet.translationY = visualTop - bottomSheet.top
+        startPresentationAnimation(sourceDialog, startOffscreen = false)
+    }
+
+    @SuppressLint("ClickableViewAccessibility")
+    private fun installBackdrop(sourceDialog: BottomSheetDialog) {
+        val touchOutside =
+            sourceDialog.findViewById<View>(com.google.android.material.R.id.touch_outside)
+                ?: return
+        touchOutside.setBackgroundColor(Color.BLACK)
+        touchOutside.alpha = 0f
+        var startedOutsideSheet = false
+        val detector =
+            GestureDetector(
+                context,
+                object : GestureDetector.SimpleOnGestureListener() {
+                    override fun onDown(event: MotionEvent): Boolean {
+                        startedOutsideSheet = isOutsideSheet(sourceDialog, event)
+                        return startedOutsideSheet
+                    }
+
+                    override fun onSingleTapUp(event: MotionEvent): Boolean {
+                        if (!startedOutsideSheet || !isOutsideSheet(sourceDialog, event)) {
+                            return false
+                        }
+                        requestNativeDismiss(FormSheetDismissChannel.BACKDROP, sourceDialog)
+                        return true
+                    }
+                },
+            )
+
+        touchOutside.setOnClickListener(null)
+        touchOutside.setOnTouchListener { _, event ->
+            detector.onTouchEvent(event)
+            true
+        }
+    }
+
+    private fun isOutsideSheet(
+        sourceDialog: BottomSheetDialog,
+        event: MotionEvent,
+    ): Boolean {
+        val bottomSheet =
+            sourceDialog.findViewById<View>(com.google.android.material.R.id.design_bottom_sheet)
+                ?: return false
+        val bounds = Rect()
+        if (!bottomSheet.getGlobalVisibleRect(bounds)) {
+            return false
+        }
+        return !bounds.contains(event.rawX.toInt(), event.rawY.toInt())
+    }
+
+    private fun recoverPreventedDragDismiss(behavior: FormSheetBehavior<*>) {
+        if (recoveringPreventedDragDismiss) {
+            return
+        }
+        recoveringPreventedDragDismiss = true
+        eventEmitter?.emitOnNativeDismissPrevented(FormSheetDismissChannel.DRAG)
+        behavior.state = stateForIndex(0, currentDetentsCount)
+    }
+
+    private fun requestSheetLayoutUpdate(bottomSheet: View) {
+        dialog?.window?.decorView?.let(ViewCompat::requestApplyInsets)
+        bottomSheet.post {
+            if (bottomSheet === currentBottomSheet()) {
+                updateSheetSurfaceLayout(bottomSheet)
+                updateDimming(bottomSheet)
+            }
+        }
+    }
+
+    private fun currentBottomSheet(): FrameLayout? =
+        dialog?.findViewById(com.google.android.material.R.id.design_bottom_sheet)
+
+    private fun installWindowInsetsListener(sourceDialog: BottomSheetDialog) {
+        val decorView = sourceDialog.window?.decorView ?: return
+        val bottomSheet = sourceDialog.findViewById<FrameLayout>(com.google.android.material.R.id.design_bottom_sheet)
+        val coordinator = bottomSheet?.parent as? View
+        val container = coordinator?.parent as? View
+        val clearMaterialSystemBarInsets = {
+            container?.fitsSystemWindows = false
+            coordinator?.fitsSystemWindows = false
+            bottomSheet?.fitsSystemWindows = false
+            container?.setPadding(0, 0, 0, 0)
+            coordinator?.setPadding(0, 0, 0, 0)
+            bottomSheet?.setPadding(0, 0, 0, 0)
+            container?.requestLayout()
+        }
+
+        // BottomSheetDialog configures these ancestors before show(). Disable
+        // fitsSystemWindows and remove the padding it already applied.
+        clearMaterialSystemBarInsets()
+        ViewCompat.setOnApplyWindowInsetsListener(decorView) { _, insets ->
+            if (dialog === sourceDialog) {
+                clearMaterialSystemBarInsets()
+                updateSheetSurfaceLayout(bottomSheet)
+                decorView.post {
+                    if (dialog === sourceDialog) {
+                        // Child listeners run after the decor listener and may
+                        // reapply Material's inset padding during this dispatch.
+                        clearMaterialSystemBarInsets()
+                        updateSheetSurfaceLayout(bottomSheet)
+                    }
+                }
+            }
+            insets
+        }
+        ViewCompat.requestApplyInsets(decorView)
+    }
+
+    private fun trackPotentialDismissDrag(event: MotionEvent) {
+        when (event.actionMasked) {
+            MotionEvent.ACTION_DOWN -> {
+                dismissDragStartRawY = event.rawY
+                maxDownwardDismissDragDistance = 0f
+            }
+            MotionEvent.ACTION_MOVE,
+            MotionEvent.ACTION_UP,
+            MotionEvent.ACTION_CANCEL,
+            -> {
+                if (!dismissDragStartRawY.isNaN()) {
+                    maxDownwardDismissDragDistance =
+                        maxOf(maxDownwardDismissDragDistance, event.rawY - dismissDragStartRawY)
+                }
+            }
+        }
+    }
+
+    private fun updateSheetSurfaceLayout(bottomSheet: View?) {
+        if (latestConfig?.detents?.isFitToContents == true && bottomSheet != null && bottomSheet.height > 0) {
+            currentDetentHeights = listOf(bottomSheet.height)
+        }
+
+        // Material can apply system-bar padding to the internal sheet through
+        // theme flags. Insets belong exclusively to the content host here.
+        if (bottomSheet != null &&
+            (bottomSheet.paddingLeft != 0 ||
+                bottomSheet.paddingTop != 0 ||
+                bottomSheet.paddingRight != 0 ||
+                bottomSheet.paddingBottom != 0)
+        ) {
+            bottomSheet.setPadding(0, 0, 0, 0)
+        }
+
+        val containerLayoutParams = sheetContainer.layoutParams as FrameLayout.LayoutParams
+        val containerHeight =
+            if (latestConfig?.detents?.isFitToContents == false && bottomSheet != null) {
+                val parentHeight = (bottomSheet.parent as? View)?.height ?: 0
+                visibleSheetSurfaceHeight(
+                    parentHeight = parentHeight,
+                    sheetTop = bottomSheet.top,
+                    maximumHeight = bottomSheet.height,
+                )
+            } else {
+                containerLayoutParams.height
+            }
+        if (containerLayoutParams.height != containerHeight ||
+            containerLayoutParams.leftMargin != 0 ||
+            containerLayoutParams.rightMargin != 0 ||
+            containerLayoutParams.bottomMargin != 0
+        ) {
+            containerLayoutParams.height = containerHeight
+            containerLayoutParams.leftMargin = 0
+            containerLayoutParams.rightMargin = 0
+            containerLayoutParams.bottomMargin = 0
+            sheetContainer.layoutParams = containerLayoutParams
+        }
+
+        val grabberLayoutParams = grabber.layoutParams as FrameLayout.LayoutParams
+        if (grabberLayoutParams.topMargin != dp(8)) {
+            grabberLayoutParams.topMargin = dp(8)
+            grabber.layoutParams = grabberLayoutParams
+        }
+    }
+
+    private fun visibleSheetHeight(
+        bottomSheet: View,
+        fallbackParentHeight: Int,
+    ): Int {
+        val parentHeight = (bottomSheet.parent as? View)?.height?.takeIf { it > 0 }
+            ?: fallbackParentHeight
+        return (parentHeight - bottomSheet.top).coerceAtLeast(0)
+    }
+
+    private fun lowestDetentOffset(): Float =
+        when (currentDetentsCount) {
+            // With a single detent the sheet rests at the expanded (top) position.
+            1 -> 1f
+            else -> 0f
+        }
+
+    private fun dp(value: Int): Int = (value * resources.displayMetrics.density).roundToInt()
+
+    private companion object {
+        val SHEET_ANIMATION_INTERPOLATOR = AccelerateDecelerateInterpolator()
+        const val SHEET_ANIMATION_DURATION_MS = 300L
+        const val DEFAULT_DIM_AMOUNT = 0.5f
+        const val DIM_AMOUNT_EPSILON = 0.001f
+        const val DISMISS_ATTEMPT_OFFSET_THRESHOLD = 0.1f
+    }
+
+    private class SheetContentView(
+        context: LynxContext,
+        transfer: BaseUITransfer<*>,
+    ) : BaseUITransfer.BaseTransferContentView(context, transfer) {
+        override fun onMeasure(
+            widthMeasureSpec: Int,
+            heightMeasureSpec: Int,
+        ) {
+            // Propagate the sheet constraints to the transfer ShadowNode and remeasure the Lynx subtree.
+            super.onMeasure(widthMeasureSpec, heightMeasureSpec)
+            val contentWidth = (0 until childCount).maxOfOrNull { getChildAt(it).right } ?: 0
+            val contentHeight = (0 until childCount).maxOfOrNull { getChildAt(it).bottom } ?: 0
+            setMeasuredDimension(
+                resolveSize(contentWidth, widthMeasureSpec),
+                resolveSize(contentHeight, heightMeasureSpec),
+            )
+        }
+
+    }
+}

--- a/android/src/main/java/com/lynxscreens/screens/formsheet/FormSheetShadowNode.kt
+++ b/android/src/main/java/com/lynxscreens/screens/formsheet/FormSheetShadowNode.kt
@@ -1,0 +1,7 @@
+package com.lynxscreens.screens.formsheet
+
+import com.lynx.tasm.behavior.LynxShadowNode
+import com.lynxscreens.screens.common.BaseTransferShadowNode
+
+@LynxShadowNode(tagName = "form-sheet-native")
+internal class FormSheetShadowNode : BaseTransferShadowNode()

--- a/android/src/test/java/com/lynxscreens/screens/formsheet/FormSheetAnchorsTest.kt
+++ b/android/src/test/java/com/lynxscreens/screens/formsheet/FormSheetAnchorsTest.kt
@@ -1,0 +1,76 @@
+package com.lynxscreens.screens.formsheet
+
+import org.junit.Assert.assertEquals
+import org.junit.Test
+
+class FormSheetAnchorsTest {
+    @Test
+    fun `three detents resolve to their exact screen heights`() {
+        assertEquals(
+            listOf(0, 400, 700),
+            resolveFormSheetAnchorTops(
+                parentHeight = 1000,
+                sheetHeight = 1000,
+                detentHeights = listOf(300, 600, 1000),
+                fitToContents = false,
+            ),
+        )
+    }
+
+    @Test
+    fun `release direction selects the next detent`() {
+        val anchors = listOf(0, 400, 700)
+
+        assertEquals(
+            400,
+            selectFormSheetAnchorTop(anchors, currentTop = 200, verticalVelocity = 100f, minimumFlingVelocity = 50f),
+        )
+        assertEquals(
+            400,
+            selectFormSheetAnchorTop(anchors, currentTop = 600, verticalVelocity = -100f, minimumFlingVelocity = 50f),
+        )
+        assertEquals(
+            700,
+            selectFormSheetAnchorTop(anchors, currentTop = 620, verticalVelocity = 10f, minimumFlingVelocity = 50f),
+        )
+    }
+
+    @Test
+    fun `fit to contents uses the measured sheet height`() {
+        assertEquals(
+            listOf(650),
+            resolveFormSheetAnchorTops(
+                parentHeight = 1000,
+                sheetHeight = 350,
+                detentHeights = emptyList(),
+                fitToContents = true,
+            ),
+        )
+    }
+
+    @Test
+    fun `pixel rounding keeps each configured detent addressable`() {
+        assertEquals(
+            listOf(0, 1, 2),
+            resolveFormSheetAnchorTops(
+                parentHeight = 1000,
+                sheetHeight = 1000,
+                detentHeights = listOf(999, 1000, 1000),
+                fitToContents = false,
+            ),
+        )
+    }
+
+    @Test
+    fun `tiny parent does not fail while resolving anchors`() {
+        assertEquals(
+            listOf(0, 0, 1),
+            resolveFormSheetAnchorTops(
+                parentHeight = 1,
+                sheetHeight = 1,
+                detentHeights = listOf(0, 1, 1),
+                fitToContents = false,
+            ),
+        )
+    }
+}

--- a/android/src/test/java/com/lynxscreens/screens/formsheet/FormSheetDetentsTest.kt
+++ b/android/src/test/java/com/lynxscreens/screens/formsheet/FormSheetDetentsTest.kt
@@ -1,0 +1,16 @@
+package com.lynxscreens.screens.formsheet
+
+import org.junit.Assert.assertEquals
+import org.junit.Test
+
+class FormSheetDetentsTest {
+    @Test
+    fun `sheet detents use the edge to edge window`() {
+        val detents = FormSheetDetents.parse(listOf(0.2, 0.4, 0.8))
+        val geometry = detents.resolveGeometry(windowHeight = 1200)
+
+        assertEquals(1200, geometry.availableHeight)
+        assertEquals(listOf(240, 480, 960), geometry.sheetHeights)
+        assertEquals(480, visibleSheetSurfaceHeight(1200, 720, 960))
+    }
+}

--- a/android/src/test/java/com/lynxscreens/screens/formsheet/FormSheetDimmingTest.kt
+++ b/android/src/test/java/com/lynxscreens/screens/formsheet/FormSheetDimmingTest.kt
@@ -1,0 +1,91 @@
+package com.lynxscreens.screens.formsheet
+
+import org.junit.Assert.assertEquals
+import org.junit.Test
+
+class FormSheetDimmingTest {
+    @Test
+    fun `pending presentation dims for the selected detent`() {
+        assertEquals(
+            600,
+            resolveFormSheetDimHeight(
+                visibleSheetHeight = 300,
+                detentHeights = listOf(300, 600),
+                presentationTargetDetentIndex = 1,
+            ),
+        )
+    }
+
+    @Test
+    fun `dimming without a presentation target tracks the visible sheet height`() {
+        assertEquals(
+            450,
+            resolveFormSheetDimHeight(
+                visibleSheetHeight = 450,
+                detentHeights = listOf(300, 600),
+                presentationTargetDetentIndex = null,
+            ),
+        )
+    }
+
+    @Test
+    fun `dim amount interpolates above the largest undimmed detent`() {
+        val detents = listOf(300, 600, 900)
+
+        assertDimAmount(0f, visibleHeight = 300, detents = detents, largestUndimmedIndex = 0)
+        assertDimAmount(0.25f, visibleHeight = 450, detents = detents, largestUndimmedIndex = 0)
+        assertDimAmount(0.5f, visibleHeight = 600, detents = detents, largestUndimmedIndex = 0)
+        assertDimAmount(0.5f, visibleHeight = 900, detents = detents, largestUndimmedIndex = 0)
+    }
+
+    @Test
+    fun `always dimmed backdrop fades across the full dismiss drag`() {
+        val detents = listOf(300, 600)
+
+        assertDimAmount(0.5f, visibleHeight = 300, detents = detents, largestUndimmedIndex = -1)
+        assertDimAmount(0.375f, visibleHeight = 225, detents = detents, largestUndimmedIndex = -1)
+        assertDimAmount(0.25f, visibleHeight = 150, detents = detents, largestUndimmedIndex = -1)
+        assertDimAmount(0.125f, visibleHeight = 75, detents = detents, largestUndimmedIndex = -1)
+        assertDimAmount(0f, visibleHeight = 0, detents = detents, largestUndimmedIndex = -1)
+    }
+
+    @Test
+    fun `never dimmed backdrop remains clear`() {
+        assertDimAmount(0f, visibleHeight = 600, detents = listOf(300, 600), largestUndimmedIndex = -2)
+    }
+
+    @Test
+    fun `unresolved controlled dimming starts clear`() {
+        assertDimAmount(0f, visibleHeight = 600, detents = emptyList(), largestUndimmedIndex = 0)
+    }
+
+    @Test
+    fun `small detent fades completely before becoming hidden`() {
+        assertDimAmount(0.25f, visibleHeight = 15, detents = listOf(30), largestUndimmedIndex = -1)
+        assertDimAmount(0f, visibleHeight = 0, detents = listOf(30), largestUndimmedIndex = -1)
+    }
+
+    @Test
+    fun `zero height detent fades as it approaches hidden`() {
+        assertDimAmount(0.25f, visibleHeight = 150, detents = listOf(0, 300), largestUndimmedIndex = -1)
+        assertDimAmount(0f, visibleHeight = 0, detents = listOf(0, 300), largestUndimmedIndex = -1)
+    }
+
+    private fun assertDimAmount(
+        expected: Float,
+        visibleHeight: Int,
+        detents: List<Int>,
+        largestUndimmedIndex: Int,
+    ) {
+        assertEquals(
+            expected,
+            calculateFormSheetDimAmount(
+                visibleSheetHeight = visibleHeight,
+                detentHeights = detents,
+                largestUndimmedDetentIndex = largestUndimmedIndex,
+                maximumDimAmount = 0.5f,
+            ),
+            0.0001f,
+        )
+    }
+}

--- a/android/src/test/java/com/lynxscreens/screens/formsheet/FormSheetDismissConfigTest.kt
+++ b/android/src/test/java/com/lynxscreens/screens/formsheet/FormSheetDismissConfigTest.kt
@@ -1,0 +1,36 @@
+package com.lynxscreens.screens.formsheet
+
+import com.lynx.react.bridge.Dynamic
+import com.lynx.react.bridge.DynamicFromArray
+import com.lynx.react.bridge.JavaOnlyArray
+import org.junit.Assert.assertEquals
+import org.junit.Test
+
+class FormSheetDismissConfigTest {
+    @Test
+    fun `true prevents every native dismiss channel`() {
+        assertEquals(
+            FormSheetDismissChannel.values().toSet(),
+            parsePreventNativeDismissChannels(dynamic(true)),
+        )
+    }
+
+    @Test
+    fun `false and null do not prevent native dismissal`() {
+        assertEquals(emptySet<FormSheetDismissChannel>(), parsePreventNativeDismissChannels(dynamic(false)))
+        assertEquals(emptySet<FormSheetDismissChannel>(), parsePreventNativeDismissChannels(null))
+    }
+
+    @Test
+    fun `array prevents only recognized channels`() {
+        assertEquals(
+            setOf(FormSheetDismissChannel.BACK, FormSheetDismissChannel.DRAG),
+            parsePreventNativeDismissChannels(
+                dynamic(JavaOnlyArray.of("back", "drag", "unknown", 1)),
+            ),
+        )
+    }
+
+    private fun dynamic(value: Any): Dynamic =
+        DynamicFromArray(JavaOnlyArray.of(value), 0)
+}

--- a/ios/LynxScreens.podspec
+++ b/ios/LynxScreens.podspec
@@ -17,7 +17,7 @@ Pod::Spec.new do |s|
   # modular_headers-based autolinking setup relies on.
   s.static_framework = true
 
-  s.source_files = 'host/**/*.{h,m,mm}', 'screen/**/*.{h,m,mm}'
+  s.source_files = 'common/**/*.{h,m,mm}', 'host/**/*.{h,m,mm}', 'screen/**/*.{h,m,mm}', 'formsheet/**/*.{h,m,mm}'
 
   s.dependency 'Lynx'
 end

--- a/ios/common/BaseTransferShadowNode.h
+++ b/ios/common/BaseTransferShadowNode.h
@@ -1,0 +1,16 @@
+#import <Lynx/LynxCustomMeasureShadowNode.h>
+
+NS_ASSUME_NONNULL_BEGIN
+
+/** ShadowNode that lays out transferred Lynx children with native receiver constraints. */
+@interface BaseTransferShadowNode : LynxCustomMeasureShadowNode
+
+/** Updates the native receiver constraints used for the next Lynx child layout pass. */
+- (void)updateHostConstraintsWithWidth:(CGFloat)width
+                             widthMode:(LynxMeasureMode)widthMode
+                                height:(CGFloat)height
+                            heightMode:(LynxMeasureMode)heightMode;
+
+@end
+
+NS_ASSUME_NONNULL_END

--- a/ios/common/BaseTransferShadowNode.mm
+++ b/ios/common/BaseTransferShadowNode.mm
@@ -1,0 +1,74 @@
+#import "BaseTransferShadowNode.h"
+
+#import <Lynx/LynxCustomMeasureDelegate.h>
+#import <Lynx/LynxNativeLayoutNode.h>
+
+@implementation BaseTransferShadowNode {
+    CGFloat _hostWidth;
+    LynxMeasureMode _hostWidthMode;
+    CGFloat _hostHeight;
+    LynxMeasureMode _hostHeightMode;
+}
+
+- (instancetype)initWithSign:(NSInteger)sign tagName:(NSString *)tagName
+{
+    if (self = [super initWithSign:sign tagName:tagName]) {
+        self.hasCustomLayout = YES;
+        _hostWidthMode = LynxMeasureModeIndefinite;
+        _hostHeightMode = LynxMeasureModeIndefinite;
+    }
+    return self;
+}
+
+- (void)updateHostConstraintsWithWidth:(CGFloat)width
+                             widthMode:(LynxMeasureMode)widthMode
+                                height:(CGFloat)height
+                            heightMode:(LynxMeasureMode)heightMode
+{
+    if (fabs(_hostWidth - width) <= CGFLOAT_EPSILON &&
+        _hostWidthMode == widthMode &&
+        fabs(_hostHeight - height) <= CGFLOAT_EPSILON &&
+        _hostHeightMode == heightMode) {
+        return;
+    }
+
+    _hostWidth = width;
+    _hostWidthMode = widthMode;
+    _hostHeight = height;
+    _hostHeightMode = heightMode;
+    [self setNeedsLayout];
+}
+
+- (MeasureResult)customMeasureLayoutNode:(MeasureParam *)param
+                          measureContext:(MeasureContext *)context
+{
+    MeasureParam *childParam =
+        [[MeasureParam alloc] initWithWidth:_hostWidthMode == LynxMeasureModeIndefinite ? param.width : _hostWidth
+                                 WidthMode:_hostWidthMode == LynxMeasureModeIndefinite ? param.widthMode : _hostWidthMode
+                                    Height:_hostHeightMode == LynxMeasureModeIndefinite ? param.height : _hostHeight
+                                HeightMode:_hostHeightMode == LynxMeasureModeIndefinite ? param.heightMode : _hostHeightMode];
+    for (LynxShadowNode *child in self.children) {
+        if ([child isKindOfClass:LynxNativeLayoutNode.class]) {
+            [(LynxNativeLayoutNode *)child measureWithMeasureParam:childParam MeasureContext:context];
+        } else if ([child isKindOfClass:LynxCustomMeasureShadowNode.class]) {
+            [(id<LynxCustomMeasureDelegate>)child measureWithMeasureParam:childParam
+                                                           MeasureContext:context];
+        }
+    }
+    return (MeasureResult){CGSizeZero, 0.f};
+}
+
+- (void)customAlignLayoutNode:(AlignParam *)param alignContext:(AlignContext *)context
+{
+    AlignParam *childParam = [AlignParam new];
+    [childParam SetAlignOffsetWithLeft:0.f Top:0.f];
+    for (LynxShadowNode *child in self.children) {
+        if ([child isKindOfClass:LynxNativeLayoutNode.class]) {
+            [(LynxNativeLayoutNode *)child alignWithAlignParam:childParam AlignContext:context];
+        } else if ([child isKindOfClass:LynxCustomMeasureShadowNode.class]) {
+            [(id<LynxCustomMeasureDelegate>)child alignWithAlignParam:childParam AlignContext:context];
+        }
+    }
+}
+
+@end

--- a/ios/common/BaseTransferUI.h
+++ b/ios/common/BaseTransferUI.h
@@ -1,0 +1,29 @@
+#import <Lynx/LynxUIView.h>
+#import <UIKit/UIKit.h>
+
+NS_ASSUME_NONNULL_BEGIN
+
+@class BaseTransferUI;
+
+/** Native receiver that hosts Lynx child views outside their original view hierarchy. */
+@interface BaseTransferReceiverView : UIView
+
+/** The transfer UI whose Lynx subtree is hosted by this receiver. */
+@property (nonatomic, weak, readonly) BaseTransferUI *transfer;
+
+- (instancetype)initWithTransfer:(BaseTransferUI *)transfer;
+
+@end
+
+/** Base Lynx UI for native components that render their children in another native hierarchy. */
+@interface BaseTransferUI : LynxUIView
+
+/** Receiver containing the transferred Lynx child views. */
+@property (nonatomic, strong, readonly) BaseTransferReceiverView *transferReceiver;
+
+/** Override to provide a specialized receiver view. */
+- (BaseTransferReceiverView *)createTransferReceiver;
+
+@end
+
+NS_ASSUME_NONNULL_END

--- a/ios/common/BaseTransferUI.mm
+++ b/ios/common/BaseTransferUI.mm
@@ -1,0 +1,129 @@
+#import "BaseTransferUI.h"
+#import "BaseTransferShadowNode.h"
+
+#import <Lynx/LynxBackgroundManager.h>
+#import <Lynx/LynxShadowNode.h>
+#import <Lynx/LynxUI+Internal.h>
+#import <Lynx/LynxUIContext.h>
+
+@interface BaseTransferUI ()
+
+- (void)syncHostConstraintsFromReceiver:(BaseTransferReceiverView *)receiver;
+
+@end
+
+@implementation BaseTransferReceiverView
+
+- (instancetype)initWithTransfer:(BaseTransferUI *)transfer
+{
+    if (self = [super initWithFrame:CGRectZero]) {
+        _transfer = transfer;
+        self.translatesAutoresizingMaskIntoConstraints = YES;
+        self.autoresizingMask = UIViewAutoresizingFlexibleWidth | UIViewAutoresizingFlexibleHeight;
+    }
+    return self;
+}
+
+- (void)layoutSubviews
+{
+    [super layoutSubviews];
+    [self.transfer syncHostConstraintsFromReceiver:self];
+}
+
+@end
+
+@implementation BaseTransferUI {
+    BaseTransferReceiverView *_transferReceiver;
+}
+
+- (BaseTransferReceiverView *)transferReceiver
+{
+    if (!_transferReceiver) {
+        _transferReceiver = [self createTransferReceiver];
+    }
+    return _transferReceiver;
+}
+
+- (BaseTransferReceiverView *)createTransferReceiver
+{
+    return [[BaseTransferReceiverView alloc] initWithTransfer:self];
+}
+
+- (UIView *)childrenContainerView
+{
+    return self.transferReceiver;
+}
+
+- (void)insertChild:(LynxUI *)child atIndex:(NSInteger)index
+{
+    UIView *containerView = self.transferReceiver;
+    CALayer *mainLayer = child.view.layer;
+    CALayer *containerLayer = containerView.layer;
+    LynxBackgroundManager *backgroundManager = child.backgroundManager;
+
+    // Lynx versions before childrenContainerView support always insert into self.view.
+    [self didInsertChild:child atIndex:index];
+    [containerView insertSubview:child.view atIndex:index];
+
+    if (index > 0) {
+        LynxUI *previousSibling = self.children[index - 1];
+        if ([containerLayer.sublayers indexOfObject:previousSibling.topLayer] >
+            [containerLayer.sublayers indexOfObject:mainLayer]) {
+            [child.view removeFromSuperview];
+            [containerView insertSubview:child.view aboveSubview:previousSibling.view];
+            [mainLayer removeFromSuperlayer];
+            [containerLayer insertSublayer:mainLayer above:previousSibling.topLayer];
+        }
+    }
+
+    if ((NSUInteger)index < self.children.count - 1) {
+        LynxUI *nextSibling = self.children[index + 1];
+        if ([containerLayer.sublayers indexOfObject:nextSibling.bottomLayer] <
+            [containerLayer.sublayers indexOfObject:mainLayer]) {
+            [child.view removeFromSuperview];
+            [containerView insertSubview:child.view belowSubview:nextSibling.view];
+            [mainLayer removeFromSuperlayer];
+            [containerLayer insertSublayer:mainLayer below:nextSibling.bottomLayer];
+        }
+    }
+
+    if (backgroundManager.borderLayer) {
+        [backgroundManager.borderLayer removeFromSuperlayer];
+        if (child.overflow == OVERFLOW_HIDDEN_VAL) {
+            [containerLayer insertSublayer:backgroundManager.borderLayer above:mainLayer];
+        } else {
+            [containerLayer insertSublayer:backgroundManager.borderLayer below:mainLayer];
+        }
+    }
+
+    if (backgroundManager.backgroundLayer) {
+        [backgroundManager.backgroundLayer removeFromSuperlayer];
+        if (child.overflow != OVERFLOW_HIDDEN_VAL && backgroundManager.borderLayer) {
+            [containerLayer insertSublayer:backgroundManager.backgroundLayer
+                                     below:backgroundManager.borderLayer];
+        } else {
+            [containerLayer insertSublayer:backgroundManager.backgroundLayer below:mainLayer];
+        }
+    }
+}
+
+- (void)syncHostConstraintsFromReceiver:(BaseTransferReceiverView *)receiver
+{
+    BOOL hasExternalHost = receiver.superview && receiver.superview != self.view;
+    CGFloat width = CGRectGetWidth(receiver.bounds);
+    CGFloat height = CGRectGetHeight(receiver.bounds);
+    LynxMeasureMode widthMode = hasExternalHost ? LynxMeasureModeDefinite : LynxMeasureModeIndefinite;
+    LynxMeasureMode heightMode = hasExternalHost ? LynxMeasureModeDefinite : LynxMeasureModeIndefinite;
+    [self.context findShadowNodeAndRunTask:self.sign
+                                     task:^(LynxShadowNode *node) {
+                                         if ([node isKindOfClass:BaseTransferShadowNode.class]) {
+                                             [(BaseTransferShadowNode *)node
+                                                 updateHostConstraintsWithWidth:width
+                                                                      widthMode:widthMode
+                                                                         height:height
+                                                                     heightMode:heightMode];
+                                         }
+                                     }];
+}
+
+@end

--- a/ios/formsheet/RNSFormSheetComponent.h
+++ b/ios/formsheet/RNSFormSheetComponent.h
@@ -1,0 +1,39 @@
+#import <UIKit/UIKit.h>
+#import "BaseTransferUI.h"
+#import "RNSFormSheetHostView.h"
+
+NS_ASSUME_NONNULL_BEGIN
+
+@class RNSFormSheetController;
+
+@interface RNSFormSheetComponent : BaseTransferUI
+
+@property (nonatomic, copy) NSArray<NSNumber *> *detents;
+@property (nonatomic) BOOL prefersGrabberVisible;
+@property (nonatomic) CGFloat preferredCornerRadius;
+@property (nonatomic) NSInteger largestUndimmedDetentIndex;
+@property (nonatomic) NSInteger initialDetentIndex;
+@property (nonatomic) NSInteger selectedDetentIndex;
+@property (nonatomic) BOOL prefersScrollingExpandsWhenScrolledToEdge;
+/// Native dismissal channels to block ('back' | 'drag' | 'backdrop').
+@property (nonatomic, copy) NSArray<NSString *> *preventNativeDismissChannels;
+@property (nonatomic) BOOL preventNativeDismissDragFeedback;
+
+- (BOOL)isDismissPreventedForChannel:(NSString *)channel;
+
+- (void)hostViewDidMoveToWindow;
+- (CGFloat)measuredContentHeight;
+- (UIColor *)resolvedContainerBackgroundColor;
+
+- (void)emitOnWillAppear;
+- (void)emitOnDidAppear;
+- (void)emitOnWillDisappear;
+- (void)emitOnDidDisappear;
+- (void)emitOnNativeDismissPreventedWithChannel:(NSString *)channel;
+- (void)emitOnDetentChanged:(NSInteger)index;
+- (void)formSheetWasNativelyDismissed;
+- (void)formSheetDidDisappear;
+
+@end
+
+NS_ASSUME_NONNULL_END

--- a/ios/formsheet/RNSFormSheetComponent.mm
+++ b/ios/formsheet/RNSFormSheetComponent.mm
@@ -1,0 +1,388 @@
+#import "RNSFormSheetComponent.h"
+#import "RNSFormSheetController.h"
+#import "RNSFormSheetEventEmitter.h"
+
+#import <Lynx/LynxComponentRegistry.h>
+#import <Lynx/LynxEventHandler.h>
+#import <Lynx/LynxLog.h>
+#import <Lynx/LynxPropsProcessor.h>
+#import <Lynx/LynxTouchHandler.h>
+#import <Lynx/LynxUI+Internal.h>
+
+@interface RNSFormSheetContentView : BaseTransferReceiverView
+
+@property (nonatomic, weak) LynxEventHandler *eventHandler;
+
+@end
+
+
+@implementation RNSFormSheetContentView
+
+- (UIView *)hitTest:(CGPoint)point withEvent:(UIEvent *)event
+{
+    // Detached sheet content bypasses LynxView's hook, so record the Lynx target here.
+    [self.eventHandler hitTest:point withEvent:event];
+    return [super hitTest:point withEvent:event];
+}
+
+@end
+
+
+@LynxElement("form-sheet-native")
+@implementation RNSFormSheetComponent {
+    RNSFormSheetContentView *_contentView;
+    RNSFormSheetController *_controller;
+    RNSFormSheetEventEmitter *_eventEmitter;
+    LynxEventHandler *_sheetEventHandler;
+    NSInteger _gestureArenaIndex;
+
+    BOOL _isOpen;
+    BOOL _previousRequestedOpen;
+    BOOL _isPresented;
+    BOOL _isTransitioning;
+    BOOL _nativeDismissedForCurrentRequest;
+    NSUInteger _transitionGeneration;
+    NSString *_nativeContainerBackgroundColor;
+}
+
+LYNX_LAZY_REGISTER_UI("form-sheet-native")
+
+- (instancetype)init
+{
+    if (self = [super init]) {
+        _contentView = (RNSFormSheetContentView *)self.transferReceiver;
+        // Transparent by default; nativeContainerStyle.backgroundColor can
+        // provide the sheet surface color.
+        _contentView.backgroundColor = UIColor.clearColor;
+        _controller = [[RNSFormSheetController alloc] initWithComponent:self contentView:_contentView];
+        _detents = @[];
+        _preferredCornerRadius = -1;
+        _largestUndimmedDetentIndex = -1;
+        _initialDetentIndex = 0;
+        _selectedDetentIndex = -2;
+        _prefersScrollingExpandsWhenScrolledToEdge = YES;
+        _gestureArenaIndex = -1;
+    }
+    return self;
+}
+
+- (BaseTransferReceiverView *)createTransferReceiver
+{
+    return [[RNSFormSheetContentView alloc] initWithTransfer:self];
+}
+
+- (UIView *)createView
+{
+    RNSFormSheetHostView *view = [[RNSFormSheetHostView alloc] init];
+    view.component = self;
+    return view;
+}
+
+LYNX_PROP_SETTER("isOpen", setIsOpen, BOOL) {
+    _isOpen = requestReset ? NO : value;
+}
+
+LYNX_PROP_SETTER("detents", setDetents, NSArray *) {
+    self.detents = requestReset ? @[] : (value ?: @[]);
+}
+
+LYNX_PROP_SETTER("prefersGrabberVisible", setPrefersGrabberVisible, BOOL) {
+    self.prefersGrabberVisible = requestReset ? NO : value;
+}
+
+LYNX_PROP_SETTER("preferredCornerRadius", setPreferredCornerRadius, CGFloat) {
+    self.preferredCornerRadius = requestReset ? -1 : value;
+}
+
+LYNX_PROP_SETTER("largestUndimmedDetentIndex", setLargestUndimmedDetentIndex, NSInteger) {
+    self.largestUndimmedDetentIndex = requestReset ? -1 : value;
+}
+
+LYNX_PROP_SETTER("initialDetentIndex", setInitialDetentIndex, NSInteger) {
+    self.initialDetentIndex = requestReset ? 0 : value;
+}
+
+LYNX_PROP_SETTER("selectedDetentIndex", setSelectedDetentIndex, NSInteger) {
+    self.selectedDetentIndex = requestReset ? -2 : value;
+}
+
+LYNX_PROP_SETTER("prefersScrollingExpandsWhenScrolledToEdge", setPrefersScrollingExpandsWhenScrolledToEdge, BOOL) {
+    self.prefersScrollingExpandsWhenScrolledToEdge = requestReset ? YES : value;
+}
+
+LYNX_PROP_SETTER("preventNativeDismiss", setPreventNativeDismiss, id) {
+    NSArray *channels;
+    if (requestReset) {
+        channels = @[];
+    } else if ([value isKindOfClass:NSArray.class]) {
+        channels = value;
+    } else if ([value isKindOfClass:NSNumber.class] && [value boolValue]) {
+        // `true` blocks every native dismissal channel.
+        channels = @[ @"back", @"drag", @"backdrop" ];
+    } else {
+        channels = @[];
+    }
+    self.preventNativeDismissChannels = channels;
+}
+
+LYNX_PROP_SETTER("preventNativeDismissDragFeedback", setPreventNativeDismissDragFeedback, BOOL) {
+    self.preventNativeDismissDragFeedback = requestReset ? NO : value;
+}
+
+- (BOOL)isDismissPreventedForChannel:(NSString *)channel
+{
+    for (NSString *item in self.preventNativeDismissChannels) {
+        if ([item isEqualToString:channel]) {
+            return YES;
+        }
+    }
+    return NO;
+}
+
+LYNX_PROP_SETTER("nativeContainerBackgroundColor", setNativeContainerBackgroundColor, NSString *) {
+    _nativeContainerBackgroundColor = requestReset ? nil : value;
+    UIColor *backgroundColor = [self colorFromString:_nativeContainerBackgroundColor];
+    if (!backgroundColor) {
+        backgroundColor = UIColor.clearColor;
+    }
+    _contentView.backgroundColor = backgroundColor;
+}
+
+- (void)propsDidUpdate
+{
+    [self reconcilePresentation];
+}
+
+- (void)layoutDidFinished
+{
+    [super layoutDidFinished];
+    [_controller invalidateDetents];
+}
+
+- (void)hostViewDidMoveToWindow
+{
+    if (self.view.window) {
+        [self attachSheetEventHandlerIfNeeded];
+        [self reconcilePresentation];
+        return;
+    }
+
+    if (_isPresented || _isTransitioning) {
+        NSUInteger generation = ++_transitionGeneration;
+        _isTransitioning = YES;
+        [_controller dismissViewControllerAnimated:NO completion:^{
+            if (generation != self->_transitionGeneration) {
+                return;
+            }
+            self->_isTransitioning = NO;
+            self->_isPresented = NO;
+            [self reconcilePresentation];
+        }];
+    }
+}
+
+- (void)attachSheetEventHandlerIfNeeded
+{
+    if (_sheetEventHandler || !self.context.eventHandler) {
+        return;
+    }
+
+    _sheetEventHandler = [[LynxEventHandler alloc] initWithRootView:_contentView withRootUI:self];
+    _contentView.eventHandler = _sheetEventHandler;
+    [_sheetEventHandler updateUiOwner:self.context.uiOwner eventEmitter:self.context.eventEmitter];
+    _gestureArenaIndex = [_sheetEventHandler setGestureArenaManagerAndGetIndex:self.context.eventHandler.gestureArenaManager];
+}
+
+- (id<LynxEventTarget>)hitTest:(CGPoint)point withEvent:(UIEvent *)event
+{
+    for (LynxUI *child in self.children.reverseObjectEnumerator) {
+        if (![child shouldHitTest:point withEvent:event]) {
+            continue;
+        }
+        CGPoint childPoint = [_contentView.layer convertPoint:point toLayer:child.view.layer];
+        CGPoint hitTestPoint = self.context.enableEventRefactor ? childPoint : point;
+        if ([child containsPoint:hitTestPoint]) {
+            return [child hitTest:childPoint withEvent:event];
+        }
+    }
+    return self;
+}
+
+- (void)dealloc
+{
+    if (_gestureArenaIndex >= 0) {
+        [_sheetEventHandler removeGestureArenaManager:_gestureArenaIndex];
+    }
+    [_contentView removeGestureRecognizer:_sheetEventHandler.touchRecognizer];
+    [_contentView removeGestureRecognizer:_sheetEventHandler.tapRecognizer];
+    [_contentView removeGestureRecognizer:_sheetEventHandler.longPressRecognizer];
+}
+
+- (void)reconcilePresentation
+{
+    if (_isOpen != _previousRequestedOpen) {
+        _previousRequestedOpen = _isOpen;
+        if (_isOpen) {
+            _nativeDismissedForCurrentRequest = NO;
+        }
+    }
+    if (!_isOpen) {
+        _nativeDismissedForCurrentRequest = NO;
+    }
+
+    if (_isTransitioning) {
+        return;
+    }
+
+    if (_isOpen && !_isPresented && !_nativeDismissedForCurrentRequest && self.view.window) {
+        UIViewController *presenter = [self presentingViewController];
+        if (!presenter) {
+            return;
+        }
+
+        _isTransitioning = YES;
+        _isPresented = YES;
+        NSUInteger generation = ++_transitionGeneration;
+        [_controller applyConfigurationApplyingInitialDetent:YES];
+        [presenter presentViewController:_controller animated:YES completion:^{
+            if (generation != self->_transitionGeneration) {
+                return;
+            }
+            self->_isTransitioning = NO;
+            [self reconcilePresentation];
+        }];
+    } else if (!_isOpen && _isPresented) {
+        _isTransitioning = YES;
+        NSUInteger generation = ++_transitionGeneration;
+        [_controller dismissSheetWithCompletion:^{
+            if (generation != self->_transitionGeneration) {
+                return;
+            }
+            self->_isTransitioning = NO;
+            self->_isPresented = NO;
+            [[self eventEmitter] emitOnDismiss];
+            [self reconcilePresentation];
+        }];
+    } else if (_isOpen && _isPresented) {
+        [_controller applyConfigurationApplyingInitialDetent:NO];
+    }
+}
+
+- (UIViewController *)presentingViewController
+{
+    UIResponder *responder = self.view.nextResponder;
+    while (responder && ![responder isKindOfClass:UIViewController.class]) {
+        responder = responder.nextResponder;
+    }
+
+    UIViewController *presenter = (UIViewController *)responder;
+    while (presenter.presentedViewController && presenter.presentedViewController != _controller) {
+        presenter = presenter.presentedViewController;
+    }
+    return presenter;
+}
+
+- (CGFloat)measuredContentHeight
+{
+    CGFloat height = self.view.bounds.size.height;
+    for (UIView *subview in _contentView.subviews) {
+        height = MAX(height, CGRectGetMaxY(subview.frame));
+    }
+    return height;
+}
+
+- (UIColor *)resolvedContainerBackgroundColor
+{
+    return _contentView.backgroundColor;
+}
+
+- (void)formSheetWasNativelyDismissed
+{
+    if (!_isPresented || _isTransitioning) {
+        return;
+    }
+    _isPresented = NO;
+    _nativeDismissedForCurrentRequest = YES;
+    [[self eventEmitter] emitOnNativeDismiss];
+}
+
+- (void)formSheetDidDisappear
+{
+    if (_isPresented && !_isTransitioning && !_controller.presentingViewController) {
+        [self formSheetWasNativelyDismissed];
+    }
+}
+
+- (RNSFormSheetEventEmitter *)eventEmitter
+{
+    if (!_eventEmitter && self.context) {
+        _eventEmitter = [[RNSFormSheetEventEmitter alloc] initWithEventEmitter:self.context.eventEmitter
+                                                                    targetSign:self.sign];
+    }
+    return _eventEmitter;
+}
+
+- (void)emitOnWillAppear
+{
+    [[self eventEmitter] emitOnWillAppear];
+}
+
+- (void)emitOnDidAppear
+{
+    [[self eventEmitter] emitOnDidAppear];
+}
+
+- (void)emitOnWillDisappear
+{
+    [[self eventEmitter] emitOnWillDisappear];
+}
+
+- (void)emitOnDidDisappear
+{
+    [[self eventEmitter] emitOnDidDisappear];
+}
+
+- (void)emitOnNativeDismissPreventedWithChannel:(NSString *)channel
+{
+    [[self eventEmitter] emitOnNativeDismissPreventedWithChannel:channel];
+}
+
+- (void)emitOnDetentChanged:(NSInteger)index
+{
+    [[self eventEmitter] emitOnDetentChanged:index];
+}
+
+- (UIColor *)colorFromString:(NSString *)value
+{
+    if (!value) {
+        return nil;
+    }
+    if ([value isEqualToString:@"transparent"]) {
+        return UIColor.clearColor;
+    }
+    if (![value hasPrefix:@"#"]) {
+        return nil;
+    }
+
+    NSString *hex = [value substringFromIndex:1];
+    unsigned long long number = 0;
+    if (![[NSScanner scannerWithString:hex] scanHexLongLong:&number]) {
+        return nil;
+    }
+
+    if (hex.length == 6) {
+        return [UIColor colorWithRed:((number >> 16) & 0xff) / 255.0
+                               green:((number >> 8) & 0xff) / 255.0
+                                blue:(number & 0xff) / 255.0
+                               alpha:1];
+    }
+    if (hex.length == 8) {
+        return [UIColor colorWithRed:((number >> 24) & 0xff) / 255.0
+                               green:((number >> 16) & 0xff) / 255.0
+                                blue:((number >> 8) & 0xff) / 255.0
+                               alpha:(number & 0xff) / 255.0];
+    }
+    return nil;
+}
+
+@end

--- a/ios/formsheet/RNSFormSheetController.h
+++ b/ios/formsheet/RNSFormSheetController.h
@@ -1,0 +1,40 @@
+#import <UIKit/UIKit.h>
+
+NS_ASSUME_NONNULL_BEGIN
+
+@class RNSFormSheetComponent;
+
+/**
+ * Presents the FormSheet content in a custom, fully controlled sheet.
+ *
+ * This deliberately does NOT use UISheetPresentationController: since iOS 26
+ * the system applies a `scale(0.961)` transform to the sheet's presentation
+ * wrapper at every non-large detent, leaving ~8pt margins on both sides with
+ * no public API to disable it. Instead we present an over-full-screen modal and
+ * draw the dimming backdrop, rounded sheet container, grabber, detents and the
+ * drag interaction ourselves.
+ */
+@interface RNSFormSheetController : UIViewController <UIGestureRecognizerDelegate, UIViewControllerTransitioningDelegate>
+
+@property (nonatomic, weak) RNSFormSheetComponent *component;
+
+- (instancetype)initWithComponent:(RNSFormSheetComponent *)component
+                      contentView:(UIView *)contentView;
+
+/// Re-applies appearance and detent configuration. When `applyInitialDetent`
+/// is set the requested initial/selected detent is applied (otherwise only an
+/// explicitly controlled selectedDetentIndex is honored).
+- (void)applyConfigurationApplyingInitialDetent:(BOOL)applyInitialDetent;
+
+/// Re-resolves detent heights and reapplies the current sheet frame. Called on
+/// layout changes (e.g. content growth for fitToContents detents).
+- (void)invalidateDetents;
+
+/// Dismisses with a custom animation (backdrop fades out, sheet slides down),
+/// then removes the controller. Used for both user-initiated and programmatic
+/// dismissal so the backdrop never slides with the sheet.
+- (void)dismissSheetWithCompletion:(void (^)(void))completion;
+
+@end
+
+NS_ASSUME_NONNULL_END

--- a/ios/formsheet/RNSFormSheetController.mm
+++ b/ios/formsheet/RNSFormSheetController.mm
@@ -1,0 +1,802 @@
+#import "RNSFormSheetController.h"
+#import "RNSFormSheetComponent.h"
+
+#import <QuartzCore/QuartzCore.h>
+
+#include <cmath>
+
+static const CGFloat RNSFormSheetDefaultDimAlpha = 0.5;
+static const CGFloat RNSFormSheetDefaultCornerRadius = 12.0;
+static const CGFloat RNSFormSheetGrabberWidth = 36.0;
+static const CGFloat RNSFormSheetGrabberHeight = 5.0;
+static const CGFloat RNSFormSheetDismissZone = 60.0;
+static const NSTimeInterval RNSFormSheetAnimationDuration = 0.3;
+
+// selectedDetentIndex / initialDetentIndex sentinels
+static const NSInteger RNSFormSheetLastDetent = -1;
+// largestUndimmedDetentIndex sentinels
+static const NSInteger RNSFormSheetAlwaysDimmed = -1;
+static const NSInteger RNSFormSheetNeverDimmed = -2;
+// detents sentinel for fitToContents
+static const double RNSFormSheetFitToContents = -1.0;
+
+#pragma mark - Present transition
+
+// Presents the sheet with the backdrop fading in while the sheet itself slides
+// up. Keeps the dim from sliding with the sheet (a plain CoverVertical modal
+// transition moves them together, leaving a moving dim edge on screen).
+@interface RNSFormSheetPresentAnimator : NSObject <UIViewControllerAnimatedTransitioning>
+
+- (instancetype)initWithDimmingView:(UIView *)dimmingView sheetView:(UIView *)sheetView;
+
+@end
+
+@implementation RNSFormSheetPresentAnimator {
+    UIView *_dimmingView;
+    UIView *_sheetView;
+}
+
+- (instancetype)initWithDimmingView:(UIView *)dimmingView sheetView:(UIView *)sheetView
+{
+    if (self = [super init]) {
+        _dimmingView = dimmingView;
+        _sheetView = sheetView;
+    }
+    return self;
+}
+
+- (NSTimeInterval)transitionDuration:(id<UIViewControllerContextTransitioning>)transitionContext
+{
+    return RNSFormSheetAnimationDuration;
+}
+
+- (void)animateTransition:(id<UIViewControllerContextTransitioning>)transitionContext
+{
+    UIView *containerView = transitionContext.containerView;
+    UIView *toView = [transitionContext viewForKey:UITransitionContextToViewKey];
+    if (toView.superview != containerView) {
+        [containerView addSubview:toView];
+    }
+    toView.frame = containerView.bounds;
+    [toView layoutIfNeeded];
+
+    CGFloat targetDimAlpha = _dimmingView.alpha;
+    CGFloat targetSheetY = CGRectGetMinY(_sheetView.frame);
+    CGFloat containerHeight = CGRectGetHeight(containerView.bounds);
+
+    _dimmingView.alpha = 0;
+    CGRect startFrame = _sheetView.frame;
+    startFrame.origin.y = containerHeight;
+    _sheetView.frame = startFrame;
+
+    // Backdrop fades in with the same ease-in-out curve as the sheet slide, so
+    // the two stay in lockstep.
+    [UIView animateWithDuration:[self transitionDuration:transitionContext]
+                          delay:0
+                        options:UIViewAnimationOptionCurveEaseInOut
+                     animations:^{
+        CGRect frame = self->_sheetView.frame;
+        frame.origin.y = targetSheetY;
+        self->_sheetView.frame = frame;
+        self->_dimmingView.alpha = targetDimAlpha;
+    } completion:^(BOOL finished) {
+        [transitionContext completeTransition:!transitionContext.transitionWasCancelled];
+    }];
+}
+
+@end
+
+@implementation RNSFormSheetController {
+    UIView *_dimmingView;
+    UIView *_sheetView;
+    UIView *_grabberView;
+    UIView *_contentView;
+
+    UIPanGestureRecognizer *_panGesture;
+    UITapGestureRecognizer *_backdropTapGesture;
+    UIGestureRecognizer *_disabledScrollPanGesture;
+
+    NSArray<NSNumber *> *_resolvedHeights;
+    NSInteger _currentDetentIndex;
+    NSInteger _lastEmittedDetentIndex;
+    BOOL _applyInitialDetent;
+    BOOL _applyInitialDetentPending;
+
+    CGFloat _dragStartTop;
+    BOOL _isDragging;
+    CGSize _lastLayoutSize;
+}
+
+- (instancetype)initWithComponent:(RNSFormSheetComponent *)component
+                      contentView:(UIView *)contentView
+{
+    if (self = [super initWithNibName:nil bundle:nil]) {
+        _component = component;
+        _contentView = contentView;
+        _currentDetentIndex = 0;
+        _lastEmittedDetentIndex = -1;
+        _lastLayoutSize = CGSizeZero;
+
+        self.modalPresentationStyle = UIModalPresentationOverFullScreen;
+        self.modalTransitionStyle = UIModalTransitionStyleCoverVertical;
+        self.transitioningDelegate = self;
+
+        [self setUpViews];
+    }
+    return self;
+}
+
+- (void)setUpViews
+{
+    self.view.backgroundColor = UIColor.clearColor;
+
+    _dimmingView = [[UIView alloc] initWithFrame:self.view.bounds];
+    _dimmingView.autoresizingMask = UIViewAutoresizingFlexibleWidth | UIViewAutoresizingFlexibleHeight;
+    _dimmingView.backgroundColor = UIColor.blackColor;
+    _dimmingView.alpha = RNSFormSheetDefaultDimAlpha;
+    [self.view addSubview:_dimmingView];
+
+    // Attached to the full-screen background rather than the dimming view:
+    // UIKit hit-testing ignores views whose alpha drops below 0.01, so once the
+    // backdrop fades out (largestUndimmedDetentIndex) it would stop receiving taps.
+    _backdropTapGesture = [[UITapGestureRecognizer alloc] initWithTarget:self
+                                                                  action:@selector(handleBackdropTap:)];
+    _backdropTapGesture.delegate = self;
+    _backdropTapGesture.cancelsTouchesInView = NO;
+    [self.view addGestureRecognizer:_backdropTapGesture];
+
+    _sheetView = [[UIView alloc] initWithFrame:self.view.bounds];
+    if (@available(iOS 11.0, *)) {
+        _sheetView.layer.maskedCorners = kCALayerMinXMinYCorner | kCALayerMaxXMinYCorner;
+    }
+    _sheetView.clipsToBounds = YES;
+    _sheetView.backgroundColor = UIColor.clearColor;
+    [self.view addSubview:_sheetView];
+
+    _contentView.frame = _sheetView.bounds;
+    [_sheetView addSubview:_contentView];
+
+    _grabberView = [[UIView alloc] init];
+    _grabberView.backgroundColor = [UIColor colorWithWhite:0.5 alpha:0.6];
+    _grabberView.layer.cornerRadius = RNSFormSheetGrabberHeight / 2.0;
+    _grabberView.userInteractionEnabled = NO;
+    [_sheetView addSubview:_grabberView];
+
+    _panGesture = [[UIPanGestureRecognizer alloc] initWithTarget:self action:@selector(handlePan:)];
+    _panGesture.delegate = self;
+    _panGesture.maximumNumberOfTouches = 1;
+    [_sheetView addGestureRecognizer:_panGesture];
+}
+
+#pragma mark - Configuration
+
+- (void)applyConfigurationApplyingInitialDetent:(BOOL)applyInitialDetent
+{
+    _applyInitialDetent = applyInitialDetent;
+    [self applyAppearance];
+
+    BOOL hasSize = self.view.bounds.size.height > 0;
+    if (hasSize) {
+        [self resolveDetentHeights];
+        [self applyDetentFrameAnimated:NO];
+        [self applyRequestedDetentAnimated:NO];
+    } else {
+        _applyInitialDetentPending = YES;
+    }
+    [self layoutContent];
+    [self updateDimming];
+}
+
+- (void)invalidateDetents
+{
+    if (!_isDragging) {
+        [self resolveDetentHeights];
+        [self applyDetentFrameAnimated:NO];
+        [self updateDimming];
+    }
+}
+
+- (void)applyAppearance
+{
+    _sheetView.layer.cornerRadius = self.component.preferredCornerRadius < 0
+        ? RNSFormSheetDefaultCornerRadius
+        : self.component.preferredCornerRadius;
+    // The native sheet frame already stays inside the safe area. The content
+    // fills that frame; apps remain responsible for any additional insets.
+    _contentView.backgroundColor = [self.component resolvedContainerBackgroundColor] ?: UIColor.clearColor;
+}
+
+- (void)resolveDetentHeights
+{
+    CGFloat availableHeight = CGRectGetHeight(self.view.bounds);
+    if (availableHeight <= 0) {
+        return;
+    }
+
+    NSArray<NSNumber *> *rawDetents = [self validatedDetents:self.component.detents];
+    NSMutableArray<NSNumber *> *heights = [NSMutableArray arrayWithCapacity:rawDetents.count ?: 1];
+
+    if (rawDetents.count == 0) {
+        [heights addObject:@(availableHeight)];
+    } else if (rawDetents.count == 1 && rawDetents.firstObject.doubleValue == RNSFormSheetFitToContents) {
+        CGFloat contentHeight = MAX([self.component measuredContentHeight], 1);
+        [heights addObject:@(MIN(contentHeight, availableHeight))];
+    } else {
+        [rawDetents enumerateObjectsUsingBlock:^(NSNumber *fraction, NSUInteger idx, BOOL *stop) {
+            [heights addObject:@(availableHeight * MIN(MAX(fraction.doubleValue, 0), 1))];
+        }];
+    }
+
+    _resolvedHeights = heights;
+    _currentDetentIndex = MIN(MAX(_currentDetentIndex, 0), (NSInteger)_resolvedHeights.count - 1);
+}
+
+#pragma mark - Detent layout
+
+- (void)viewDidLayoutSubviews
+{
+    [super viewDidLayoutSubviews];
+
+    _dimmingView.frame = self.view.bounds;
+
+    if (!CGSizeEqualToSize(_lastLayoutSize, self.view.bounds.size)) {
+        _lastLayoutSize = self.view.bounds.size;
+        [self resolveDetentHeights];
+        [self applyDetentFrameAnimated:NO];
+        [self updateDimming];
+    }
+
+    if (_applyInitialDetentPending) {
+        _applyInitialDetentPending = NO;
+        [self applyRequestedDetentAnimated:NO];
+    }
+
+    [self layoutContent];
+    [self layoutGrabber];
+}
+
+- (void)viewSafeAreaInsetsDidChange
+{
+    if (@available(iOS 11.0, *)) {
+        [super viewSafeAreaInsetsDidChange];
+        [self resolveDetentHeights];
+        [self applyDetentFrameAnimated:NO];
+        [self updateDimming];
+    }
+}
+
+- (void)applyDetentFrameAnimated:(BOOL)animated
+{
+    if (_resolvedHeights.count == 0) {
+        return;
+    }
+    CGFloat height = _resolvedHeights[_currentDetentIndex].doubleValue;
+    CGRect safeFrame = self.view.bounds;
+    CGFloat top = MAX(CGRectGetMaxY(safeFrame) - height, CGRectGetMinY(safeFrame));
+    CGFloat targetDimAlpha = [self dimAlphaForSheetHeight:height];
+
+    if (animated) {
+        // The backdrop follows the sheet with the same curve and duration, so
+        // its edge always tracks the sheet edge (FloatingPanel does the same by
+        // setting backdropView.alpha inside the sheet's animator).
+        [UIView animateWithDuration:0.28
+                              delay:0
+             usingSpringWithDamping:0.85
+              initialSpringVelocity:0
+                            options:UIViewAnimationOptionCurveEaseOut
+                         animations:^{
+            [self setSheetTop:top];
+            self->_dimmingView.alpha = targetDimAlpha;
+        } completion:nil];
+    } else {
+        [self setSheetTop:top];
+        _dimmingView.alpha = targetDimAlpha;
+    }
+}
+
+- (void)applyRequestedDetentAnimated:(BOOL)animated
+{
+    NSInteger count = (NSInteger)_resolvedHeights.count;
+    if (count == 0) {
+        _applyInitialDetentPending = YES;
+        return;
+    }
+
+    NSInteger selected = self.component.selectedDetentIndex;
+    NSInteger index;
+    if (selected >= RNSFormSheetLastDetent) {
+        index = selected;
+        // JS-driven controlled updates animate; the very first (initial) apply
+        // stays non-animated so it doesn't fight the presentation transition.
+        if (!_applyInitialDetent) {
+            animated = YES;
+        }
+    } else if (_applyInitialDetent) {
+        index = self.component.initialDetentIndex;
+    } else {
+        return;
+    }
+
+    if (index == RNSFormSheetLastDetent) {
+        index = count - 1;
+    }
+    [self setDetentIndex:MIN(MAX(index, 0), count - 1) animated:animated];
+}
+
+- (void)setDetentIndex:(NSInteger)index animated:(BOOL)animated
+{
+    NSInteger count = (NSInteger)_resolvedHeights.count;
+    if (count == 0) {
+        return;
+    }
+    NSInteger clamped = MIN(MAX(index, 0), count - 1);
+    _currentDetentIndex = clamped;
+    [self applyDetentFrameAnimated:animated];
+
+    if (clamped != _lastEmittedDetentIndex) {
+        _lastEmittedDetentIndex = clamped;
+        [self.component emitOnDetentChanged:clamped];
+    }
+}
+
+- (void)setSheetTop:(CGFloat)top
+{
+    CGRect safeFrame = self.view.bounds;
+    CGFloat height = MAX(CGRectGetMaxY(safeFrame) - top, 0);
+    _sheetView.frame = CGRectMake(CGRectGetMinX(safeFrame), top, CGRectGetWidth(safeFrame), height);
+    [self layoutContent];
+    [self layoutGrabber];
+}
+
+- (void)layoutContent
+{
+    _contentView.frame = _sheetView.bounds;
+}
+
+- (void)layoutGrabber
+{
+    CGFloat x = (CGRectGetWidth(_sheetView.bounds) - RNSFormSheetGrabberWidth) / 2.0;
+    _grabberView.frame = CGRectMake(x, 8, RNSFormSheetGrabberWidth, RNSFormSheetGrabberHeight);
+    _grabberView.hidden = !self.component.prefersGrabberVisible;
+}
+
+#pragma mark - Dimming
+
+- (void)updateDimming
+{
+    CGFloat sheetHeight = CGRectGetHeight(_sheetView.bounds);
+    if (sheetHeight <= 0) {
+        _dimmingView.alpha = RNSFormSheetDefaultDimAlpha;
+        return;
+    }
+    _dimmingView.alpha = [self dimAlphaForSheetHeight:sheetHeight];
+}
+
+- (CGFloat)dimAlphaForSheetHeight:(CGFloat)sheetHeight
+{
+    NSInteger lud = self.component.largestUndimmedDetentIndex;
+    CGFloat baseAlpha;
+    if (lud == RNSFormSheetAlwaysDimmed) {
+        baseAlpha = RNSFormSheetDefaultDimAlpha;
+    } else if (lud == RNSFormSheetNeverDimmed) {
+        baseAlpha = 0;
+    } else if (_resolvedHeights.count == 0) {
+        baseAlpha = RNSFormSheetDefaultDimAlpha;
+    } else {
+        NSInteger index = MIN(MAX(lud, 0), (NSInteger)_resolvedHeights.count - 1);
+        CGFloat threshold = _resolvedHeights[index].doubleValue;
+        if (sheetHeight <= threshold) {
+            // At or below the largest undimmed detent the backdrop stays clear.
+            baseAlpha = 0;
+        } else {
+            // Larger detents dim the backdrop. Fade it in linearly across the
+            // whole gap between the largest undimmed detent and the next larger
+            // one, so the alpha follows the sheet position.
+            NSInteger nextIndex = MIN(index + 1, (NSInteger)_resolvedHeights.count - 1);
+            CGFloat upper = _resolvedHeights[nextIndex].doubleValue;
+            if (upper <= threshold) {
+                baseAlpha = RNSFormSheetDefaultDimAlpha;
+            } else {
+                CGFloat progress = MIN((sheetHeight - threshold) / (upper - threshold), 1);
+                baseAlpha = RNSFormSheetDefaultDimAlpha * progress;
+            }
+        }
+    }
+
+    // When the backdrop is otherwise always dimmed, fade it across the full
+    // distance from the smallest visible detent to hidden.
+    if (lud == RNSFormSheetAlwaysDimmed && _resolvedHeights.count > 0) {
+        CGFloat fadeStartHeight = 0;
+        for (NSNumber *height in _resolvedHeights) {
+            if (height.doubleValue > 0) {
+                fadeStartHeight = height.doubleValue;
+                break;
+            }
+        }
+        if (fadeStartHeight > 0) {
+            CGFloat dismissProgress = MIN(MAX(sheetHeight / fadeStartHeight, 0), 1);
+            baseAlpha *= dismissProgress;
+        } else {
+            baseAlpha = 0;
+        }
+    }
+    return baseAlpha;
+}
+
+#pragma mark - Drag interaction
+
+- (void)handlePan:(UIPanGestureRecognizer *)pan
+{
+    switch (pan.state) {
+        case UIGestureRecognizerStateBegan: {
+            _isDragging = YES;
+            _dragStartTop = CGRectGetMinY(_sheetView.frame);
+            _disabledScrollPanGesture = [self scrollPanGestureAtPoint:[pan locationInView:_sheetView]];
+            _disabledScrollPanGesture.enabled = NO;
+            break;
+        }
+        case UIGestureRecognizerStateChanged: {
+            if (_resolvedHeights.count == 0) {
+                break;
+            }
+            CGFloat translationY = [pan translationInView:self.view].y;
+            CGFloat top = _dragStartTop + translationY;
+            // Clamp the top edge so the sheet never grows beyond its largest detent.
+            top = MAX(top, [self largestDetentTop]);
+            if ([self isPullDownDismissRigid]) {
+                // preventNativeDismissDragFeedback: keep the sheet rigid at
+                // the smallest detent - it neither follows the finger below it
+                // nor bounces back.
+                top = MIN(top, [self smallestDetentTop]);
+            }
+            [self setSheetTop:top];
+            [self updateDimming];
+            break;
+        }
+        case UIGestureRecognizerStateEnded:
+        case UIGestureRecognizerStateCancelled: {
+            _isDragging = NO;
+            _disabledScrollPanGesture.enabled = YES;
+            _disabledScrollPanGesture = nil;
+            if (_resolvedHeights.count == 0) {
+                break;
+            }
+            CGFloat velocity = [pan velocityInView:self.view].y;
+            [self settleAfterDragWithVelocity:velocity];
+            break;
+        }
+        default:
+            break;
+    }
+}
+
+- (void)settleAfterDragWithVelocity:(CGFloat)velocity
+{
+    CGFloat top = CGRectGetMinY(_sheetView.frame);
+    BOOL inDismissZone = top > [self smallestDetentTop] + RNSFormSheetDismissZone;
+    BOOL fastDownwardFromSmallest = _currentDetentIndex == 0 && velocity > 1200.0;
+
+    if (inDismissZone || fastDownwardFromSmallest) {
+        if ([self isPullDownDismissPrevented]) {
+            [self.component emitOnNativeDismissPreventedWithChannel:@"drag"];
+            [self setDetentIndex:0 animated:YES];
+            return;
+        }
+        [self performNativeDismiss];
+        return;
+    }
+
+    NSInteger target = [self targetDetentIndexForTop:top velocity:velocity];
+    [self setDetentIndex:target animated:YES];
+}
+
+- (NSInteger)targetDetentIndexForTop:(CGFloat)top velocity:(CGFloat)velocity
+{
+    NSInteger count = (NSInteger)_resolvedHeights.count;
+    if (count <= 1) {
+        return 0;
+    }
+    if (velocity == 0) {
+        return [self nearestDetentIndexForTop:top];
+    }
+
+    CGFloat availableHeight = CGRectGetHeight(self.view.bounds);
+    CGFloat (^detentTop)(NSInteger) = ^CGFloat(NSInteger index) {
+        return availableHeight - self->_resolvedHeights[index].doubleValue;
+    };
+
+    // Detent indices sorted by top ascending (largest detent first).
+    NSMutableArray<NSNumber *> *sorted = [NSMutableArray arrayWithCapacity:count];
+    for (NSInteger i = count - 1; i >= 0; i--) {
+        [sorted addObject:@(i)];
+    }
+    NSInteger (^indexAt)(NSInteger) = ^NSInteger(NSInteger position) {
+        return sorted[position].integerValue;
+    };
+    NSInteger (^nextIndex)(NSInteger) = ^NSInteger(NSInteger idx) {
+        NSUInteger position = [sorted indexOfObject:@(idx)];
+        return (position != NSNotFound && position + 1 < sorted.count) ? sorted[position + 1].integerValue : idx;
+    };
+    NSInteger (^preIndex)(NSInteger) = ^NSInteger(NSInteger idx) {
+        NSUInteger position = [sorted indexOfObject:@(idx)];
+        return (position != NSNotFound && position > 0) ? sorted[position - 1].integerValue : idx;
+    };
+
+    BOOL forward = velocity > 0; // moving down (toward smaller detents)
+
+    // Locate the adjacent detent pair around the release position. Boundary
+    // handling is direction-aware (mirrors FloatingPanel's segment(at:forward:)):
+    // a release exactly on a detent moves toward the next detent in the travel
+    // direction instead of being stuck on the resting detent.
+    NSInteger upperPosition = NSNotFound;
+    for (NSInteger position = 0; position < count; position++) {
+        CGFloat detent = detentTop(indexAt(position));
+        if (forward ? (top < detent) : (top <= detent)) {
+            upperPosition = position;
+            break;
+        }
+    }
+
+    NSInteger lowerIndex;
+    NSInteger upperIndex;
+    if (upperPosition == NSNotFound) {
+        lowerIndex = upperIndex = indexAt(count - 1);
+    } else if (upperPosition == 0) {
+        lowerIndex = upperIndex = indexAt(0);
+    } else {
+        lowerIndex = indexAt(upperPosition - 1);
+        upperIndex = indexAt(upperPosition);
+    }
+
+    if (lowerIndex == upperIndex) {
+        if (forward) {
+            upperIndex = nextIndex(upperIndex);
+        } else {
+            lowerIndex = preIndex(lowerIndex);
+        }
+    }
+
+    NSInteger fromIndex = forward ? lowerIndex : upperIndex;
+    NSInteger toIndex = forward ? upperIndex : lowerIndex;
+
+    // Project the release with the WWDC18 momentum model, trimmed to the
+    // release segment so a single gesture moves at most ONE detent.
+    CGFloat projected = top + [self projectedOffsetForVelocity:velocity];
+    CGFloat fromTop = detentTop(fromIndex);
+    CGFloat toTop = detentTop(toIndex);
+    CGFloat minTop = MIN(fromTop, toTop);
+    CGFloat maxTop = MAX(fromTop, toTop);
+    CGFloat clamped = MAX(MIN(projected, maxTop), minTop);
+    CGFloat progress = (maxTop == minTop) ? 1.0 : std::fabs(clamped - fromTop) / std::fabs(toTop - fromTop);
+    return progress > 0.5 ? toIndex : fromIndex;
+}
+
+- (NSInteger)nearestDetentIndexForTop:(CGFloat)top
+{
+    NSInteger count = (NSInteger)_resolvedHeights.count;
+    CGFloat availableHeight = CGRectGetHeight(self.view.bounds);
+    NSInteger target = 0;
+    CGFloat bestDistance = CGFLOAT_MAX;
+    for (NSInteger i = 0; i < count; i++) {
+        CGFloat detentTop = availableHeight - _resolvedHeights[i].doubleValue;
+        CGFloat distance = std::fabs(top - detentTop);
+        if (distance < bestDistance) {
+            bestDistance = distance;
+            target = i;
+        }
+    }
+    return target;
+}
+
+- (CGFloat)projectedOffsetForVelocity:(CGFloat)velocity
+{
+    // Distance travelled while decelerating from `velocity` at UIScrollView's
+    // normal deceleration rate (WWDC18 "Designing Fluid Interfaces").
+    static const CGFloat kDecelerationRate = 0.998;
+    return (velocity / 1000.0) * kDecelerationRate / (1.0 - kDecelerationRate);
+}
+
+- (void)requestUserDismiss
+{
+    if ([self.component isDismissPreventedForChannel:@"backdrop"]) {
+        [self.component emitOnNativeDismissPreventedWithChannel:@"backdrop"];
+        return;
+    }
+    [self performNativeDismiss];
+}
+
+- (void)performNativeDismiss
+{
+    [self.component formSheetWasNativelyDismissed];
+    [self dismissSheetWithCompletion:^{
+        [self.component formSheetDidDisappear];
+    }];
+}
+
+- (BOOL)isPullDownDismissPrevented
+{
+    return [self.component isDismissPreventedForChannel:@"drag"];
+}
+
+- (BOOL)isPullDownDismissRigid
+{
+    return [self isPullDownDismissPrevented] && self.component.preventNativeDismissDragFeedback;
+}
+
+- (void)dismissSheetWithCompletion:(void (^)(void))completion
+{
+    [UIView animateWithDuration:RNSFormSheetAnimationDuration
+                          delay:0
+                        options:UIViewAnimationOptionCurveEaseInOut
+                     animations:^{
+        CGRect frame = self->_sheetView.frame;
+        frame.origin.y = CGRectGetHeight(self.view.bounds);
+        self->_sheetView.frame = frame;
+        self->_dimmingView.alpha = 0;
+    } completion:^(BOOL finished) {
+        [self dismissViewControllerAnimated:NO completion:completion];
+    }];
+}
+
+- (void)handleBackdropTap:(UITapGestureRecognizer *)tap
+{
+    if (tap.state == UIGestureRecognizerStateRecognized) {
+        [self requestUserDismiss];
+    }
+}
+
+#pragma mark - Scroll coordination
+
+- (UIScrollView *)scrollViewAtPoint:(CGPoint)pointInSheet
+{
+    CGPoint pointInContent = [_sheetView convertPoint:pointInSheet toView:_contentView];
+    UIView *target = [_contentView hitTest:pointInContent withEvent:nil];
+    if (!target) {
+        return nil;
+    }
+    UIView *view = target;
+    while (view) {
+        if ([view isKindOfClass:UIScrollView.class]) {
+            return (UIScrollView *)view;
+        }
+        view = view.superview;
+    }
+    return nil;
+}
+
+- (UIGestureRecognizer *)scrollPanGestureAtPoint:(CGPoint)pointInSheet
+{
+    UIScrollView *scroll = [self scrollViewAtPoint:pointInSheet];
+    if (scroll && [self isScrollViewAtTop:scroll]) {
+        return scroll.panGestureRecognizer;
+    }
+    return nil;
+}
+
+- (BOOL)isScrollViewAtTop:(UIScrollView *)scroll
+{
+    UIEdgeInsets contentInset = scroll.contentInset;
+    if (@available(iOS 11.0, *)) {
+        contentInset = scroll.adjustedContentInset;
+    }
+    return scroll.contentOffset.y <= -contentInset.top + 1.0;
+}
+
+#pragma mark - UIGestureRecognizerDelegate
+
+- (BOOL)gestureRecognizer:(UIGestureRecognizer *)gestureRecognizer
+    shouldReceiveTouch:(UITouch *)touch
+{
+    if (gestureRecognizer == _backdropTapGesture) {
+        // Only treat taps outside the sheet as backdrop taps, so content inside
+        // the sheet keeps its own interaction.
+        CGPoint point = [touch locationInView:self.view];
+        return !CGRectContainsPoint(_sheetView.frame, point);
+    }
+    return YES;
+}
+
+- (BOOL)gestureRecognizerShouldBegin:(UIGestureRecognizer *)gestureRecognizer
+{
+    if (gestureRecognizer != _panGesture) {
+        return YES;
+    }
+    CGPoint point = [gestureRecognizer locationInView:_sheetView];
+    UIScrollView *scroll = [self scrollViewAtPoint:point];
+    if (!scroll) {
+        return YES;
+    }
+    if (scroll.isTracking || scroll.isDragging) {
+        return NO;
+    }
+    if (!self.component.prefersScrollingExpandsWhenScrolledToEdge) {
+        return NO;
+    }
+    return [self isScrollViewAtTop:scroll];
+}
+
+#pragma mark - UIViewControllerTransitioningDelegate
+
+- (id<UIViewControllerAnimatedTransitioning>)
+    animationControllerForPresentedController:(UIViewController *)presented
+                         presentingController:(UIViewController *)presenting
+                             sourceController:(UIViewController *)source
+{
+    return [[RNSFormSheetPresentAnimator alloc] initWithDimmingView:_dimmingView
+                                                          sheetView:_sheetView];
+}
+
+#pragma mark - Helpers
+
+- (CGFloat)largestDetentTop
+{
+    CGFloat availableHeight = CGRectGetHeight(self.view.bounds);
+    return availableHeight - _resolvedHeights.lastObject.doubleValue;
+}
+
+- (CGFloat)smallestDetentTop
+{
+    CGFloat availableHeight = CGRectGetHeight(self.view.bounds);
+    return availableHeight - _resolvedHeights.firstObject.doubleValue;
+}
+
+- (NSArray<NSNumber *> *)validatedDetents:(NSArray *)detents
+{
+    if (detents.count == 0) {
+        return @[];
+    }
+    if (detents.count == 1 && [detents.firstObject isKindOfClass:NSNumber.class]
+        && [detents.firstObject doubleValue] == RNSFormSheetFitToContents) {
+        return detents;
+    }
+
+    BOOL valid = YES;
+    double previous = -1;
+    for (id value in detents) {
+        if (![value isKindOfClass:NSNumber.class]) {
+            valid = NO;
+            break;
+        }
+        double fraction = [value doubleValue];
+        if (!std::isfinite(fraction) || fraction < 0 || fraction > 1 || fraction <= previous) {
+            valid = NO;
+            break;
+        }
+        previous = fraction;
+    }
+
+    if (!valid) {
+        NSLog(@"[RNScreens] Invalid FormSheet detents %@. Falling back to the large detent.", detents);
+        return @[];
+    }
+    return detents;
+}
+
+#pragma mark - Lifecycle events
+
+- (void)viewWillAppear:(BOOL)animated
+{
+    [super viewWillAppear:animated];
+    [self.component emitOnWillAppear];
+}
+
+- (void)viewDidAppear:(BOOL)animated
+{
+    [super viewDidAppear:animated];
+    [self.component emitOnDidAppear];
+}
+
+- (void)viewWillDisappear:(BOOL)animated
+{
+    [super viewWillDisappear:animated];
+    [self.component emitOnWillDisappear];
+}
+
+- (void)viewDidDisappear:(BOOL)animated
+{
+    [super viewDidDisappear:animated];
+    [self.component formSheetDidDisappear];
+    [self.component emitOnDidDisappear];
+}
+
+@end

--- a/ios/formsheet/RNSFormSheetEventEmitter.h
+++ b/ios/formsheet/RNSFormSheetEventEmitter.h
@@ -1,0 +1,22 @@
+#import <Foundation/Foundation.h>
+#import <Lynx/LynxEventEmitter.h>
+
+NS_ASSUME_NONNULL_BEGIN
+
+@interface RNSFormSheetEventEmitter : NSObject
+
+- (instancetype)initWithEventEmitter:(LynxEventEmitter *)eventEmitter
+                           targetSign:(NSInteger)sign;
+
+- (void)emitOnWillAppear;
+- (void)emitOnDidAppear;
+- (void)emitOnWillDisappear;
+- (void)emitOnDidDisappear;
+- (void)emitOnDismiss;
+- (void)emitOnNativeDismiss;
+- (void)emitOnNativeDismissPreventedWithChannel:(NSString *)channel;
+- (void)emitOnDetentChanged:(NSInteger)index;
+
+@end
+
+NS_ASSUME_NONNULL_END

--- a/ios/formsheet/RNSFormSheetEventEmitter.mm
+++ b/ios/formsheet/RNSFormSheetEventEmitter.mm
@@ -1,0 +1,68 @@
+#import "RNSFormSheetEventEmitter.h"
+
+@implementation RNSFormSheetEventEmitter {
+    __weak LynxEventEmitter *_eventEmitter;
+    NSInteger _sign;
+}
+
+- (instancetype)initWithEventEmitter:(LynxEventEmitter *)eventEmitter
+                           targetSign:(NSInteger)sign
+{
+    if (self = [super init]) {
+        _eventEmitter = eventEmitter;
+        _sign = sign;
+    }
+    return self;
+}
+
+- (void)emitOnWillAppear
+{
+    [self dispatch:@"OnWillAppear" detail:@{}];
+}
+
+- (void)emitOnDidAppear
+{
+    [self dispatch:@"OnDidAppear" detail:@{}];
+}
+
+- (void)emitOnWillDisappear
+{
+    [self dispatch:@"OnWillDisappear" detail:@{}];
+}
+
+- (void)emitOnDidDisappear
+{
+    [self dispatch:@"OnDidDisappear" detail:@{}];
+}
+
+- (void)emitOnDismiss
+{
+    [self dispatch:@"OnDismiss" detail:@{}];
+}
+
+- (void)emitOnNativeDismiss
+{
+    [self dispatch:@"OnNativeDismiss" detail:@{}];
+}
+
+- (void)emitOnNativeDismissPreventedWithChannel:(NSString *)channel
+{
+    [self dispatch:@"OnNativeDismissPrevented" detail:@{ @"channel": channel }];
+}
+
+- (void)emitOnDetentChanged:(NSInteger)index
+{
+    [self dispatch:@"OnDetentChanged" detail:@{ @"index": @(index) }];
+}
+
+- (void)dispatch:(NSString *)name detail:(NSDictionary *)detail
+{
+    if (_eventEmitter) {
+        LynxCustomEvent *event = [[LynxDetailEvent alloc] initWithName:name
+                                                            targetSign:_sign
+                                                                detail:detail];
+        [_eventEmitter dispatchCustomEvent:event];
+    }
+}
+
+@end

--- a/ios/formsheet/RNSFormSheetHostView.h
+++ b/ios/formsheet/RNSFormSheetHostView.h
@@ -1,0 +1,13 @@
+#import <UIKit/UIKit.h>
+
+@class RNSFormSheetComponent;
+
+NS_ASSUME_NONNULL_BEGIN
+
+@interface RNSFormSheetHostView : UIView
+
+@property (nonatomic, weak) RNSFormSheetComponent *component;
+
+@end
+
+NS_ASSUME_NONNULL_END

--- a/ios/formsheet/RNSFormSheetHostView.mm
+++ b/ios/formsheet/RNSFormSheetHostView.mm
@@ -1,0 +1,17 @@
+#import "RNSFormSheetHostView.h"
+#import "RNSFormSheetComponent.h"
+
+@implementation RNSFormSheetHostView
+
+- (void)didMoveToWindow
+{
+    [super didMoveToWindow];
+    [self.component hostViewDidMoveToWindow];
+}
+
+- (UIView *)hitTest:(CGPoint)point withEvent:(UIEvent *)event
+{
+    return nil;
+}
+
+@end

--- a/ios/formsheet/RNSFormSheetShadowNode.mm
+++ b/ios/formsheet/RNSFormSheetShadowNode.mm
@@ -1,0 +1,16 @@
+#import "BaseTransferShadowNode.h"
+
+#import <Lynx/LynxComponentRegistry.h>
+
+@interface RNSFormSheetShadowNode : BaseTransferShadowNode
+@end
+
+@implementation RNSFormSheetShadowNode
+
+#if LYNX_LAZY_LOAD
+LYNX_LAZY_REGISTER_SHADOW_NODE("form-sheet-native")
+#else
+LYNX_REGISTER_SHADOW_NODE("form-sheet-native")
+#endif
+
+@end

--- a/package-lock.json
+++ b/package-lock.json
@@ -20,7 +20,9 @@
         "globals": "^16.3.0",
         "prettier": "^3.6.2",
         "typescript": "~5.9.2",
-        "typescript-eslint": "^8.38.0"
+        "typescript-eslint": "^8.38.0",
+        "vite": "^6.1.0",
+        "vitest": "^3.2.4"
       },
       "engines": {
         "node": ">=18"
@@ -1278,18 +1280,6 @@
       "dev": true,
       "license": "ISC"
     },
-    "node_modules/jiti": {
-      "version": "2.6.1",
-      "resolved": "https://registry.npmjs.org/jiti/-/jiti-2.6.1.tgz",
-      "integrity": "sha512-ekilCSN1jwRvIbgeg/57YFh8qQDNbwDb9xT/qu2DAHbFFZUicIl4ygVaAvzveMhMVr3LnpSKTNnwt8PoOfmKhQ==",
-      "dev": true,
-      "license": "MIT",
-      "optional": true,
-      "peer": true,
-      "bin": {
-        "jiti": "lib/jiti-cli.mjs"
-      }
-    },
     "node_modules/js-yaml": {
       "version": "4.1.1",
       "resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-4.1.1.tgz",
@@ -1715,6 +1705,1656 @@
       "dependencies": {
         "punycode": "^2.1.0"
       }
+    },
+    "node_modules/vite": {
+      "version": "6.4.3",
+      "resolved": "https://registry.npmjs.org/vite/-/vite-6.4.3.tgz",
+      "integrity": "sha512-NTKlcQjlAK7MlQoyb6LgaqHc8sso/pVyUJYWMws3jg21uTJw/LddqIFPcPqP6PzpgbIcZyKI85sFE4HBrQDA8A==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "esbuild": "^0.25.0",
+        "fdir": "^6.4.4",
+        "picomatch": "^4.0.2",
+        "postcss": "^8.5.3",
+        "rollup": "^4.34.9",
+        "tinyglobby": "^0.2.13"
+      },
+      "bin": {
+        "vite": "bin/vite.js"
+      },
+      "engines": {
+        "node": "^18.0.0 || ^20.0.0 || >=22.0.0"
+      },
+      "funding": {
+        "url": "https://github.com/vitejs/vite?sponsor=1"
+      },
+      "optionalDependencies": {
+        "fsevents": "~2.3.3"
+      },
+      "peerDependencies": {
+        "@types/node": "^18.0.0 || ^20.0.0 || >=22.0.0",
+        "jiti": ">=1.21.0",
+        "less": "*",
+        "lightningcss": "^1.21.0",
+        "sass": "*",
+        "sass-embedded": "*",
+        "stylus": "*",
+        "sugarss": "*",
+        "terser": "^5.16.0",
+        "tsx": "^4.8.1",
+        "yaml": "^2.4.2"
+      },
+      "peerDependenciesMeta": {
+        "@types/node": {
+          "optional": true
+        },
+        "jiti": {
+          "optional": true
+        },
+        "less": {
+          "optional": true
+        },
+        "lightningcss": {
+          "optional": true
+        },
+        "sass": {
+          "optional": true
+        },
+        "sass-embedded": {
+          "optional": true
+        },
+        "stylus": {
+          "optional": true
+        },
+        "sugarss": {
+          "optional": true
+        },
+        "terser": {
+          "optional": true
+        },
+        "tsx": {
+          "optional": true
+        },
+        "yaml": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/vite/node_modules/esbuild": {
+      "version": "0.25.12",
+      "resolved": "https://registry.npmjs.org/esbuild/-/esbuild-0.25.12.tgz",
+      "integrity": "sha512-bbPBYYrtZbkt6Os6FiTLCTFxvq4tt3JKall1vRwshA3fdVztsLAatFaZobhkBC8/BrPetoa0oksYoKXoG4ryJg==",
+      "dev": true,
+      "hasInstallScript": true,
+      "license": "MIT",
+      "bin": {
+        "esbuild": "bin/esbuild"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "optionalDependencies": {
+        "@esbuild/aix-ppc64": "0.25.12",
+        "@esbuild/android-arm": "0.25.12",
+        "@esbuild/android-arm64": "0.25.12",
+        "@esbuild/android-x64": "0.25.12",
+        "@esbuild/darwin-arm64": "0.25.12",
+        "@esbuild/darwin-x64": "0.25.12",
+        "@esbuild/freebsd-arm64": "0.25.12",
+        "@esbuild/freebsd-x64": "0.25.12",
+        "@esbuild/linux-arm": "0.25.12",
+        "@esbuild/linux-arm64": "0.25.12",
+        "@esbuild/linux-ia32": "0.25.12",
+        "@esbuild/linux-loong64": "0.25.12",
+        "@esbuild/linux-mips64el": "0.25.12",
+        "@esbuild/linux-ppc64": "0.25.12",
+        "@esbuild/linux-riscv64": "0.25.12",
+        "@esbuild/linux-s390x": "0.25.12",
+        "@esbuild/linux-x64": "0.25.12",
+        "@esbuild/netbsd-arm64": "0.25.12",
+        "@esbuild/netbsd-x64": "0.25.12",
+        "@esbuild/openbsd-arm64": "0.25.12",
+        "@esbuild/openbsd-x64": "0.25.12",
+        "@esbuild/openharmony-arm64": "0.25.12",
+        "@esbuild/sunos-x64": "0.25.12",
+        "@esbuild/win32-arm64": "0.25.12",
+        "@esbuild/win32-ia32": "0.25.12",
+        "@esbuild/win32-x64": "0.25.12"
+      }
+    },
+    "node_modules/vite/node_modules/esbuild/node_modules/@esbuild/aix-ppc64": {
+      "version": "0.25.12",
+      "resolved": "https://registry.npmjs.org/@esbuild/aix-ppc64/-/aix-ppc64-0.25.12.tgz",
+      "integrity": "sha512-Hhmwd6CInZ3dwpuGTF8fJG6yoWmsToE+vYgD4nytZVxcu1ulHpUQRAB1UJ8+N1Am3Mz4+xOByoQoSZf4D+CpkA==",
+      "cpu": [
+        "ppc64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "aix"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/vite/node_modules/esbuild/node_modules/@esbuild/android-arm": {
+      "version": "0.25.12",
+      "resolved": "https://registry.npmjs.org/@esbuild/android-arm/-/android-arm-0.25.12.tgz",
+      "integrity": "sha512-VJ+sKvNA/GE7Ccacc9Cha7bpS8nyzVv0jdVgwNDaR4gDMC/2TTRc33Ip8qrNYUcpkOHUT5OZ0bUcNNVZQ9RLlg==",
+      "cpu": [
+        "arm"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "android"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/vite/node_modules/esbuild/node_modules/@esbuild/android-arm64": {
+      "version": "0.25.12",
+      "resolved": "https://registry.npmjs.org/@esbuild/android-arm64/-/android-arm64-0.25.12.tgz",
+      "integrity": "sha512-6AAmLG7zwD1Z159jCKPvAxZd4y/VTO0VkprYy+3N2FtJ8+BQWFXU+OxARIwA46c5tdD9SsKGZ/1ocqBS/gAKHg==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "android"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/vite/node_modules/esbuild/node_modules/@esbuild/android-x64": {
+      "version": "0.25.12",
+      "resolved": "https://registry.npmjs.org/@esbuild/android-x64/-/android-x64-0.25.12.tgz",
+      "integrity": "sha512-5jbb+2hhDHx5phYR2By8GTWEzn6I9UqR11Kwf22iKbNpYrsmRB18aX/9ivc5cabcUiAT/wM+YIZ6SG9QO6a8kg==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "android"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/vite/node_modules/esbuild/node_modules/@esbuild/darwin-arm64": {
+      "version": "0.25.12",
+      "resolved": "https://registry.npmjs.org/@esbuild/darwin-arm64/-/darwin-arm64-0.25.12.tgz",
+      "integrity": "sha512-N3zl+lxHCifgIlcMUP5016ESkeQjLj/959RxxNYIthIg+CQHInujFuXeWbWMgnTo4cp5XVHqFPmpyu9J65C1Yg==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/vite/node_modules/esbuild/node_modules/@esbuild/darwin-x64": {
+      "version": "0.25.12",
+      "resolved": "https://registry.npmjs.org/@esbuild/darwin-x64/-/darwin-x64-0.25.12.tgz",
+      "integrity": "sha512-HQ9ka4Kx21qHXwtlTUVbKJOAnmG1ipXhdWTmNXiPzPfWKpXqASVcWdnf2bnL73wgjNrFXAa3yYvBSd9pzfEIpA==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/vite/node_modules/esbuild/node_modules/@esbuild/freebsd-arm64": {
+      "version": "0.25.12",
+      "resolved": "https://registry.npmjs.org/@esbuild/freebsd-arm64/-/freebsd-arm64-0.25.12.tgz",
+      "integrity": "sha512-gA0Bx759+7Jve03K1S0vkOu5Lg/85dou3EseOGUes8flVOGxbhDDh/iZaoek11Y8mtyKPGF3vP8XhnkDEAmzeg==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "freebsd"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/vite/node_modules/esbuild/node_modules/@esbuild/freebsd-x64": {
+      "version": "0.25.12",
+      "resolved": "https://registry.npmjs.org/@esbuild/freebsd-x64/-/freebsd-x64-0.25.12.tgz",
+      "integrity": "sha512-TGbO26Yw2xsHzxtbVFGEXBFH0FRAP7gtcPE7P5yP7wGy7cXK2oO7RyOhL5NLiqTlBh47XhmIUXuGciXEqYFfBQ==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "freebsd"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/vite/node_modules/esbuild/node_modules/@esbuild/linux-arm": {
+      "version": "0.25.12",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-arm/-/linux-arm-0.25.12.tgz",
+      "integrity": "sha512-lPDGyC1JPDou8kGcywY0YILzWlhhnRjdof3UlcoqYmS9El818LLfJJc3PXXgZHrHCAKs/Z2SeZtDJr5MrkxtOw==",
+      "cpu": [
+        "arm"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/vite/node_modules/esbuild/node_modules/@esbuild/linux-arm64": {
+      "version": "0.25.12",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-arm64/-/linux-arm64-0.25.12.tgz",
+      "integrity": "sha512-8bwX7a8FghIgrupcxb4aUmYDLp8pX06rGh5HqDT7bB+8Rdells6mHvrFHHW2JAOPZUbnjUpKTLg6ECyzvas2AQ==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/vite/node_modules/esbuild/node_modules/@esbuild/linux-ia32": {
+      "version": "0.25.12",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-ia32/-/linux-ia32-0.25.12.tgz",
+      "integrity": "sha512-0y9KrdVnbMM2/vG8KfU0byhUN+EFCny9+8g202gYqSSVMonbsCfLjUO+rCci7pM0WBEtz+oK/PIwHkzxkyharA==",
+      "cpu": [
+        "ia32"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/vite/node_modules/esbuild/node_modules/@esbuild/linux-loong64": {
+      "version": "0.25.12",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-loong64/-/linux-loong64-0.25.12.tgz",
+      "integrity": "sha512-h///Lr5a9rib/v1GGqXVGzjL4TMvVTv+s1DPoxQdz7l/AYv6LDSxdIwzxkrPW438oUXiDtwM10o9PmwS/6Z0Ng==",
+      "cpu": [
+        "loong64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/vite/node_modules/esbuild/node_modules/@esbuild/linux-mips64el": {
+      "version": "0.25.12",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-mips64el/-/linux-mips64el-0.25.12.tgz",
+      "integrity": "sha512-iyRrM1Pzy9GFMDLsXn1iHUm18nhKnNMWscjmp4+hpafcZjrr2WbT//d20xaGljXDBYHqRcl8HnxbX6uaA/eGVw==",
+      "cpu": [
+        "mips64el"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/vite/node_modules/esbuild/node_modules/@esbuild/linux-ppc64": {
+      "version": "0.25.12",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-ppc64/-/linux-ppc64-0.25.12.tgz",
+      "integrity": "sha512-9meM/lRXxMi5PSUqEXRCtVjEZBGwB7P/D4yT8UG/mwIdze2aV4Vo6U5gD3+RsoHXKkHCfSxZKzmDssVlRj1QQA==",
+      "cpu": [
+        "ppc64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/vite/node_modules/esbuild/node_modules/@esbuild/linux-riscv64": {
+      "version": "0.25.12",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-riscv64/-/linux-riscv64-0.25.12.tgz",
+      "integrity": "sha512-Zr7KR4hgKUpWAwb1f3o5ygT04MzqVrGEGXGLnj15YQDJErYu/BGg+wmFlIDOdJp0PmB0lLvxFIOXZgFRrdjR0w==",
+      "cpu": [
+        "riscv64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/vite/node_modules/esbuild/node_modules/@esbuild/linux-s390x": {
+      "version": "0.25.12",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-s390x/-/linux-s390x-0.25.12.tgz",
+      "integrity": "sha512-MsKncOcgTNvdtiISc/jZs/Zf8d0cl/t3gYWX8J9ubBnVOwlk65UIEEvgBORTiljloIWnBzLs4qhzPkJcitIzIg==",
+      "cpu": [
+        "s390x"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/vite/node_modules/esbuild/node_modules/@esbuild/linux-x64": {
+      "version": "0.25.12",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-x64/-/linux-x64-0.25.12.tgz",
+      "integrity": "sha512-uqZMTLr/zR/ed4jIGnwSLkaHmPjOjJvnm6TVVitAa08SLS9Z0VM8wIRx7gWbJB5/J54YuIMInDquWyYvQLZkgw==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/vite/node_modules/esbuild/node_modules/@esbuild/netbsd-arm64": {
+      "version": "0.25.12",
+      "resolved": "https://registry.npmjs.org/@esbuild/netbsd-arm64/-/netbsd-arm64-0.25.12.tgz",
+      "integrity": "sha512-xXwcTq4GhRM7J9A8Gv5boanHhRa/Q9KLVmcyXHCTaM4wKfIpWkdXiMog/KsnxzJ0A1+nD+zoecuzqPmCRyBGjg==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "netbsd"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/vite/node_modules/esbuild/node_modules/@esbuild/netbsd-x64": {
+      "version": "0.25.12",
+      "resolved": "https://registry.npmjs.org/@esbuild/netbsd-x64/-/netbsd-x64-0.25.12.tgz",
+      "integrity": "sha512-Ld5pTlzPy3YwGec4OuHh1aCVCRvOXdH8DgRjfDy/oumVovmuSzWfnSJg+VtakB9Cm0gxNO9BzWkj6mtO1FMXkQ==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "netbsd"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/vite/node_modules/esbuild/node_modules/@esbuild/openbsd-arm64": {
+      "version": "0.25.12",
+      "resolved": "https://registry.npmjs.org/@esbuild/openbsd-arm64/-/openbsd-arm64-0.25.12.tgz",
+      "integrity": "sha512-fF96T6KsBo/pkQI950FARU9apGNTSlZGsv1jZBAlcLL1MLjLNIWPBkj5NlSz8aAzYKg+eNqknrUJ24QBybeR5A==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "openbsd"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/vite/node_modules/esbuild/node_modules/@esbuild/openbsd-x64": {
+      "version": "0.25.12",
+      "resolved": "https://registry.npmjs.org/@esbuild/openbsd-x64/-/openbsd-x64-0.25.12.tgz",
+      "integrity": "sha512-MZyXUkZHjQxUvzK7rN8DJ3SRmrVrke8ZyRusHlP+kuwqTcfWLyqMOE3sScPPyeIXN/mDJIfGXvcMqCgYKekoQw==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "openbsd"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/vite/node_modules/esbuild/node_modules/@esbuild/openharmony-arm64": {
+      "version": "0.25.12",
+      "resolved": "https://registry.npmjs.org/@esbuild/openharmony-arm64/-/openharmony-arm64-0.25.12.tgz",
+      "integrity": "sha512-rm0YWsqUSRrjncSXGA7Zv78Nbnw4XL6/dzr20cyrQf7ZmRcsovpcRBdhD43Nuk3y7XIoW2OxMVvwuRvk9XdASg==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "openharmony"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/vite/node_modules/esbuild/node_modules/@esbuild/sunos-x64": {
+      "version": "0.25.12",
+      "resolved": "https://registry.npmjs.org/@esbuild/sunos-x64/-/sunos-x64-0.25.12.tgz",
+      "integrity": "sha512-3wGSCDyuTHQUzt0nV7bocDy72r2lI33QL3gkDNGkod22EsYl04sMf0qLb8luNKTOmgF/eDEDP5BFNwoBKH441w==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "sunos"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/vite/node_modules/esbuild/node_modules/@esbuild/win32-arm64": {
+      "version": "0.25.12",
+      "resolved": "https://registry.npmjs.org/@esbuild/win32-arm64/-/win32-arm64-0.25.12.tgz",
+      "integrity": "sha512-rMmLrur64A7+DKlnSuwqUdRKyd3UE7oPJZmnljqEptesKM8wx9J8gx5u0+9Pq0fQQW8vqeKebwNXdfOyP+8Bsg==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/vite/node_modules/esbuild/node_modules/@esbuild/win32-ia32": {
+      "version": "0.25.12",
+      "resolved": "https://registry.npmjs.org/@esbuild/win32-ia32/-/win32-ia32-0.25.12.tgz",
+      "integrity": "sha512-HkqnmmBoCbCwxUKKNPBixiWDGCpQGVsrQfJoVGYLPT41XWF8lHuE5N6WhVia2n4o5QK5M4tYr21827fNhi4byQ==",
+      "cpu": [
+        "ia32"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/vite/node_modules/esbuild/node_modules/@esbuild/win32-x64": {
+      "version": "0.25.12",
+      "resolved": "https://registry.npmjs.org/@esbuild/win32-x64/-/win32-x64-0.25.12.tgz",
+      "integrity": "sha512-alJC0uCZpTFrSL0CCDjcgleBXPnCrEAhTBILpeAp7M/OFgoqtAetfBzX0xM00MUsVVPpVjlPuMbREqnZCXaTnA==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/vite/node_modules/fdir": {
+      "version": "6.5.0",
+      "resolved": "https://registry.npmjs.org/fdir/-/fdir-6.5.0.tgz",
+      "integrity": "sha512-tIbYtZbucOs0BRGqPJkshJUYdL+SDH7dVM8gjy+ERp3WAUjLEFJE+02kanyHtwjWOnwrKYBiwAmM0p4kLJAnXg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=12.0.0"
+      },
+      "peerDependencies": {
+        "picomatch": "^3 || ^4"
+      },
+      "peerDependenciesMeta": {
+        "picomatch": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/vite/node_modules/fsevents": {
+      "version": "2.3.3",
+      "resolved": "https://registry.npmjs.org/fsevents/-/fsevents-2.3.3.tgz",
+      "integrity": "sha512-5xoDfX+fL7faATnagmWPpbFtwh/R77WmMMqqHGS65C3vvB0YHrgF+B1YmZ3441tMj5n63k0212XNoJwzlhffQw==",
+      "dev": true,
+      "hasInstallScript": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": "^8.16.0 || ^10.6.0 || >=11.0.0"
+      }
+    },
+    "node_modules/vite/node_modules/picomatch": {
+      "version": "4.0.5",
+      "resolved": "https://registry.npmjs.org/picomatch/-/picomatch-4.0.5.tgz",
+      "integrity": "sha512-RvwwcruNjI1ncT5xRakeyS9Lf8lcItv34KD+aif+VH9kduAyfYBipGh12274xtenIPZ119/R9BdTBa8gAwSh0A==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=12"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/jonschlinkert"
+      }
+    },
+    "node_modules/vite/node_modules/postcss": {
+      "version": "8.5.26",
+      "resolved": "https://registry.npmjs.org/postcss/-/postcss-8.5.26.tgz",
+      "integrity": "sha512-u82N74LFzG8ca+dD8puPnplTXoGH4fTPpVGuIbt36G3qvNlkvfD0lEAZSxaly3KX8TS/L1A1gsCEmvKmBcVbkQ==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "opencollective",
+          "url": "https://opencollective.com/postcss/"
+        },
+        {
+          "type": "tidelift",
+          "url": "https://tidelift.com/funding/github/npm/postcss"
+        },
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/ai"
+        }
+      ],
+      "license": "MIT",
+      "dependencies": {
+        "nanoid": "^3.3.17",
+        "picocolors": "^1.1.1",
+        "source-map-js": "^1.2.1"
+      },
+      "engines": {
+        "node": "^10 || ^12 || >=14"
+      }
+    },
+    "node_modules/vite/node_modules/postcss/node_modules/nanoid": {
+      "version": "3.3.18",
+      "resolved": "https://registry.npmjs.org/nanoid/-/nanoid-3.3.18.tgz",
+      "integrity": "sha512-DTg4MJbGMWkfi6VZFdNt2/caMbQy4Ou+Op/hJQvGEWcnVfoA1QA+xzRKAzw9jD6+GVOOeYr/mIcuDSdug6F6+w==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/ai"
+        }
+      ],
+      "license": "MIT",
+      "bin": {
+        "nanoid": "bin/nanoid.cjs"
+      },
+      "engines": {
+        "node": "^10 || ^12 || ^13.7 || ^14 || >=15.0.1"
+      }
+    },
+    "node_modules/vite/node_modules/postcss/node_modules/picocolors": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/picocolors/-/picocolors-1.1.1.tgz",
+      "integrity": "sha512-xceH2snhtb5M9liqDsmEw56le376mTZkEX/jEb/RxNFyegNul7eNslCXP9FDj/Lcu0X8KEyMceP2ntpaHrDEVA==",
+      "dev": true,
+      "license": "ISC"
+    },
+    "node_modules/vite/node_modules/postcss/node_modules/source-map-js": {
+      "version": "1.2.1",
+      "resolved": "https://registry.npmjs.org/source-map-js/-/source-map-js-1.2.1.tgz",
+      "integrity": "sha512-UXWMKhLOwVKb728IUtQPXxfYU+usdybtUrK/8uGE8CQMvrhOpwvzDBwj0QhSL7MQc7vIsISBG8VQ8+IDQxpfQA==",
+      "dev": true,
+      "license": "BSD-3-Clause",
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/vite/node_modules/rollup": {
+      "version": "4.62.4",
+      "resolved": "https://registry.npmjs.org/rollup/-/rollup-4.62.4.tgz",
+      "integrity": "sha512-RXOqwaPsBGjMNMa4sQjDjHieHEZDFoj/Rdr46l2MU5DfEs16wHJPC2RPTPHWhNl+M3aI472LLqFkFKut4SblOg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@types/estree": "1.0.9"
+      },
+      "bin": {
+        "rollup": "dist/bin/rollup"
+      },
+      "engines": {
+        "node": ">=18.0.0",
+        "npm": ">=8.0.0"
+      },
+      "optionalDependencies": {
+        "@napi-rs/lzma-linux-x64-gnu": "1.5.1",
+        "@rollup/rollup-android-arm-eabi": "4.62.4",
+        "@rollup/rollup-android-arm64": "4.62.4",
+        "@rollup/rollup-darwin-arm64": "4.62.4",
+        "@rollup/rollup-darwin-x64": "4.62.4",
+        "@rollup/rollup-freebsd-arm64": "4.62.4",
+        "@rollup/rollup-freebsd-x64": "4.62.4",
+        "@rollup/rollup-linux-arm-gnueabihf": "4.62.4",
+        "@rollup/rollup-linux-arm-musleabihf": "4.62.4",
+        "@rollup/rollup-linux-arm64-gnu": "4.62.4",
+        "@rollup/rollup-linux-arm64-musl": "4.62.4",
+        "@rollup/rollup-linux-loong64-gnu": "4.62.4",
+        "@rollup/rollup-linux-loong64-musl": "4.62.4",
+        "@rollup/rollup-linux-ppc64-gnu": "4.62.4",
+        "@rollup/rollup-linux-ppc64-musl": "4.62.4",
+        "@rollup/rollup-linux-riscv64-gnu": "4.62.4",
+        "@rollup/rollup-linux-riscv64-musl": "4.62.4",
+        "@rollup/rollup-linux-s390x-gnu": "4.62.4",
+        "@rollup/rollup-linux-x64-gnu": "4.62.4",
+        "@rollup/rollup-linux-x64-musl": "4.62.4",
+        "@rollup/rollup-openbsd-x64": "4.62.4",
+        "@rollup/rollup-openharmony-arm64": "4.62.4",
+        "@rollup/rollup-win32-arm64-msvc": "4.62.4",
+        "@rollup/rollup-win32-ia32-msvc": "4.62.4",
+        "@rollup/rollup-win32-x64-gnu": "4.62.4",
+        "@rollup/rollup-win32-x64-msvc": "4.62.4",
+        "fsevents": "~2.3.2"
+      }
+    },
+    "node_modules/vite/node_modules/rollup/node_modules/@napi-rs/lzma-linux-x64-gnu": {
+      "version": "1.5.1",
+      "resolved": "https://registry.npmjs.org/@napi-rs/lzma-linux-x64-gnu/-/lzma-linux-x64-gnu-1.5.1.tgz",
+      "integrity": "sha512-oTXEIha4SsuXdTA4Iyskj0kpdx2yVXdhd75c2v3xGrHFfVMsbhTPZU/nMPL4sWKo4pBHm3aucLaqGlF696dTyQ==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "libc": [
+        "glibc"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": "^22.20 || ^24.12 || >=25"
+      }
+    },
+    "node_modules/vite/node_modules/rollup/node_modules/@rollup/rollup-android-arm-eabi": {
+      "version": "4.62.4",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-android-arm-eabi/-/rollup-android-arm-eabi-4.62.4.tgz",
+      "integrity": "sha512-RrPokAb7dmbxFoeO3TloqHyOjgye8RkBhSqmp4aJMIex4c9r46ZstPnleDQOq1t46VOVjwIuwNogIqbodV1Vvg==",
+      "cpu": [
+        "arm"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "android"
+      ]
+    },
+    "node_modules/vite/node_modules/rollup/node_modules/@rollup/rollup-android-arm64": {
+      "version": "4.62.4",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-android-arm64/-/rollup-android-arm64-4.62.4.tgz",
+      "integrity": "sha512-JKuJc+pnpks2pjy7L/N3v/cAkZxYlnmuZoD840ldbMI5KDbC4iO9NKwPKYdjYFCMAIIlBzYSFHxIJVYzRo2/8A==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "android"
+      ]
+    },
+    "node_modules/vite/node_modules/rollup/node_modules/@rollup/rollup-darwin-arm64": {
+      "version": "4.62.4",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-darwin-arm64/-/rollup-darwin-arm64-4.62.4.tgz",
+      "integrity": "sha512-krw5uS2STmvJ02x0uTXHbqQNuz+9eZ1iw+qXk9dmW2gvV4jV7O2hEoOnuhFrpOPiel1mBFtqbxYZZtC46hXLOw==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ]
+    },
+    "node_modules/vite/node_modules/rollup/node_modules/@rollup/rollup-darwin-x64": {
+      "version": "4.62.4",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-darwin-x64/-/rollup-darwin-x64-4.62.4.tgz",
+      "integrity": "sha512-wsTxtgApb4PrOsNJIm0FZ1h3WvCC+k9uxLJ4ad75hgoS4NiRes2SoJFlDAyMwiUY8IssDqGcHbXuN0sx1tfF1A==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ]
+    },
+    "node_modules/vite/node_modules/rollup/node_modules/@rollup/rollup-freebsd-arm64": {
+      "version": "4.62.4",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-freebsd-arm64/-/rollup-freebsd-arm64-4.62.4.tgz",
+      "integrity": "sha512-GUOnQlyZe3yAXhWOtOMsn5Qkrv5E5mZXa0thbARWi5Ei2szlVXJFQhddZ4HbAzh8q92w5twp+CQvs/eFanz9YQ==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "freebsd"
+      ]
+    },
+    "node_modules/vite/node_modules/rollup/node_modules/@rollup/rollup-freebsd-x64": {
+      "version": "4.62.4",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-freebsd-x64/-/rollup-freebsd-x64-4.62.4.tgz",
+      "integrity": "sha512-/Y7f3QuxjzPKsjA/rfEDa3+0vXqyjmJ50Ln8dPpCmWkKTrUoWHG1cWhTqaAMLob2m2nESWuC7yGrREz019Ztqg==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "freebsd"
+      ]
+    },
+    "node_modules/vite/node_modules/rollup/node_modules/@rollup/rollup-linux-arm-gnueabihf": {
+      "version": "4.62.4",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-arm-gnueabihf/-/rollup-linux-arm-gnueabihf-4.62.4.tgz",
+      "integrity": "sha512-81wiiX3v7aqy+T+bT61TJ78yJjRquqFFTTbAPt08imfQQzkPIW8t6aJbkTagtCCrXMNc9D66+geqlK7ydLPNqA==",
+      "cpu": [
+        "arm"
+      ],
+      "dev": true,
+      "libc": [
+        "glibc"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/vite/node_modules/rollup/node_modules/@rollup/rollup-linux-arm-musleabihf": {
+      "version": "4.62.4",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-arm-musleabihf/-/rollup-linux-arm-musleabihf-4.62.4.tgz",
+      "integrity": "sha512-9kmDIvNZqdoHOBZgNtpTBeLWYO/LVipM3H/j62P8848/l/VPEQL6N3uxU9pvP1oZAsXyC2MEnFP3ovRjo7WYNQ==",
+      "cpu": [
+        "arm"
+      ],
+      "dev": true,
+      "libc": [
+        "musl"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/vite/node_modules/rollup/node_modules/@rollup/rollup-linux-arm64-gnu": {
+      "version": "4.62.4",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-arm64-gnu/-/rollup-linux-arm64-gnu-4.62.4.tgz",
+      "integrity": "sha512-CcnXHWnXg69g+DX5VWL3FHts3qMRN2uVEHX+BZvGLdd07/gXkn3ePjYtO1LDJvxkGKVHMclKBRa1QUTH+6toYQ==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "libc": [
+        "glibc"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/vite/node_modules/rollup/node_modules/@rollup/rollup-linux-arm64-musl": {
+      "version": "4.62.4",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-arm64-musl/-/rollup-linux-arm64-musl-4.62.4.tgz",
+      "integrity": "sha512-iFOibiHnTRuhrWLlRsOQFdZJJIa7S8OwkneJr4ocALP16u5yk6lWLINFwhHaEqBFMsKDUZofLkGos7+CPzGB3g==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "libc": [
+        "musl"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/vite/node_modules/rollup/node_modules/@rollup/rollup-linux-loong64-gnu": {
+      "version": "4.62.4",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-loong64-gnu/-/rollup-linux-loong64-gnu-4.62.4.tgz",
+      "integrity": "sha512-XnWYMI7euHlb5a871xPja+Gm7DRCFU+FGRrtS2sMq9N8FvqtpagUy6gD4YOemC5MRk9xbh8+jYMEJbigFQwsgA==",
+      "cpu": [
+        "loong64"
+      ],
+      "dev": true,
+      "libc": [
+        "glibc"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/vite/node_modules/rollup/node_modules/@rollup/rollup-linux-loong64-musl": {
+      "version": "4.62.4",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-loong64-musl/-/rollup-linux-loong64-musl-4.62.4.tgz",
+      "integrity": "sha512-qGDAlO0U8xedCcsdRm9oaoQY8DAx/QT7uIxJWhCdx0ceIWX783UC9QSYkdpzAe29wNiVfp24+bZdQmn49o45SQ==",
+      "cpu": [
+        "loong64"
+      ],
+      "dev": true,
+      "libc": [
+        "musl"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/vite/node_modules/rollup/node_modules/@rollup/rollup-linux-ppc64-gnu": {
+      "version": "4.62.4",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-ppc64-gnu/-/rollup-linux-ppc64-gnu-4.62.4.tgz",
+      "integrity": "sha512-ru4H6ezD7ysA5EiEK6qkkaEb4modH8CTej6kUy/gQi20u3kB3G7Zn8snXXkeJSCOFKG/rbPPtM/+9Wgas1961w==",
+      "cpu": [
+        "ppc64"
+      ],
+      "dev": true,
+      "libc": [
+        "glibc"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/vite/node_modules/rollup/node_modules/@rollup/rollup-linux-ppc64-musl": {
+      "version": "4.62.4",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-ppc64-musl/-/rollup-linux-ppc64-musl-4.62.4.tgz",
+      "integrity": "sha512-2W4MO5WQVJnbJaZdvDb9rhBDuFU1nKIepPFpJUBsTh2k1YY2g+ODViaWuyOAjQ5cOP7NvrvLzt3wvHOoiAvc7w==",
+      "cpu": [
+        "ppc64"
+      ],
+      "dev": true,
+      "libc": [
+        "musl"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/vite/node_modules/rollup/node_modules/@rollup/rollup-linux-riscv64-gnu": {
+      "version": "4.62.4",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-riscv64-gnu/-/rollup-linux-riscv64-gnu-4.62.4.tgz",
+      "integrity": "sha512-+fxjfuoAmVMCYV5QyjoIpu0cp5DOiOTeqYFk1AVaxGr+/ravWLX89XfQmptsoWcaVy/TGf2hexzbUOrCQIL1CQ==",
+      "cpu": [
+        "riscv64"
+      ],
+      "dev": true,
+      "libc": [
+        "glibc"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/vite/node_modules/rollup/node_modules/@rollup/rollup-linux-riscv64-musl": {
+      "version": "4.62.4",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-riscv64-musl/-/rollup-linux-riscv64-musl-4.62.4.tgz",
+      "integrity": "sha512-jTn8JfHGL4djjFxPuM06LmNUJDsst2jeVlsd9OmIH6zc5sC9K6rIuO4YajXatLUpBmBKl6b35ro1QZocLi+tcA==",
+      "cpu": [
+        "riscv64"
+      ],
+      "dev": true,
+      "libc": [
+        "musl"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/vite/node_modules/rollup/node_modules/@rollup/rollup-linux-s390x-gnu": {
+      "version": "4.62.4",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-s390x-gnu/-/rollup-linux-s390x-gnu-4.62.4.tgz",
+      "integrity": "sha512-oCJCJL4pXsoDcP2QZ+JVlPTIRc6266zsIaeJJsWImmF7HO0W8nb6HuSgZlMWxJwaPf8ehbSw8yo0EUw925hKsA==",
+      "cpu": [
+        "s390x"
+      ],
+      "dev": true,
+      "libc": [
+        "glibc"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/vite/node_modules/rollup/node_modules/@rollup/rollup-linux-x64-gnu": {
+      "version": "4.62.4",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-x64-gnu/-/rollup-linux-x64-gnu-4.62.4.tgz",
+      "integrity": "sha512-W69hukhZ3KKNRCaMIEzKvcFye42hh0FE1+YoYaf5+Ikacuftoco6yO/xouz0hc5d5W/s3yBro5jRiuEE/Q5vUw==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "libc": [
+        "glibc"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/vite/node_modules/rollup/node_modules/@rollup/rollup-linux-x64-musl": {
+      "version": "4.62.4",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-x64-musl/-/rollup-linux-x64-musl-4.62.4.tgz",
+      "integrity": "sha512-qiXbGG2jkjXhzXpsFZSR2Xpb8DN/UaxYsbb/STbuR/6fpaDgRmmaq1B/LmtF2wQFOFOSsK2jdE0RZ3a0zHn4QA==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "libc": [
+        "musl"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/vite/node_modules/rollup/node_modules/@rollup/rollup-openbsd-x64": {
+      "version": "4.62.4",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-openbsd-x64/-/rollup-openbsd-x64-4.62.4.tgz",
+      "integrity": "sha512-nWeM//hxv8mIo6jD7Hu4o48DVmV9pbV6gsKaWU+4NFyqHoPKwrkRiZGLKUhOBk8qNmDmpwFtPKg80Bo/Tn4xiQ==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "openbsd"
+      ]
+    },
+    "node_modules/vite/node_modules/rollup/node_modules/@rollup/rollup-openharmony-arm64": {
+      "version": "4.62.4",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-openharmony-arm64/-/rollup-openharmony-arm64-4.62.4.tgz",
+      "integrity": "sha512-s62SQ/vgsRSvMwDkOEfTqfgASF0f26ZNaQuTA6Aok5lrikf89yI2W0gFHvZb2Jpgc6N8JnOKZgCK2iciO3CsxQ==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "openharmony"
+      ]
+    },
+    "node_modules/vite/node_modules/rollup/node_modules/@rollup/rollup-win32-arm64-msvc": {
+      "version": "4.62.4",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-win32-arm64-msvc/-/rollup-win32-arm64-msvc-4.62.4.tgz",
+      "integrity": "sha512-J6wGf8TVGbXJq+HH+ttTvrcfNKPbuZecV6KT1B8I18BC5IURUh5kl4Yl5OEP5eFIUoI5BWxCsyYMhFsDx8kekw==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ]
+    },
+    "node_modules/vite/node_modules/rollup/node_modules/@rollup/rollup-win32-ia32-msvc": {
+      "version": "4.62.4",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-win32-ia32-msvc/-/rollup-win32-ia32-msvc-4.62.4.tgz",
+      "integrity": "sha512-zmfrQd/0wu6oJs8Vq8KwY/YtsKSsLtKe/HwAP4Wqy8LhWjeT55fHRAkOhYQ12wI3ayS4Tt12d5CDRD7N96SAYQ==",
+      "cpu": [
+        "ia32"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ]
+    },
+    "node_modules/vite/node_modules/rollup/node_modules/@rollup/rollup-win32-x64-gnu": {
+      "version": "4.62.4",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-win32-x64-gnu/-/rollup-win32-x64-gnu-4.62.4.tgz",
+      "integrity": "sha512-qPzHqdj9rfUD+w79dtE07zi/kFwKyCJqplp5K5ygeLTp7jLpAoc16OAH39HSmRC9UpozaecsleI8uAdEj6v2yw==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ]
+    },
+    "node_modules/vite/node_modules/rollup/node_modules/@rollup/rollup-win32-x64-msvc": {
+      "version": "4.62.4",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-win32-x64-msvc/-/rollup-win32-x64-msvc-4.62.4.tgz",
+      "integrity": "sha512-zD6NdeWEByGE9QF9vCrlJ5YQB4oq9q91kPZS37Jwj5hOkvR1lTBSpsKhKDw4IJtbQ35LsTS1HD9DZYGKIshU1Q==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ]
+    },
+    "node_modules/vite/node_modules/rollup/node_modules/@types/estree": {
+      "version": "1.0.9",
+      "resolved": "https://registry.npmjs.org/@types/estree/-/estree-1.0.9.tgz",
+      "integrity": "sha512-GhdPgy1el4/ImP05X05Uw4cw2/M93BCUmnEvWZNStlCzEKME4Fkk+YpoA5OiHNQmoS7Cafb8Xa3Pya8m1Qrzeg==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/vitest": {
+      "version": "3.2.7",
+      "resolved": "https://registry.npmjs.org/vitest/-/vitest-3.2.7.tgz",
+      "integrity": "sha512-KrxIJ62Fd89gfysR4WotlgZABiz2dqFPgqGzX7s+CwsqLFomRH7777ZcrOD6+WVAh7khPQP41A+BKbpcJFrdEg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@types/chai": "^5.2.2",
+        "@vitest/expect": "3.2.7",
+        "@vitest/mocker": "3.2.7",
+        "@vitest/pretty-format": "^3.2.7",
+        "@vitest/runner": "3.2.7",
+        "@vitest/snapshot": "3.2.7",
+        "@vitest/spy": "3.2.7",
+        "@vitest/utils": "3.2.7",
+        "chai": "^5.2.0",
+        "debug": "^4.4.1",
+        "expect-type": "^1.2.1",
+        "magic-string": "^0.30.17",
+        "pathe": "^2.0.3",
+        "picomatch": "^4.0.2",
+        "std-env": "^3.9.0",
+        "tinybench": "^2.9.0",
+        "tinyexec": "^0.3.2",
+        "tinyglobby": "^0.2.14",
+        "tinypool": "^1.1.1",
+        "tinyrainbow": "^2.0.0",
+        "vite": "^5.0.0 || ^6.0.0 || ^7.0.0-0",
+        "vite-node": "3.2.4",
+        "why-is-node-running": "^2.3.0"
+      },
+      "bin": {
+        "vitest": "vitest.mjs"
+      },
+      "engines": {
+        "node": "^18.0.0 || ^20.0.0 || >=22.0.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      },
+      "peerDependencies": {
+        "@edge-runtime/vm": "*",
+        "@types/debug": "^4.1.12",
+        "@types/node": "^18.0.0 || ^20.0.0 || >=22.0.0",
+        "@vitest/browser": "3.2.7",
+        "@vitest/ui": "3.2.7",
+        "happy-dom": "*",
+        "jsdom": "*"
+      },
+      "peerDependenciesMeta": {
+        "@edge-runtime/vm": {
+          "optional": true
+        },
+        "@types/debug": {
+          "optional": true
+        },
+        "@types/node": {
+          "optional": true
+        },
+        "@vitest/browser": {
+          "optional": true
+        },
+        "@vitest/ui": {
+          "optional": true
+        },
+        "happy-dom": {
+          "optional": true
+        },
+        "jsdom": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/vitest/node_modules/@types/chai": {
+      "version": "5.2.3",
+      "resolved": "https://registry.npmjs.org/@types/chai/-/chai-5.2.3.tgz",
+      "integrity": "sha512-Mw558oeA9fFbv65/y4mHtXDs9bPnFMZAL/jxdPFUpOHHIXX91mcgEHbS5Lahr+pwZFR8A7GQleRWeI6cGFC2UA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@types/deep-eql": "*",
+        "assertion-error": "^2.0.1"
+      }
+    },
+    "node_modules/vitest/node_modules/@types/chai/node_modules/@types/deep-eql": {
+      "version": "4.0.2",
+      "resolved": "https://registry.npmjs.org/@types/deep-eql/-/deep-eql-4.0.2.tgz",
+      "integrity": "sha512-c9h9dVVMigMPc4bwTvC5dxqtqJZwQPePsWjPlpSOnojbor6pGqdk541lfA7AqFQr5pB1BRdq0juY9db81BwyFw==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/vitest/node_modules/@types/chai/node_modules/assertion-error": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/assertion-error/-/assertion-error-2.0.1.tgz",
+      "integrity": "sha512-Izi8RQcffqCeNVgFigKli1ssklIbpHnCYc6AknXGYoB6grJqyeby7jv12JUQgmTAnIDnbck1uxksT4dzN3PWBA==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/vitest/node_modules/@vitest/expect": {
+      "version": "3.2.7",
+      "resolved": "https://registry.npmjs.org/@vitest/expect/-/expect-3.2.7.tgz",
+      "integrity": "sha512-E8eBXaKibuvH2pSZErOjdVb5vF4PbKYcrnluBTYxEk1l/VhhwZg1kZQsdtjq+CsF5CFydf2Rdkz7jDHKSisi3w==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@types/chai": "^5.2.2",
+        "@vitest/spy": "3.2.7",
+        "@vitest/utils": "3.2.7",
+        "chai": "^5.2.0",
+        "tinyrainbow": "^2.0.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      }
+    },
+    "node_modules/vitest/node_modules/@vitest/mocker": {
+      "version": "3.2.7",
+      "resolved": "https://registry.npmjs.org/@vitest/mocker/-/mocker-3.2.7.tgz",
+      "integrity": "sha512-Trr0hYO9CM3Wj6ksWHRhK9IZpIY6wTMO5u/MqXurMxT57sWBaOPEtP3Oq60ihZuh5JsiagKfz95OcxdEP6dBrA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@vitest/spy": "3.2.7",
+        "estree-walker": "^3.0.3",
+        "magic-string": "^0.30.17"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      },
+      "peerDependencies": {
+        "msw": "^2.4.9",
+        "vite": "^5.0.0 || ^6.0.0 || ^7.0.0-0"
+      },
+      "peerDependenciesMeta": {
+        "msw": {
+          "optional": true
+        },
+        "vite": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/vitest/node_modules/@vitest/mocker/node_modules/estree-walker": {
+      "version": "3.0.3",
+      "resolved": "https://registry.npmjs.org/estree-walker/-/estree-walker-3.0.3.tgz",
+      "integrity": "sha512-7RUKfXgSMMkzt6ZuXmqapOurLGPPfgj6l9uRZ7lRGolvk0y2yocc35LdcxKC5PQZdn2DMqioAQ2NoWcrTKmm6g==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@types/estree": "^1.0.0"
+      }
+    },
+    "node_modules/vitest/node_modules/@vitest/mocker/node_modules/estree-walker/node_modules/@types/estree": {
+      "version": "1.0.9",
+      "resolved": "https://registry.npmjs.org/@types/estree/-/estree-1.0.9.tgz",
+      "integrity": "sha512-GhdPgy1el4/ImP05X05Uw4cw2/M93BCUmnEvWZNStlCzEKME4Fkk+YpoA5OiHNQmoS7Cafb8Xa3Pya8m1Qrzeg==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/vitest/node_modules/@vitest/pretty-format": {
+      "version": "3.2.7",
+      "resolved": "https://registry.npmjs.org/@vitest/pretty-format/-/pretty-format-3.2.7.tgz",
+      "integrity": "sha512-KUHlwqVu0sRlhCdyPdQ/wBoTfRahjUky1MubOmYw9fWfIZy1gNoHpuaaQBPAaMaVYdQYHJLurzj8ECCj5OwTqA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "tinyrainbow": "^2.0.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      }
+    },
+    "node_modules/vitest/node_modules/@vitest/runner": {
+      "version": "3.2.7",
+      "resolved": "https://registry.npmjs.org/@vitest/runner/-/runner-3.2.7.tgz",
+      "integrity": "sha512-sB9y4ovltoQP+WaUPwmSxO9WIg9Ig694Di5PalVPsYHklAdE027mehpWF2SQSVq+k6sFgaivbTjTJwZLSHbedA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@vitest/utils": "3.2.7",
+        "pathe": "^2.0.3",
+        "strip-literal": "^3.0.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      }
+    },
+    "node_modules/vitest/node_modules/@vitest/runner/node_modules/strip-literal": {
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/strip-literal/-/strip-literal-3.1.0.tgz",
+      "integrity": "sha512-8r3mkIM/2+PpjHoOtiAW8Rg3jJLHaV7xPwG+YRGrv6FP0wwk/toTpATxWYOW0BKdWwl82VT2tFYi5DlROa0Mxg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "js-tokens": "^9.0.1"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/antfu"
+      }
+    },
+    "node_modules/vitest/node_modules/@vitest/runner/node_modules/strip-literal/node_modules/js-tokens": {
+      "version": "9.0.1",
+      "resolved": "https://registry.npmjs.org/js-tokens/-/js-tokens-9.0.1.tgz",
+      "integrity": "sha512-mxa9E9ITFOt0ban3j6L5MpjwegGz6lBQmM1IJkWeBZGcMxto50+eWdjC/52xDbS2vy0k7vIMK0Fe2wfL9OQSpQ==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/vitest/node_modules/@vitest/snapshot": {
+      "version": "3.2.7",
+      "resolved": "https://registry.npmjs.org/@vitest/snapshot/-/snapshot-3.2.7.tgz",
+      "integrity": "sha512-7C+MwShwtBSI5Buwoyg3s/iY1eHL9PKAf+O1wVh/TdnjXUtkoL/9YQtre90i4MtNXM6edP1wJ2zOBpfCyhIS7g==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@vitest/pretty-format": "3.2.7",
+        "magic-string": "^0.30.17",
+        "pathe": "^2.0.3"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      }
+    },
+    "node_modules/vitest/node_modules/@vitest/spy": {
+      "version": "3.2.7",
+      "resolved": "https://registry.npmjs.org/@vitest/spy/-/spy-3.2.7.tgz",
+      "integrity": "sha512-Q2eQGI6d2L/hBtZ0qNuKcAGid68XK6cv1xsoaIma6PaJhHPoqcEJhYpXZ/5myCMqkNgtP6UKuBhbc0nHKnrkuQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "tinyspy": "^4.0.3"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      }
+    },
+    "node_modules/vitest/node_modules/@vitest/spy/node_modules/tinyspy": {
+      "version": "4.0.4",
+      "resolved": "https://registry.npmjs.org/tinyspy/-/tinyspy-4.0.4.tgz",
+      "integrity": "sha512-azl+t0z7pw/z958Gy9svOTuzqIk6xq+NSheJzn5MMWtWTFywIacg2wUlzKFGtt3cthx0r2SxMK0yzJOR0IES7Q==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=14.0.0"
+      }
+    },
+    "node_modules/vitest/node_modules/@vitest/utils": {
+      "version": "3.2.7",
+      "resolved": "https://registry.npmjs.org/@vitest/utils/-/utils-3.2.7.tgz",
+      "integrity": "sha512-x6BDOd7dyo3PFLY3I9/HJ25X/6OurhGXk2/B9gOZNPF7XDVjeBK4k01lQE5uvDpbuheErh91qYuE1E2OEjK3Rw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@vitest/pretty-format": "3.2.7",
+        "loupe": "^3.1.4",
+        "tinyrainbow": "^2.0.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      }
+    },
+    "node_modules/vitest/node_modules/@vitest/utils/node_modules/loupe": {
+      "version": "3.2.1",
+      "resolved": "https://registry.npmjs.org/loupe/-/loupe-3.2.1.tgz",
+      "integrity": "sha512-CdzqowRJCeLU72bHvWqwRBBlLcMEtIvGrlvef74kMnV2AolS9Y8xUv1I0U/MNAWMhBlKIoyuEgoJ0t/bbwHbLQ==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/vitest/node_modules/chai": {
+      "version": "5.3.3",
+      "resolved": "https://registry.npmjs.org/chai/-/chai-5.3.3.tgz",
+      "integrity": "sha512-4zNhdJD/iOjSH0A05ea+Ke6MU5mmpQcbQsSOkgdaUMJ9zTlDTD/GYlwohmIE2u0gaxHYiVHEn1Fw9mZ/ktJWgw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "assertion-error": "^2.0.1",
+        "check-error": "^2.1.1",
+        "deep-eql": "^5.0.1",
+        "loupe": "^3.1.0",
+        "pathval": "^2.0.0"
+      },
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/vitest/node_modules/chai/node_modules/assertion-error": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/assertion-error/-/assertion-error-2.0.1.tgz",
+      "integrity": "sha512-Izi8RQcffqCeNVgFigKli1ssklIbpHnCYc6AknXGYoB6grJqyeby7jv12JUQgmTAnIDnbck1uxksT4dzN3PWBA==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/vitest/node_modules/chai/node_modules/check-error": {
+      "version": "2.1.3",
+      "resolved": "https://registry.npmjs.org/check-error/-/check-error-2.1.3.tgz",
+      "integrity": "sha512-PAJdDJusoxnwm1VwW07VWwUN1sl7smmC3OKggvndJFadxxDRyFJBX/ggnu/KE4kQAB7a3Dp8f/YXC1FlUprWmA==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">= 16"
+      }
+    },
+    "node_modules/vitest/node_modules/chai/node_modules/deep-eql": {
+      "version": "5.0.2",
+      "resolved": "https://registry.npmjs.org/deep-eql/-/deep-eql-5.0.2.tgz",
+      "integrity": "sha512-h5k/5U50IJJFpzfL6nO9jaaumfjO/f2NjK/oYB2Djzm4p9L+3T9qWpZqZ2hAbLPuuYq9wrU08WQyBTL5GbPk5Q==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=6"
+      }
+    },
+    "node_modules/vitest/node_modules/chai/node_modules/loupe": {
+      "version": "3.2.1",
+      "resolved": "https://registry.npmjs.org/loupe/-/loupe-3.2.1.tgz",
+      "integrity": "sha512-CdzqowRJCeLU72bHvWqwRBBlLcMEtIvGrlvef74kMnV2AolS9Y8xUv1I0U/MNAWMhBlKIoyuEgoJ0t/bbwHbLQ==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/vitest/node_modules/chai/node_modules/pathval": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/pathval/-/pathval-2.0.1.tgz",
+      "integrity": "sha512-//nshmD55c46FuFw26xV/xFAaB5HF9Xdap7HJBBnrKdAd6/GxDBaNA1870O79+9ueg61cZLSVc+OaFlfmObYVQ==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">= 14.16"
+      }
+    },
+    "node_modules/vitest/node_modules/debug": {
+      "version": "4.4.3",
+      "resolved": "https://registry.npmjs.org/debug/-/debug-4.4.3.tgz",
+      "integrity": "sha512-RGwwWnwQvkVfavKVt22FGLw+xYSdzARwm0ru6DhTVA3umU5hZc28V3kO4stgYryrTlLpuvgI9GiijltAjNbcqA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "ms": "^2.1.3"
+      },
+      "engines": {
+        "node": ">=6.0"
+      },
+      "peerDependenciesMeta": {
+        "supports-color": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/vitest/node_modules/debug/node_modules/ms": {
+      "version": "2.1.3",
+      "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.3.tgz",
+      "integrity": "sha512-6FlzubTLZG3J2a/NVCAleEhjzq5oxgHyaCU9yYXvcLsvoVaHJq/s5xXI6/XXP6tz7R9xAOtHnSO/tXtF3WRTlA==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/vitest/node_modules/expect-type": {
+      "version": "1.4.0",
+      "resolved": "https://registry.npmjs.org/expect-type/-/expect-type-1.4.0.tgz",
+      "integrity": "sha512-KfYbmpRm0VbLjEvVa9yGwCi9GI34xvi7A/HXYWQO65CSD2u3MczUJSuwXKFIxlGsgBQizV9q5J9NHj4VG0n+pA==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "engines": {
+        "node": ">=12.0.0"
+      }
+    },
+    "node_modules/vitest/node_modules/magic-string": {
+      "version": "0.30.21",
+      "resolved": "https://registry.npmjs.org/magic-string/-/magic-string-0.30.21.tgz",
+      "integrity": "sha512-vd2F4YUyEXKGcLHoq+TEyCjxueSeHnFxyyjNp80yg0XV4vUhnDer/lvvlqM/arB5bXQN5K2/3oinyCRyx8T2CQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@jridgewell/sourcemap-codec": "^1.5.5"
+      }
+    },
+    "node_modules/vitest/node_modules/magic-string/node_modules/@jridgewell/sourcemap-codec": {
+      "version": "1.5.5",
+      "resolved": "https://registry.npmjs.org/@jridgewell/sourcemap-codec/-/sourcemap-codec-1.5.5.tgz",
+      "integrity": "sha512-cYQ9310grqxueWbl+WuIUIaiUaDcj7WOq5fVhEljNVgRfOUhY9fy2zTvfoqWsnebh8Sl70VScFbICvJnLKB0Og==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/vitest/node_modules/pathe": {
+      "version": "2.0.3",
+      "resolved": "https://registry.npmjs.org/pathe/-/pathe-2.0.3.tgz",
+      "integrity": "sha512-WUjGcAqP1gQacoQe+OBJsFA7Ld4DyXuUIjZ5cc75cLHvJ7dtNsTugphxIADwspS+AraAUePCKrSVtPLFj/F88w==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/vitest/node_modules/picomatch": {
+      "version": "4.0.5",
+      "resolved": "https://registry.npmjs.org/picomatch/-/picomatch-4.0.5.tgz",
+      "integrity": "sha512-RvwwcruNjI1ncT5xRakeyS9Lf8lcItv34KD+aif+VH9kduAyfYBipGh12274xtenIPZ119/R9BdTBa8gAwSh0A==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=12"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/jonschlinkert"
+      }
+    },
+    "node_modules/vitest/node_modules/std-env": {
+      "version": "3.10.0",
+      "resolved": "https://registry.npmjs.org/std-env/-/std-env-3.10.0.tgz",
+      "integrity": "sha512-5GS12FdOZNliM5mAOxFRg7Ir0pWz8MdpYm6AY6VPkGpbA7ZzmbzNcBJQ0GPvvyWgcY7QAhCgf9Uy89I03faLkg==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/vitest/node_modules/tinybench": {
+      "version": "2.9.0",
+      "resolved": "https://registry.npmjs.org/tinybench/-/tinybench-2.9.0.tgz",
+      "integrity": "sha512-0+DUvqWMValLmha6lr4kD8iAMK1HzV0/aKnCtWb9v9641TnP/MFb7Pc2bxoxQjTXAErryXVgUOfv2YqNllqGeg==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/vitest/node_modules/tinyexec": {
+      "version": "0.3.2",
+      "resolved": "https://registry.npmjs.org/tinyexec/-/tinyexec-0.3.2.tgz",
+      "integrity": "sha512-KQQR9yN7R5+OSwaK0XQoj22pwHoTlgYqmUscPYoknOoWCWfj/5/ABTMRi69FrKU5ffPVh5QcFikpWJI/P1ocHA==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/vitest/node_modules/tinypool": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/tinypool/-/tinypool-1.1.1.tgz",
+      "integrity": "sha512-Zba82s87IFq9A9XmjiX5uZA/ARWDrB03OHlq+Vw1fSdt0I+4/Kutwy8BP4Y/y/aORMo61FQ0vIb5j44vSo5Pkg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": "^18.0.0 || >=20.0.0"
+      }
+    },
+    "node_modules/vitest/node_modules/tinyrainbow": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/tinyrainbow/-/tinyrainbow-2.0.0.tgz",
+      "integrity": "sha512-op4nsTR47R6p0vMUUoYl/a+ljLFVtlfaXkLQmqfLR1qHma1h/ysYk4hEXZ880bf2CYgTskvTa/e196Vd5dDQXw==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=14.0.0"
+      }
+    },
+    "node_modules/vitest/node_modules/vite-node": {
+      "version": "3.2.4",
+      "resolved": "https://registry.npmjs.org/vite-node/-/vite-node-3.2.4.tgz",
+      "integrity": "sha512-EbKSKh+bh1E1IFxeO0pg1n4dvoOTt0UDiXMd/qn++r98+jPO1xtJilvXldeuQ8giIB5IkpjCgMleHMNEsGH6pg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "cac": "^6.7.14",
+        "debug": "^4.4.1",
+        "es-module-lexer": "^1.7.0",
+        "pathe": "^2.0.3",
+        "vite": "^5.0.0 || ^6.0.0 || ^7.0.0-0"
+      },
+      "bin": {
+        "vite-node": "vite-node.mjs"
+      },
+      "engines": {
+        "node": "^18.0.0 || ^20.0.0 || >=22.0.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      }
+    },
+    "node_modules/vitest/node_modules/vite-node/node_modules/cac": {
+      "version": "6.7.14",
+      "resolved": "https://registry.npmjs.org/cac/-/cac-6.7.14.tgz",
+      "integrity": "sha512-b6Ilus+c3RrdDk+JhLKUAQfzzgLEPy6wcXqS7f/xe1EETvsDP6GORG7SFuOs6cID5YkqchW/LXZbX5bc8j7ZcQ==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/vitest/node_modules/vite-node/node_modules/es-module-lexer": {
+      "version": "1.7.0",
+      "resolved": "https://registry.npmjs.org/es-module-lexer/-/es-module-lexer-1.7.0.tgz",
+      "integrity": "sha512-jEQoCwk8hyb2AZziIOLhDqpm5+2ww5uIE6lkO/6jcOCusfk6LhMHpXXfBLXTZ7Ydyt0j4VoUQv6uGNYbdW+kBA==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/vitest/node_modules/why-is-node-running": {
+      "version": "2.3.0",
+      "resolved": "https://registry.npmjs.org/why-is-node-running/-/why-is-node-running-2.3.0.tgz",
+      "integrity": "sha512-hUrmaWBdVDcxvYqnyh09zunKzROWjbZTiNy8dBEjkS7ehEDQibXJ7XvlmtbwuTclUiIyN+CyXQD4Vmko8fNm8w==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "siginfo": "^2.0.0",
+        "stackback": "0.0.2"
+      },
+      "bin": {
+        "why-is-node-running": "cli.js"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/vitest/node_modules/why-is-node-running/node_modules/siginfo": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/siginfo/-/siginfo-2.0.0.tgz",
+      "integrity": "sha512-ybx0WO1/8bSBLEWXZvEd7gMW3Sn3JFlW3TvX1nREbDLRNQNaeNN8WK0meBwPdAaOI7TtRRRJn/Es1zhrrCHu7g==",
+      "dev": true,
+      "license": "ISC"
+    },
+    "node_modules/vitest/node_modules/why-is-node-running/node_modules/stackback": {
+      "version": "0.0.2",
+      "resolved": "https://registry.npmjs.org/stackback/-/stackback-0.0.2.tgz",
+      "integrity": "sha512-1XMJE5fQo1jGH6Y/7ebnwPOBEkIEnT4QF32d5R1+VXdXveM0IBMJt8zfaxX1P3QhVwrYe+576+jkANtSS2mBbw==",
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/which": {
       "version": "2.0.2",

--- a/package.json
+++ b/package.json
@@ -16,7 +16,8 @@
   "scripts": {
     "codegen": "lynx-autolink-codegen",
     "format": "prettier --write .",
-    "lint": "eslint ."
+    "lint": "eslint .",
+    "test": "vitest run"
   },
   "peerDependencies": {
     "@lynx-js/react": "*"
@@ -33,7 +34,9 @@
     "globals": "^16.3.0",
     "prettier": "^3.6.2",
     "typescript": "~5.9.2",
-    "typescript-eslint": "^8.38.0"
+    "typescript-eslint": "^8.38.0",
+    "vite": "^6.1.0",
+    "vitest": "^3.2.4"
   },
   "engines": {
     "node": ">=18"

--- a/src/__tests__/form-sheet.test.ts
+++ b/src/__tests__/form-sheet.test.ts
@@ -1,0 +1,70 @@
+import { afterAll, beforeAll, describe, expect, test, vi } from 'vitest';
+import {
+  FORM_SHEET_ALWAYS_DIMMED,
+  FORM_SHEET_FIT_TO_CONTENTS,
+  FORM_SHEET_LAST_DETENT,
+  FORM_SHEET_NEVER_DIMMED,
+  FORM_SHEET_UNCONTROLLED_DETENT,
+  resolveFormSheetHostStyle,
+  resolveInitialDetentIndex,
+  resolveLargestUndimmedDetentIndex,
+  resolveNativeCornerRadius,
+  resolveNativeDetents,
+  resolveSelectedDetentIndex,
+} from '../utils/form-sheet.js';
+
+describe('FormSheet native prop normalization', () => {
+  beforeAll(() => {
+    vi.stubGlobal('SystemInfo', {
+      pixelRatio: 2,
+      pixelWidth: 400,
+      pixelHeight: 800,
+    });
+  });
+
+  afterAll(() => {
+    vi.unstubAllGlobals();
+  });
+
+  test('maps symbolic values to the RNS native protocol', () => {
+    expect(resolveNativeDetents('fitToContents')).toEqual([
+      FORM_SHEET_FIT_TO_CONTENTS,
+    ]);
+    expect(resolveInitialDetentIndex('last', 3)).toBe(FORM_SHEET_LAST_DETENT);
+    expect(resolveLargestUndimmedDetentIndex('none', 3)).toBe(
+      FORM_SHEET_ALWAYS_DIMMED,
+    );
+    expect(resolveLargestUndimmedDetentIndex('last', 3)).toBe(
+      FORM_SHEET_NEVER_DIMMED,
+    );
+    expect(resolveNativeCornerRadius('systemDefault')).toBe(-1);
+    expect(resolveSelectedDetentIndex('last', 3)).toBe(FORM_SHEET_LAST_DETENT);
+    expect(resolveSelectedDetentIndex(undefined, 3)).toBe(
+      FORM_SHEET_UNCONTROLLED_DETENT,
+    );
+  });
+
+  test('falls back when detent indices are invalid', () => {
+    const error = vi.spyOn(console, 'error').mockImplementation(() => {});
+
+    expect(resolveInitialDetentIndex(3, 2)).toBe(0);
+    expect(resolveLargestUndimmedDetentIndex(3, 2)).toBe(
+      FORM_SHEET_ALWAYS_DIMMED,
+    );
+    expect(resolveSelectedDetentIndex(3, 2)).toBe(
+      FORM_SHEET_UNCONTROLLED_DETENT,
+    );
+    expect(error).toHaveBeenCalledTimes(3);
+
+    error.mockRestore();
+  });
+
+  test('uses full height when invalid detents reach host layout', () => {
+    expect(resolveFormSheetHostStyle([0.7, Number.NaN])).toMatchObject({
+      height: '400px',
+    });
+    expect(resolveFormSheetHostStyle([0.8, 0.4])).toMatchObject({
+      height: '400px',
+    });
+  });
+});

--- a/src/components/FormSheet.tsx
+++ b/src/components/FormSheet.tsx
@@ -1,0 +1,74 @@
+import type { FormSheetProps } from '../types/FormSheet.js';
+import {
+  resolveFormSheetHostStyle,
+  resolveInitialDetentIndex,
+  resolveLargestUndimmedDetentIndex,
+  resolveNativeCornerRadius,
+  resolveNativeDetents,
+  resolveSelectedDetentIndex,
+} from '../utils/form-sheet.js';
+
+export function FormSheet({
+  children,
+  isOpen,
+  detents,
+  prefersGrabberVisible,
+  preferredCornerRadius,
+  largestUndimmedDetentIndex,
+  initialDetentIndex,
+  selectedDetentIndex,
+  prefersScrollingExpandsWhenScrolledToEdge,
+  preventNativeDismiss,
+  preventNativeDismissDragFeedback,
+  nativeContainerStyle,
+  onWillAppear,
+  onDidAppear,
+  onWillDisappear,
+  onDidDisappear,
+  onDismiss,
+  onNativeDismiss,
+  onDetentChanged,
+  onNativeDismissPrevented,
+}: FormSheetProps) {
+  const nativeDetents = resolveNativeDetents(detents);
+  const detentsCount = nativeDetents?.length ?? 0;
+
+  return (
+    <form-sheet-native
+      style={resolveFormSheetHostStyle(detents)}
+      isOpen={isOpen}
+      user-interaction-enabled={isOpen}
+      detents={nativeDetents}
+      prefersGrabberVisible={prefersGrabberVisible}
+      preferredCornerRadius={resolveNativeCornerRadius(preferredCornerRadius)}
+      largestUndimmedDetentIndex={resolveLargestUndimmedDetentIndex(
+        largestUndimmedDetentIndex,
+        detentsCount,
+      )}
+      initialDetentIndex={resolveInitialDetentIndex(
+        initialDetentIndex,
+        detentsCount,
+      )}
+      selectedDetentIndex={resolveSelectedDetentIndex(
+        selectedDetentIndex,
+        detentsCount,
+      )}
+      prefersScrollingExpandsWhenScrolledToEdge={
+        prefersScrollingExpandsWhenScrolledToEdge
+      }
+      preventNativeDismiss={preventNativeDismiss}
+      preventNativeDismissDragFeedback={preventNativeDismissDragFeedback}
+      nativeContainerBackgroundColor={nativeContainerStyle?.backgroundColor}
+      bindOnWillAppear={onWillAppear}
+      bindOnDidAppear={onDidAppear}
+      bindOnWillDisappear={onWillDisappear}
+      bindOnDidDisappear={onDidDisappear}
+      bindOnDismiss={onDismiss}
+      bindOnNativeDismiss={onNativeDismiss}
+      bindOnDetentChanged={onDetentChanged}
+      bindOnNativeDismissPrevented={onNativeDismissPrevented}
+    >
+      {children}
+    </form-sheet-native>
+  );
+}

--- a/src/index.ts
+++ b/src/index.ts
@@ -3,6 +3,7 @@ import './lynx-elements';
 export { StackHostNativeComponent } from './native_components/StackHostNativeComponent';
 export { StackScreenNativeComponent } from './native_components/StackScreenNativeComponent';
 export { StackHeaderConfigNativeComponent } from './native_components/StackHeaderConfigNativeComponent';
+export { FormSheet } from './components/FormSheet.js';
 
 export type {
   OnDismissEventPayload,
@@ -32,3 +33,11 @@ export type {
   StackHeaderConfigPropsIOS,
   StackHeaderConfigCommandsIOS,
 } from './types/StackHeaderConfig';
+export type {
+  FormSheetDetentChangedEvent,
+  FormSheetEventHandler,
+  FormSheetNativeContainerStyleProps,
+  FormSheetNativeDismissPreventedEvent,
+  FormSheetProps,
+  PreventNativeDismissChannel,
+} from './types/FormSheet.js';

--- a/src/lynx-elements.ts
+++ b/src/lynx-elements.ts
@@ -1,11 +1,20 @@
 import type { ReactNode, Ref } from '@lynx-js/react';
 import type * as Lynx from '@lynx-js/types';
+import type { PreventNativeDismissChannel } from './types/FormSheet.js';
 
 declare module "@lynx-js/types" {
   type EmptyEventPayload = Record<string, never>;
 
   type OnDismissEventPayload = Readonly<{
     isNativeDismiss: boolean;
+  }>;
+
+  type FormSheetDetentChangedEventPayload = Readonly<{
+    index: number;
+  }>;
+
+  type FormSheetNativeDismissPreventedEventPayload = Readonly<{
+    channel: PreventNativeDismissChannel;
   }>;
 
   interface IntrinsicElements extends Lynx.IntrinsicElements {
@@ -78,6 +87,57 @@ declare module "@lynx-js/types" {
       style?: string | Lynx.CSSProperties | undefined;
       type?: 'background' | 'leading' | 'center' | 'trailing' | undefined;
       collapseMode?: 'off' | 'parallax' | undefined;
+    };
+    'form-sheet-native': {
+      className?: string | undefined;
+      children?: ReactNode | undefined;
+      id?: string | undefined;
+      style?: string | Lynx.CSSProperties | undefined;
+      isOpen: boolean;
+      'user-interaction-enabled'?: boolean | undefined;
+      detents?: number[] | undefined;
+      prefersGrabberVisible?: boolean | undefined;
+      preferredCornerRadius?: number | undefined;
+      largestUndimmedDetentIndex?: number | undefined;
+      initialDetentIndex?: number | undefined;
+      selectedDetentIndex?: number | undefined;
+      prefersScrollingExpandsWhenScrolledToEdge?: boolean | undefined;
+      preventNativeDismiss?:
+        | boolean
+        | PreventNativeDismissChannel[]
+        | undefined;
+      preventNativeDismissDragFeedback?: boolean | undefined;
+      nativeContainerBackgroundColor?:
+        | Lynx.CSSProperties['backgroundColor']
+        | undefined;
+      bindOnWillAppear?:
+        | Lynx.EventHandler<Lynx.BaseEventOrig<EmptyEventPayload>>
+        | undefined;
+      bindOnDidAppear?:
+        | Lynx.EventHandler<Lynx.BaseEventOrig<EmptyEventPayload>>
+        | undefined;
+      bindOnWillDisappear?:
+        | Lynx.EventHandler<Lynx.BaseEventOrig<EmptyEventPayload>>
+        | undefined;
+      bindOnDidDisappear?:
+        | Lynx.EventHandler<Lynx.BaseEventOrig<EmptyEventPayload>>
+        | undefined;
+      bindOnDismiss?:
+        | Lynx.EventHandler<Lynx.BaseEventOrig<EmptyEventPayload>>
+        | undefined;
+      bindOnNativeDismiss?:
+        | Lynx.EventHandler<Lynx.BaseEventOrig<EmptyEventPayload>>
+        | undefined;
+      bindOnDetentChanged?:
+        | Lynx.EventHandler<
+            Lynx.BaseEventOrig<FormSheetDetentChangedEventPayload>
+          >
+        | undefined;
+      bindOnNativeDismissPrevented?:
+        | Lynx.EventHandler<
+            Lynx.BaseEventOrig<FormSheetNativeDismissPreventedEventPayload>
+          >
+        | undefined;
     };
   }
 }

--- a/src/types/FormSheet.ts
+++ b/src/types/FormSheet.ts
@@ -1,0 +1,68 @@
+import type * as Lynx from '@lynx-js/types';
+
+type FormSheetEmptyEventPayload = Record<string, never>;
+
+export type FormSheetEventHandler<T> = Lynx.EventHandler<Lynx.BaseEventOrig<T>>;
+
+export interface FormSheetDetentChangedEvent {
+  index: number;
+}
+
+export interface FormSheetNativeDismissPreventedEvent {
+  /** The dismissal channel that was blocked. */
+  channel: PreventNativeDismissChannel;
+}
+
+export type FormSheetNativeContainerStyleProps = {
+  backgroundColor?: Lynx.CSSProperties['backgroundColor'] | undefined;
+};
+
+export type PreventNativeDismissChannel = 'back' | 'drag' | 'backdrop';
+
+export interface FormSheetProps {
+  children?: Lynx.ViewProps['children'] | undefined;
+  isOpen: boolean;
+  /** Android supports up to three detents. */
+  detents?: number[] | 'fitToContents' | undefined;
+  prefersGrabberVisible?: boolean | undefined;
+  /** Custom Android corners require Android 13 or newer. */
+  preferredCornerRadius?: number | 'systemDefault' | undefined;
+  largestUndimmedDetentIndex?: number | 'none' | 'last' | undefined;
+  initialDetentIndex?: number | 'last' | undefined;
+  selectedDetentIndex?: number | 'last' | undefined;
+  /** iOS only. */
+  prefersScrollingExpandsWhenScrolledToEdge?: boolean | undefined;
+  /**
+   * Blocks native dismissal. `true` blocks every channel; an array blocks
+   * only the listed channels.
+   *
+   * - `back`: Android back button
+   * - `drag`: pull-down drag gesture
+   * - `backdrop`: tapping the dimmed space behind the sheet
+   */
+  preventNativeDismiss?: boolean | PreventNativeDismissChannel[] | undefined;
+  /**
+   * When drag dismissal is prevented, also disables drag-follow and snap-back
+   * feedback so the sheet stays at its smallest detent.
+   */
+  preventNativeDismissDragFeedback?: boolean | undefined;
+  nativeContainerStyle?: FormSheetNativeContainerStyleProps | undefined;
+  onWillAppear?: FormSheetEventHandler<FormSheetEmptyEventPayload> | undefined;
+  onDidAppear?: FormSheetEventHandler<FormSheetEmptyEventPayload> | undefined;
+  onWillDisappear?:
+    | FormSheetEventHandler<FormSheetEmptyEventPayload>
+    | undefined;
+  onDidDisappear?:
+    | FormSheetEventHandler<FormSheetEmptyEventPayload>
+    | undefined;
+  onDismiss?: FormSheetEventHandler<FormSheetEmptyEventPayload> | undefined;
+  onNativeDismiss?:
+    | FormSheetEventHandler<FormSheetEmptyEventPayload>
+    | undefined;
+  onDetentChanged?:
+    | FormSheetEventHandler<FormSheetDetentChangedEvent>
+    | undefined;
+  onNativeDismissPrevented?:
+    | FormSheetEventHandler<FormSheetNativeDismissPreventedEvent>
+    | undefined;
+}

--- a/src/utils/form-sheet.ts
+++ b/src/utils/form-sheet.ts
@@ -1,0 +1,151 @@
+import type { FormSheetProps } from '../types/FormSheet.js';
+
+export const FORM_SHEET_FIT_TO_CONTENTS = -1;
+export const FORM_SHEET_LAST_DETENT = -1;
+export const FORM_SHEET_UNCONTROLLED_DETENT = -2;
+export const FORM_SHEET_ALWAYS_DIMMED = -1;
+export const FORM_SHEET_NEVER_DIMMED = -2;
+
+export function resolveNativeDetents(
+  detents?: FormSheetProps['detents'],
+): number[] | undefined {
+  if (!detents) {
+    return undefined;
+  }
+
+  return detents === 'fitToContents' ? [FORM_SHEET_FIT_TO_CONTENTS] : detents;
+}
+
+export function resolveInitialDetentIndex(
+  initialDetentIndex: FormSheetProps['initialDetentIndex'],
+  detentsCount = 0,
+): number {
+  if (initialDetentIndex === undefined) {
+    return 0;
+  }
+
+  if (initialDetentIndex === 'last') {
+    return FORM_SHEET_LAST_DETENT;
+  }
+
+  const lastDetentIndex = Math.max(detentsCount - 1, 0);
+  if (!isIndexInClosedRange(initialDetentIndex, 0, lastDetentIndex)) {
+    console.error(
+      `[LynxScreens] Invalid value provided for 'initialDetentIndex' (${initialDetentIndex}). Expected an integer between 0 and ${lastDetentIndex}. Falling back to 0.`,
+    );
+    return 0;
+  }
+
+  return initialDetentIndex;
+}
+
+export function resolveSelectedDetentIndex(
+  selectedDetentIndex: FormSheetProps['selectedDetentIndex'],
+  detentsCount = 0,
+): number {
+  if (selectedDetentIndex === undefined) {
+    return FORM_SHEET_UNCONTROLLED_DETENT;
+  }
+
+  if (selectedDetentIndex === 'last') {
+    return FORM_SHEET_LAST_DETENT;
+  }
+
+  const lastDetentIndex = Math.max(detentsCount - 1, 0);
+  if (!isIndexInClosedRange(selectedDetentIndex, 0, lastDetentIndex)) {
+    console.error(
+      `[LynxScreens] Invalid value provided for 'selectedDetentIndex' (${selectedDetentIndex}). Expected an integer between 0 and ${lastDetentIndex}. Leaving the FormSheet detent uncontrolled.`,
+    );
+    return FORM_SHEET_UNCONTROLLED_DETENT;
+  }
+
+  return selectedDetentIndex;
+}
+
+export function resolveLargestUndimmedDetentIndex(
+  largestUndimmedDetentIndex: FormSheetProps['largestUndimmedDetentIndex'],
+  detentsCount = 0,
+): number {
+  if (
+    largestUndimmedDetentIndex === undefined ||
+    largestUndimmedDetentIndex === 'none'
+  ) {
+    return FORM_SHEET_ALWAYS_DIMMED;
+  }
+
+  if (largestUndimmedDetentIndex === 'last') {
+    return FORM_SHEET_NEVER_DIMMED;
+  }
+
+  const lastDetentIndex = Math.max(detentsCount - 1, 0);
+  if (!isIndexInClosedRange(largestUndimmedDetentIndex, 0, lastDetentIndex)) {
+    console.error(
+      `[LynxScreens] Invalid value provided for 'largestUndimmedDetentIndex' (${largestUndimmedDetentIndex}). Expected an integer between 0 and ${lastDetentIndex}. Falling back to the default behavior (always dimmed).`,
+    );
+    return FORM_SHEET_ALWAYS_DIMMED;
+  }
+
+  return largestUndimmedDetentIndex;
+}
+
+export function resolveNativeCornerRadius(
+  radius: FormSheetProps['preferredCornerRadius'],
+): number | undefined {
+  if (
+    radius === 'systemDefault' ||
+    (typeof radius === 'number' && radius < 0)
+  ) {
+    return -1;
+  }
+
+  return radius;
+}
+
+export function resolveFormSheetHostStyle(
+  detents: FormSheetProps['detents'],
+): import('@lynx-js/types').CSSProperties {
+  const pixelRatio = SystemInfo.pixelRatio > 0 ? SystemInfo.pixelRatio : 1;
+  const screenWidth = SystemInfo.pixelWidth / pixelRatio;
+  const screenHeight = SystemInfo.pixelHeight / pixelRatio;
+
+  if (detents === 'fitToContents') {
+    return {
+      position: 'absolute',
+      top: 0,
+      left: 0,
+      width: `${screenWidth}px`,
+    };
+  }
+
+  const largestDetent =
+    detents && detents.length > 0 && areFractionalDetentsValid(detents)
+      ? Math.max(...detents)
+      : 1;
+  const largestDetentPercent = Math.max(0, Math.min(largestDetent, 1)) * 100;
+
+  return {
+    position: 'absolute',
+    left: 0,
+    bottom: 0,
+    width: `${screenWidth}px`,
+    height: `${(screenHeight * largestDetentPercent) / 100}px`,
+  };
+}
+
+function areFractionalDetentsValid(detents: number[]): boolean {
+  return detents.every(
+    (detent, index) =>
+      Number.isFinite(detent) &&
+      detent >= 0 &&
+      detent <= 1 &&
+      (index === 0 || detent > detents[index - 1]),
+  );
+}
+
+function isIndexInClosedRange(
+  value: number,
+  lowerBound: number,
+  upperBound: number,
+): boolean {
+  return Number.isInteger(value) && value >= lowerBound && value <= upperBound;
+}


### PR DESCRIPTION
## Summary

- add cross-platform native FormSheet components and transfer primitives
- expose the FormSheet TypeScript API, event types, detent configuration, styling, and dismissal controls
- integrate FormSheet routes into the example navigator while preserving the latest route-name and header configuration behavior
- add Android unit coverage for anchors, detents, dimming, and dismissal configuration
- document FormSheet support in the feature matrix

## Main-branch adaptations

- preserve the latest explicit exports and Android header implementation
- retain the FormSheet route discriminator when dynamically updating options
- synchronize controlled `selectedDetentIndex="last"` after native detent changes
- validate fractional detents when resolving host size
- omit unrelated npm lockfile regeneration noise

## Validation

- targeted ESLint for all changed TypeScript and TSX files except the pre-existing reducer lint failures
- `npm --prefix LynxExample run build`
- `LynxExample/android/gradlew :lynx_library_lynx_screens:testDebugUnitTest :app:assembleDebug -Pkotlin.compiler.execution.strategy=in-process` with JDK 17
- CocoaPods install and `xcodebuild` for the `LynxScreens` scheme on a generic iOS Simulator

## Before marking ready

- validate iOS native-dismiss lifecycle ordering and scroll-to-sheet gesture handoff
- validate safe-area and keyboard behavior across detents on iOS
- validate Android programmatic-close versus drag-dismiss races and window-size changes