### PR TITLE
feat(Android): support Fragment 1.3.6

### DIFF
--- a/android/build.gradle.kts
+++ b/android/build.gradle.kts
@@ -29,7 +29,7 @@ dependencies {
     implementation("androidx.coordinatorlayout:coordinatorlayout:1.2.0")
     // Image engine of Lynx's standard image-service setup; used by helpers/ImageLoader.
     implementation("com.facebook.fresco:fresco:2.3.0")
-    implementation("androidx.fragment:fragment-ktx:1.8.9")
+    implementation("androidx.fragment:fragment:1.3.6")
     implementation("androidx.appcompat:appcompat:1.7.1")
     implementation("androidx.transition:transition-ktx:1.7.0")
     implementation("com.google.android.material:material:1.14.0")

--- a/android/src/main/java/com/lynxscreens/screens/ext/ViewExt.kt
+++ b/android/src/main/java/com/lynxscreens/screens/ext/ViewExt.kt
@@ -3,11 +3,11 @@ package com.lynxscreens.screens.ext
 import android.view.View
 import android.view.ViewGroup
 import androidx.fragment.app.Fragment
-import androidx.fragment.app.findFragment
+import androidx.fragment.app.FragmentManager
 
 internal fun View.findFragmentOrNull(): Fragment? =
     try {
-        this.findFragment()
+        FragmentManager.findFragment<Fragment>(this)
     } catch (_: IllegalStateException) {
         null
     }

--- a/android/src/main/java/com/lynxscreens/screens/host/StackContainer.kt
+++ b/android/src/main/java/com/lynxscreens/screens/host/StackContainer.kt
@@ -5,7 +5,6 @@ import android.content.Context
 import android.util.Log
 import android.view.ViewGroup
 import android.widget.FrameLayout
-import androidx.fragment.app.Fragment
 import androidx.fragment.app.FragmentManager
 import com.lynxscreens.screens.common.container.Container
 import com.lynxscreens.screens.common.container.ParentContainerItemRegistry
@@ -244,30 +243,25 @@ internal class StackContainer(
         }
     }
 
-    // This is called after special effects (animations) are dispatched
-    override fun onBackStackChanged() = Unit
-
+    /**
+     * Fragment 1.3 only exposes this coarse back-stack callback. JS-driven pops update stackModel
+     * before the transaction, while a native pop leaves the removed top Fragment in stackModel.
+     */
     // This is called before the special effects (animations) are dispatched, however mid transaction!
     // Therefore make sure to not execute any action that might cause synchronous transaction synchronously
     // from this callback.
-    override fun onBackStackChangeCommitted(
-        fragment: Fragment,
-        pop: Boolean,
-    ) {
-        if (fragment !is StackScreenFragment) {
-            Log.w(TAG, "[RNScreens] Unexpected type of fragment: ${fragment.javaClass.simpleName}")
-            return
-        }
-        // This callback is called for every fragment involved in the back stack change, even
-        // if its not added or removed, but e.g. set as a primary navigation fragment, hence
-        // we need to check whether the fragment is actually being removed.
-        // I avoid using `pop` parameter here, because transaction might not be classified as `pop`
-        // and still include fragment removal operations.
-        if (fragment.isRemoving) {
-            delegate.get()?.onScreenDismissCommitted(fragment.stackScreen)
-            if (stackModel.contains(fragment)) {
-                onNativeFragmentPop(fragment)
+    override fun onBackStackChanged() {
+        val currentFragmentManager = fragmentManager ?: return
+        val addedFragments = currentFragmentManager.fragments
+
+        while (stackModel.size > 1) {
+            val topFragment = stackModel.last()
+            if (addedFragments.contains(topFragment)) {
+                return
             }
+
+            delegate.get()?.onScreenDismissCommitted(topFragment.stackScreen)
+            onNativeFragmentPop(topFragment)
         }
     }
 


### PR DESCRIPTION
## Summary

This PR makes the Android implementation compatible with hosts that use
AndroidX Fragment 1.3.6.

- Depend on `androidx.fragment:fragment:1.3.6`.
- Replace the `View.findFragment()` KTX extension with
  `FragmentManager.findFragment(View)` from the base Fragment artifact.
- Replace the newer `onBackStackChangeCommitted` callback with the
  Fragment 1.3-compatible `onBackStackChanged` callback.
- Detect native pops by reconciling the internal stack model with
  `FragmentManager.fragments`.

This PR does not change the minimum SDK, AppCompat, Material, or other
platform dependencies.

## Motivation

Some internal host applications use Fragment 1.3.6 as their validated
dependency baseline.

The current Android implementation depends on newer Fragment APIs, which
requires these hosts to upgrade Fragment before integrating lynx-screens.

This change uses APIs available in Fragment 1.3.6 while preserving the
existing push, pop, nested-stack, and native-back behavior.

## Why `fragment-ktx` is no longer required

The Android implementation only used `fragment-ktx` for the
`View.findFragment()` extension.

Fragment 1.3.6 provides the equivalent
`FragmentManager.findFragment(View)` API directly in the base `fragment`
artifact. After switching to that API, no Fragment KTX extensions remain in
the implementation, so lynx-screens no longer needs a direct
`fragment-ktx` dependency.

## Native-pop handling

JS-driven pops update the internal stack model before their Fragment
transaction is committed. Native pops leave the removed screen in the model.

The Fragment 1.3-compatible `onBackStackChanged` implementation compares the
model with the FragmentManager's currently added fragments and removes trailing
entries that are no longer present. The root entry is preserved.

## Validation checklist

- [x] Build the library Debug and Release AARs with JDK 17.
- [x] Build and install the Example Debug APK.
- [x] Confirm `fragment-ktx` is absent from the library classpath.
- [x] Force the Example dependency graph to resolve Fragment 1.3.6 and run it
      on a physical Android device.
- [x] Verify regular JS and native pops with `TestStackSimpleNav`.
- [x] Verify batched Fragment transactions with `TestBatch`.
- [x] Verify single-stack `preventNativeDismiss`.
- [x] Verify nested Fragment lookup, stack creation, and Back dispatch with
      `TestNested`.
- [x] Verify nested-stack `preventNativeDismiss`.
- [x] Compare the only observed nested-dismiss error with `upstream/main`.
- [x] Verify the integration in a real internal host using Fragment 1.3.6.

## Validation results

| Area | Status | Result |
| --- | --- | --- |
| Library build | Passed | Debug and Release AARs built successfully. |
| Example build and installation | Passed | Debug APK built, installed, and launched successfully. |
| Fragment 1.3.6 runtime | Passed | The Example was run with a temporary resolution rule selecting `androidx.fragment:fragment:1.3.6`. |
| `fragment-ktx` removal | Passed | No `fragment-ktx` dependency remained in the library classpath. |
| `TestStackSimpleNav` | Passed | `Home → A → JS Pop → Home` and `Home → B → native Back → Home` behaved as expected. |
| `TestBatch` | Passed | The batched pop/push transaction completed successfully with `E` as the final top screen. |
| `TestPreventNativeDismissSingleStack` | Passed | Back was blocked while enabled; after disabling it, `B` emitted exactly one native-dismiss event. |
| `TestNested` | Passed for this PR's scope | Nested creation and Back dispatch worked. Removing the entire nested stack exposed a pre-existing duplicate child-root dismiss issue. |
| `TestPreventNativeDismissNestedStack` | Passed for this PR's scope | Nested top/root prevention and release worked. Removing the entire nested stack exposed the same pre-existing issue. |
| Baseline comparison | Passed | The same child-root dismiss and reducer error were reproduced on `upstream/main` with Fragment 1.8.9, confirming that they were not introduced by this PR. |
| Internal host integration | Passed | The changes were verified in a real internal host using Fragment 1.3.6. |

The current Example normally resolves Fragment 1.5.4 through AppCompat.
Therefore, the Fragment 1.3.6 compatibility run used a temporary Gradle
resolution rule. No test-only resolution changes are included in this PR.

## Known baseline issue

When an entire nested stack is removed through native Back, the nested root
screen also emits a native-dismiss event. The nested reducer then rejects the
event because only one route remains:

`pop-native can not be performed with less than 2 routes`

The same behavior was reproduced on `upstream/main`, so it is not caused by
the Fragment 1.3.6 compatibility changes. It is addressed separately by the
nested-dismiss deduplication PR.
