### PR TITLE
fix(example): give the Kotlin daemon the kapt --add-exports

### DIFF
--- a/LynxExample/android/gradle.properties
+++ b/LynxExample/android/gradle.properties
@@ -16,6 +16,20 @@ org.gradle.jvmargs=-Xmx2048m -Dfile.encoding=UTF-8 \
   --add-opens=jdk.compiler/com.sun.tools.javac.main=ALL-UNNAMED
 
 kapt.use.worker.api=false
+
+# kapt.use.worker.api=false runs kapt inside the Kotlin compile daemon, which
+# reads kotlin.daemon.jvmargs rather than org.gradle.jvmargs. Without the same
+# --add-exports here, kapt dies on JDK 17+ with an IllegalAccessError reaching
+# com.sun.tools.javac.main.
+kotlin.daemon.jvmargs=-Xmx2048m \
+  --add-exports=jdk.compiler/com.sun.tools.javac.api=ALL-UNNAMED \
+  --add-exports=jdk.compiler/com.sun.tools.javac.file=ALL-UNNAMED \
+  --add-exports=jdk.compiler/com.sun.tools.javac.parser=ALL-UNNAMED \
+  --add-exports=jdk.compiler/com.sun.tools.javac.tree=ALL-UNNAMED \
+  --add-exports=jdk.compiler/com.sun.tools.javac.util=ALL-UNNAMED \
+  --add-exports=jdk.compiler/com.sun.tools.javac.main=ALL-UNNAMED \
+  --add-opens=jdk.compiler/com.sun.tools.javac.main=ALL-UNNAMED
+
 # When configured, Gradle will run in incubating parallel mode.
 # This option should only be used with decoupled projects. For more details, visit
 # https://developer.android.com/r/tools/gradle-multi-project-decoupled-projects


### PR DESCRIPTION
Building `LynxExample` on JDK 17+ fails in `kaptGenerateStubsDebugKotlin`:

```
e: java.lang.IllegalAccessError: superclass access check failed: class
org.jetbrains.kotlin.kapt3.base.javac.KaptJavaCompiler (in unnamed module)
cannot access class com.sun.tools.javac.main.JavaCompiler (in module
jdk.compiler) because module jdk.compiler does not export
com.sun.tools.javac.main to unnamed module
```

The `--add-exports` that kapt needs are already in `gradle.properties`, but only on `org.gradle.jvmargs`. With `kapt.use.worker.api=false`, kapt runs inside the Kotlin compile daemon rather than the Gradle daemon, and that process reads `kotlin.daemon.jvmargs` — which isn't set, so it starts without them.

This adds the same flags there.

Verified on macOS with Android Studio's bundled JDK: `./gradlew assembleDebug` fails before the change and succeeds after, and the resulting app runs on both an emulator and a Pixel 5.
