### PR TITLE
feat(example): let the example hosts open a route

### DIFF
--- a/LynxExample/android/app/src/main/AndroidManifest.xml
+++ b/LynxExample/android/app/src/main/AndroidManifest.xml
@@ -18,8 +18,19 @@
         tools:targetApi="31">
         <activity
             android:name=".DebugActivity"
-            android:exported="false"
-            android:theme="@style/Theme.AppCompat.DayNight.NoActionBar" />
+            android:exported="true"
+            android:launchMode="singleTop"
+            android:theme="@style/Theme.AppCompat.DayNight.NoActionBar">
+
+            <intent-filter>
+                <action android:name="android.intent.action.VIEW" />
+
+                <category android:name="android.intent.category.DEFAULT" />
+                <category android:name="android.intent.category.BROWSABLE" />
+
+                <data android:scheme="lynxscreens" />
+            </intent-filter>
+        </activity>
         <activity
             android:name=".HomeActivity"
             android:exported="true"

--- a/LynxExample/android/app/src/main/java/com/lynxscreens/DebugActivity.kt
+++ b/LynxExample/android/app/src/main/java/com/lynxscreens/DebugActivity.kt
@@ -1,26 +1,94 @@
 package com.lynxscreens
 
-import android.app.Activity
+import android.content.Intent
 import android.os.Bundle
+import androidx.appcompat.app.AppCompatActivity
 import com.lynxscreens.providers.TemplateProvider
 import com.lynx.tasm.LynxView
 import com.lynx.tasm.LynxViewBuilder
+import com.lynx.react.bridge.JavaOnlyArray
+import com.lynx.react.bridge.JavaOnlyMap
 import com.lynx.tasm.TemplateData
 
-class DebugActivity : Activity() {
+/**
+ * adb shell am start -a android.intent.action.VIEW -d "lynxscreens:///depth/3"
+ */
+// AppCompatActivity: lynx-screens needs a FragmentManager, which a plain
+// Activity cannot give it.
+class DebugActivity : AppCompatActivity() {
+    private var lynxView: LynxView? = null
+
     override fun onCreate(savedInstanceState: Bundle?) {
         super.onCreate(savedInstanceState)
-        val lynxView = buildLynxView()
-        setContentView(lynxView)
-        val url = intent.getStringExtra("url")
-        if (url != null) {
-            lynxView.renderTemplateUrl(url, TemplateData.empty())
+        val view = buildLynxView()
+        lynxView = view
+        setContentView(view)
+        // A link carries a route, not a bundle, so it opens the one used last.
+        val url = intent.getStringExtra("url") ?: lastBundleUrl() ?: run {
+            startActivity(Intent(this, HomeActivity::class.java))
+            finish()
+            return
         }
+
+        view.renderTemplateUrl(url, navigationData(intent))
+    }
+
+    private fun lastBundleUrl(): String? =
+        getSharedPreferences("home", MODE_PRIVATE)
+            .getString("history", null)
+            ?.lineSequence()
+            ?.firstOrNull { it.isNotBlank() }
+
+    override fun onNewIntent(intent: Intent) {
+        super.onNewIntent(intent)
+        setIntent(intent)
+
+        val route = route(intent) ?: return
+
+        // A nested plain Kotlin map arrives in JS as null; the bridge only
+        // converts its own JavaOnly* types.
+        val payload = JavaOnlyMap.from(mapOf<String, Any>("url" to route))
+
+        lynxView?.sendGlobalEvent(URL_EVENT, JavaOnlyArray.of(payload))
+    }
+
+    private fun route(intent: Intent): String? {
+        val uri = intent.data ?: return null
+
+        // `lynxscreens://depth/3` parses `depth` as the authority, while
+        // `lynxscreens:///depth/3` puts all of it in the path.
+        val path = buildString {
+            uri.host?.takeIf(String::isNotEmpty)?.let { append('/').append(it) }
+            append(uri.path.orEmpty())
+        }.ifEmpty { "/" }
+
+        return uri.query?.takeIf(String::isNotEmpty)?.let { "$path?$it" } ?: path
+    }
+
+    private fun navigationData(intent: Intent): TemplateData {
+        val route = route(intent) ?: return TemplateData.empty()
+
+        return TemplateData.fromMap(
+            mapOf(
+                NAVIGATION_KEY to mapOf(
+                    "route" to route,
+                    // initData is state, not an event: the same route twice
+                    // would leave it untouched and be dropped.
+                    "nonce" to System.currentTimeMillis(),
+                ),
+            ),
+        )
     }
 
     private fun buildLynxView(): LynxView {
         val viewBuilder = LynxViewBuilder()
         viewBuilder.setTemplateProvider(TemplateProvider(this))
         return viewBuilder.build(this)
+    }
+
+    private companion object {
+        // Both match `@react-navigation/lynx`.
+        const val NAVIGATION_KEY = "__navigation"
+        const val URL_EVENT = "reactnavigation.url"
     }
 }

--- a/LynxExample/ios/LynxScreens/CardViewController.swift
+++ b/LynxExample/ios/LynxScreens/CardViewController.swift
@@ -3,10 +3,12 @@ import UIKit
 /// Renders one bundle. The URL comes from the home screen, never from here.
 class CardViewController: UIViewController {
   private let url: String
+  private let route: String?
   private var lynxView: LynxView?
 
-  init(url: String) {
+  init(url: String, route: String? = nil) {
     self.url = url
+    self.route = route
     super.init(nibName: nil, bundle: nil)
   }
 
@@ -63,7 +65,7 @@ class CardViewController: UIViewController {
     resize(lynxView)
     view.addSubview(lynxView)
 
-    lynxView.loadTemplate(fromURL: url, initData: nil)
+    lynxView.loadTemplate(fromURL: url, initData: Self.navigationData(for: route))
   }
 
   /// The card lives inside the safe area, so its own header does not end up
@@ -76,4 +78,26 @@ class CardViewController: UIViewController {
     lynxView.preferredLayoutWidth = frame.width
     lynxView.preferredLayoutHeight = frame.height
   }
+
+  /// A link that arrived while this card is already up.
+  func deliver(route: String) {
+    lynxView?.sendGlobalEvent(Self.urlEvent, withParams: [["url": route]])
+  }
+
+  private static func navigationData(for route: String?) -> LynxTemplateData? {
+    guard let route else { return nil }
+
+    // initData is state, not an event: the same route twice would leave it
+    // untouched and be dropped.
+    return LynxTemplateData(dictionary: [
+      navigationKey: [
+        "route": route,
+        "nonce": Date().timeIntervalSince1970,
+      ],
+    ])
+  }
+
+  // Both match `@react-navigation/lynx`.
+  private static let navigationKey = "__navigation"
+  private static let urlEvent = "reactnavigation.url"
 }

--- a/LynxExample/ios/LynxScreens/HomeViewController.swift
+++ b/LynxExample/ios/LynxScreens/HomeViewController.swift
@@ -104,5 +104,5 @@ class HomeViewController: UIViewController, UITableViewDataSource, UITableViewDe
 
 }
 
-private let historyKey = "home.history"
+let historyKey = "home.history"
 private let historyLimit = 10

--- a/LynxExample/ios/LynxScreens/Info.plist
+++ b/LynxExample/ios/LynxScreens/Info.plist
@@ -2,8 +2,6 @@
 <!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
 <plist version="1.0">
 <dict>
-	<!-- A dev-server bundle is plain HTTP on whatever host the machine has,
-	     so localhost-only ATS is not enough once the URL is typed in. -->
 	<!-- A dev-server bundle is plain HTTP on whatever host the machine has.
 	     NSAllowsLocalNetworking must not be set alongside this: when both are
 	     present iOS ignores NSAllowsArbitraryLoads. -->
@@ -16,6 +14,17 @@
 	<string>Scanning a QR code opens the bundle it points at.</string>
 	<key>CADisableMinimumFrameDurationOnPhone</key>
 	<true/>
+	<key>CFBundleURLTypes</key>
+	<array>
+		<dict>
+			<key>CFBundleURLName</key>
+			<string>com.lynxscreens</string>
+			<key>CFBundleURLSchemes</key>
+			<array>
+				<string>lynxscreens</string>
+			</array>
+		</dict>
+	</array>
 	<key>UIApplicationSceneManifest</key>
 	<dict>
 		<key>UIApplicationSupportsMultipleScenes</key>

--- a/LynxExample/ios/LynxScreens/SceneDelegate.swift
+++ b/LynxExample/ios/LynxScreens/SceneDelegate.swift
@@ -1,5 +1,6 @@
 import UIKit
 
+/// xcrun simctl openurl booted "lynxscreens:///depth/3"
 class SceneDelegate: UIResponder, UIWindowSceneDelegate {
   var window: UIWindow?
 
@@ -10,10 +11,44 @@ class SceneDelegate: UIResponder, UIWindowSceneDelegate {
   ) {
     guard let windowScene = (scene as? UIWindowScene) else { return }
 
+    let navigation = UINavigationController(rootViewController: HomeViewController())
+
     window = UIWindow(windowScene: windowScene)
-    window?.rootViewController = UINavigationController(
-      rootViewController: HomeViewController()
-    )
+    window?.rootViewController = navigation
     window?.makeKeyAndVisible()
+
+    // A link carries a route, not a bundle, so it opens the one used last.
+    if let route = Self.route(in: connectionOptions.urlContexts),
+       let url = UserDefaults.standard.stringArray(forKey: historyKey)?.first {
+      navigation.pushViewController(
+        CardViewController(url: url, route: route),
+        animated: false
+      )
+    }
+  }
+
+  func scene(_ scene: UIScene, openURLContexts URLContexts: Set<UIOpenURLContext>) {
+    guard let route = Self.route(in: URLContexts),
+          let card = (window?.rootViewController as? UINavigationController)?
+            .topViewController as? CardViewController
+    else {
+      return
+    }
+
+    card.deliver(route: route)
+  }
+
+  private static func route(in contexts: Set<UIOpenURLContext>) -> String? {
+    guard let url = contexts.first?.url else { return nil }
+
+    // `lynxscreens://depth/3` parses `depth` as the host, while
+    // `lynxscreens:///depth/3` puts all of it in the path.
+    var path = url.path
+    if let host = url.host, !host.isEmpty { path = "/\(host)\(path)" }
+    if path.isEmpty { path = "/" }
+
+    guard let query = url.query, !query.isEmpty else { return path }
+
+    return "\(path)?\(query)"
   }
 }


### PR DESCRIPTION
Lets the example hosts open a specific route, on both platforms, which React Navigation on Lynx needs and nothing demonstrated yet.

```bash
# Android
adb shell am start -n <pkg>/com.lynxscreens.DebugActivity \
  -e url <bundle url> -e route /depth/3

# iOS
xcrun simctl openurl booted "lynxscreens:///depth/3"
xcrun simctl launch booted com.example.LynxScreens -route /depth/3
```

It doubles as the reference for how a host hands a route to a card. A card is not the process that receives a link, so the host has to pass it along, and there are two moments to cover:

- **Cold start** rides in on `initData`, which the card can read before any listener exists, so there is no race to lose the launch route to. A `nonce` goes with it because `initData` is state rather than an event — navigating twice to the same route would otherwise leave the value untouched and be dropped.
- **Later routes** go out as a `reactnavigation.url` global event carrying `{ url }`, through `onNewIntent` / `scene(_:openURLContexts:)`.

iOS gets a launch argument as well as the URL scheme, because opening a custom scheme in the simulator raises a system confirmation prompt that a script cannot get past. It mirrors `-e route` on Android.

## Fixes it needed along the way

**iOS never registered any Lynx library.** `cocoapods-lynx-library` generates `LynxGeneratedLibraryRegistry` from every linked library, but nothing called it — so `ls-stack-host` was unregistered and any stack died with `LynxCreateUIException`. Android gets this for free through autolink. Wired into `AppDelegate`.

**`DebugActivity` extended `android.app.Activity`.** lynx-screens puts each screen in a Fragment and asks the host for a FragmentManager, which a plain Activity cannot give it, so the stack died on the first patch with `[RNScreens] Attempt to use nullish FragmentManager` and the screen stayed blank. `MainActivity` already used `AppCompatActivity`.

**`DebugActivity` was `exported="false"` and not `singleTop`**, so it could not be started from adb and would never see `onNewIntent`.

**kapt failed with an internal compiler error on JDK 16+.** With `kapt.use.worker.api=false`, kapt runs in the Kotlin compile daemon, which reads `kotlin.daemon.jvmargs` rather than `org.gradle.jvmargs`, so the `--add-exports` flags never reached it. Note the daemon caches its args — `./gradlew --stop` is needed once after adding them.

## Verification

Android on a Pixel 4 XL, iOS on an iPhone 17 Pro simulator. Cold start with route `/depth/3` lands on that screen on both; on Android, sending a second route to the running card navigates to it.

The consuming side is https://github.com/react-navigation/react-navigation-lynx/pull/9.
