### PR TITLE
fix(Android, Stack): avoid duplicate dismiss events during ancestor teardown

### DIFF
--- a/LynxExample/src/examples/TestNested.tsx
+++ b/LynxExample/src/examples/TestNested.tsx
@@ -52,6 +52,10 @@ function TemplateScreen() {
         label="Push NestedStack"
         onTap={() => navigation.push('NestedStack')}
       />
+      <Button
+        label="Push DeepNestedStack"
+        onTap={() => navigation.push('DeepNestedStack')}
+      />
       <Button label="Pop" onTap={() => navigation.pop(navigation.routeKey)} />
       <Button label="Preload A" onTap={() => navigation.preload('A')} />
       <Button label="Preload B" onTap={() => navigation.preload('B')} />
@@ -109,6 +113,19 @@ function NestedStackScreen() {
   return <StackContainer routeConfigs={ROUTE_CONFIGS_NESTED_STACK} />;
 }
 
+function DeepNestedStackScreen() {
+  return <StackContainer routeConfigs={ROUTE_CONFIGS_MIDDLE_STACK} />;
+}
+
+// The middle root is destroyed with its parent without being independently removed.
+// Back from the deepest root must dismiss only the outer DeepNestedStack route.
+const ROUTE_CONFIGS_MIDDLE_STACK: StackRouteConfig[] = [
+  {
+    name: 'MiddleRoot',
+    Component: NestedStackScreen,
+  },
+];
+
 const ROUTE_CONFIGS: StackRouteConfig[] = [
   {
     name: 'A',
@@ -129,6 +146,10 @@ const ROUTE_CONFIGS: StackRouteConfig[] = [
       onDidAppear: () => console.log('B onDidAppear'),
       onDidDisappear: () => console.log('B onDidDisappear'),
     },
+  },
+  {
+    name: 'DeepNestedStack',
+    Component: DeepNestedStackScreen,
   },
   {
     name: 'NestedStack',

--- a/android/src/main/java/com/lynxscreens/screens/screen/StackScreenFragment.kt
+++ b/android/src/main/java/com/lynxscreens/screens/screen/StackScreenFragment.kt
@@ -67,7 +67,12 @@ internal class StackScreenFragment(
 
     override fun onDestroy() {
         super.onDestroy()
-        stackScreen.onDismiss()
+
+        // Destroying an outer StackScreen also destroys all Fragments in its child manager. Those
+        // nested screens were not independently popped and must not emit another native dismissal.
+        if (generateSequence(parentFragment) { it.parentFragment }.none { it.isRemoving }) {
+            stackScreen.onDismiss()
+        }
         teardownPreventNativeDismissCallback()
     }
 


### PR DESCRIPTION
## Summary

Prevent nested `StackScreenFragment` instances from emitting dismiss events when they are destroyed because an ancestor Fragment is being removed.

- Check the full ancestor chain before calling `onDismiss`.
- Preserve dismissal for screens that are removed independently.
- Always clean up the `preventNativeDismiss` callback.
- Extend `TestNested` with a three-level `DeepNestedStack` example.

## Motivation

Removing an outer screen also destroys the fragments in its nested stacks. Those nested roots were not independently popped and must not report another native dismissal.

With three or more levels of nesting, an intermediate parent may be destroyed without being marked as removing. Checking only `parentFragment.isRemoving` misses the removing ancestor further up the chain:

```text
DeepNestedStack (being removed)
└── MiddleRoot (destroyed with its ancestor)
    └── NestedA (must not emit a native-dismiss event)
```

On the previous revision of this PR, returning from the deepest root incorrectly emitted a native-dismiss event for `NestedA` and triggered `pop-native can not be performed with less than 2 routes`. With the full ancestor check, only `DeepNestedStack` reports the dismissal, and navigation returns to the outer `A` screen.

## Validation

The latest revision was built and exercised on an Android 16 physical device.

| Check | Result |
| --- | --- |
| Three-level baseline reproduction | Reproduced the extra `NestedA` native-dismiss event and reducer error on the previous PR revision, which checked only the direct parent. |
| Three-level ancestor teardown | Returning from the deepest root dismissed only `DeepNestedStack`, with no extra `NestedA` or `MiddleRoot` dismissal. |
| Independent deepest-screen pop | Returning from `NestedB` emitted exactly one native-dismiss event and returned to `NestedA`. |
| Two-level nesting | The nested top screen and outer stack each emitted their own dismissal on successive Back presses; the nested root emitted no extra dismissal. |
| Regular screen pop | Returning from non-nested `B` emitted exactly one native-dismiss event. |
| Repeated entry and exit | Re-entering and leaving the three-level stack produced no extra root dismissal. |
| Runtime stability | No target reducer error or Android runtime crash was observed in these paths. |
| Builds | Library Debug/Release AARs, the Example Debug APK, and the Example bundle built successfully. |
| Static checks | The changed example passed ESLint; whitespace and added-content forbidden-keyword checks passed. Full-repository lint remains blocked by existing source errors and generated artifacts outside the changed files. |

The earlier revision also passed the nested top-screen and root-screen `preventNativeDismiss` scenarios. Those scenarios were not rerun for this revision; callback cleanup remains unconditional.
