### PR TITLE
chore: Drop mention about stack v4

### DIFF
--- a/README.md
+++ b/README.md
@@ -86,7 +86,6 @@ Parts of `react-native-screens` in the synced range that were deliberately left 
 - **FormSheet v5** — standalone RNS component; out of scope for this port.
 - **Native Tabs, SplitView, SafeArea, ScrollToTopGuard** — components lynx-screens doesn't port; see also the open topics below.
 - **ScrollViewMarker scroll edge effects** — only the scroll view registration core of the SVM epic is ported; the iOS scroll edge effect subsystem is not.
-- **Stack v4 / legacy** — lynx-screens is v5-only.
 
 ### 3. Further plans in RNScreens
 


### PR DESCRIPTION
From the Lynx perspective, stack v4 was never planned to be ported. Dropping the information from the README, because main branch in RNS already ships stack v5, so this sentence might be misleading.
