### PR TITLE
fix(android): prevent StackScreenFragment restoration crashes

### DIFF
--- a/android/build.gradle.kts
+++ b/android/build.gradle.kts
@@ -34,4 +34,6 @@ dependencies {
     implementation("androidx.transition:transition-ktx:1.7.0")
     implementation("com.google.android.material:material:1.14.0")
     implementation("androidx.core:core-ktx:1.17.0")
+
+    testImplementation("junit:junit:4.13.2")
 }

--- a/android/src/main/java/com/lynxscreens/screens/host/StackContainer.kt
+++ b/android/src/main/java/com/lynxscreens/screens/host/StackContainer.kt
@@ -209,7 +209,10 @@ internal class StackContainer(
     private fun updateTopFragment() {
         // We try to handle situation where other fragments might be present.
         val fragmentManager = requireFragmentManager()
-        val fragments = fragmentManager.fragments.filterIsInstance<StackScreenFragment>()
+        val fragments =
+            fragmentManager.fragments
+                .filterIsInstance<StackScreenFragment>()
+                .filterNot { it.isRestoredPlaceholder }
         check(fragments.isNotEmpty()) { "[RNScreens] Empty fragment manager while attempting to update top fragment" }
         fragments.forEach { it.onResignTopFragment() }
         fragments.last().onBecomeTopFragment()
@@ -231,6 +234,7 @@ internal class StackContainer(
         requireFragmentManager()
             .fragments
             .filterIsInstance<StackScreenFragment>()
+            .filterNot { it.isRestoredPlaceholder }
             .lastOrNull()
 
     /**

--- a/android/src/main/java/com/lynxscreens/screens/screen/NonRestorableLynxFragment.kt
+++ b/android/src/main/java/com/lynxscreens/screens/screen/NonRestorableLynxFragment.kt
@@ -1,0 +1,105 @@
+package com.lynxscreens.screens.screen
+
+import android.os.Bundle
+import android.view.LayoutInflater
+import android.view.View
+import android.view.ViewGroup
+import androidx.fragment.app.Fragment
+
+/**
+ * A Fragment whose runtime state comes from the current Lynx component tree and cannot be restored
+ * by Android's saved-state mechanism.
+ *
+ * Concrete Fragments still need to expose a public no-argument constructor. Instances created
+ * through that constructor are restored placeholders: they never enter runtime-only lifecycle
+ * callbacks and remove themselves as soon as they are attached to a FragmentManager.
+ */
+internal abstract class NonRestorableLynxFragment<State : Any> : Fragment() {
+    private var runtimeStateOrNull: State? = null
+
+    protected val runtimeState: State
+        get() =
+            checkNotNull(runtimeStateOrNull) {
+                "[RNScreens] Restored Fragment has no Lynx runtime state"
+            }
+
+    internal val isRestoredPlaceholder: Boolean
+        get() = runtimeStateOrNull == null
+
+    protected fun initializeRuntimeState(state: State) {
+        check(runtimeStateOrNull == null) {
+            "[RNScreens] Lynx Fragment runtime state has already been initialized"
+        }
+        runtimeStateOrNull = state
+    }
+
+    final override fun onCreate(savedInstanceState: Bundle?) {
+        super.onCreate(savedInstanceState)
+
+        if (isRestoredPlaceholder) {
+            removeRestoredFragment()
+            return
+        }
+
+        onRuntimeCreate(savedInstanceState)
+    }
+
+    final override fun onCreateView(
+        inflater: LayoutInflater,
+        container: ViewGroup?,
+        savedInstanceState: Bundle?,
+    ): View? =
+        if (isRestoredPlaceholder) {
+            null
+        } else {
+            onCreateRuntimeView(inflater, container, savedInstanceState)
+        }
+
+    final override fun onViewCreated(
+        view: View,
+        savedInstanceState: Bundle?,
+    ) {
+        super.onViewCreated(view, savedInstanceState)
+        if (!isRestoredPlaceholder) {
+            onRuntimeViewCreated(view, savedInstanceState)
+        }
+    }
+
+    final override fun onDestroyView() {
+        if (!isRestoredPlaceholder) {
+            onRuntimeDestroyView()
+        }
+        super.onDestroyView()
+    }
+
+    final override fun onDestroy() {
+        super.onDestroy()
+        if (!isRestoredPlaceholder) {
+            onRuntimeDestroy()
+        }
+    }
+
+    protected open fun onRuntimeCreate(savedInstanceState: Bundle?) = Unit
+
+    protected abstract fun onCreateRuntimeView(
+        inflater: LayoutInflater,
+        container: ViewGroup?,
+        savedInstanceState: Bundle?,
+    ): View
+
+    protected open fun onRuntimeViewCreated(
+        view: View,
+        savedInstanceState: Bundle?,
+    ) = Unit
+
+    protected open fun onRuntimeDestroyView() = Unit
+
+    protected open fun onRuntimeDestroy() = Unit
+
+    private fun removeRestoredFragment() {
+        parentFragmentManager
+            .beginTransaction()
+            .remove(this)
+            .commitAllowingStateLoss()
+    }
+}

--- a/android/src/main/java/com/lynxscreens/screens/screen/StackScreenFragment.kt
+++ b/android/src/main/java/com/lynxscreens/screens/screen/StackScreenFragment.kt
@@ -5,14 +5,35 @@ import android.view.Gravity
 import android.view.LayoutInflater
 import android.view.View
 import android.view.ViewGroup
-import androidx.fragment.app.Fragment
+import androidx.annotation.Keep
 import androidx.transition.Slide
 import com.lynxscreens.screens.header.StackHeaderCoordinatorLayout
 
-internal class StackScreenFragment(
-    internal val stackScreen: StackScreenComponent,
-    private val canNavigateBack: Boolean,
-) : Fragment() {
+internal data class StackScreenRuntimeState(
+    val stackScreen: StackScreenComponent,
+    val canNavigateBack: Boolean,
+)
+
+internal class StackScreenFragment @Keep constructor() :
+    NonRestorableLynxFragment<StackScreenRuntimeState>() {
+    internal constructor(
+        stackScreen: StackScreenComponent,
+        canNavigateBack: Boolean,
+    ) : this() {
+        initializeRuntimeState(
+            StackScreenRuntimeState(
+                stackScreen = stackScreen,
+                canNavigateBack = canNavigateBack,
+            ),
+        )
+    }
+
+    internal val stackScreen: StackScreenComponent
+        get() = runtimeState.stackScreen
+
+    private val canNavigateBack: Boolean
+        get() = runtimeState.canNavigateBack
+
     private var screenLifecycleEventEmitter: StackScreenAppearanceEventsEmitter? = null
 
     /**
@@ -27,9 +48,7 @@ internal class StackScreenFragment(
 
     private var isTopFragment: Boolean = false
 
-    override fun onCreate(savedInstanceState: Bundle?) {
-        super.onCreate(savedInstanceState)
-
+    override fun onRuntimeCreate(savedInstanceState: Bundle?) {
         setupPreventNativeDismissCallback()
 
         allowEnterTransitionOverlap = true
@@ -41,33 +60,29 @@ internal class StackScreenFragment(
         reenterTransition = Slide(Gravity.LEFT)
     }
 
-    override fun onCreateView(
+    override fun onCreateRuntimeView(
         inflater: LayoutInflater,
         container: ViewGroup?,
         savedInstanceState: Bundle?,
     ): View = StackHeaderCoordinatorLayout(requireContext(), stackScreen, canNavigateBack)
 
-    override fun onViewCreated(
+    override fun onRuntimeViewCreated(
         view: View,
-        savedInstanceState: Bundle?
+        savedInstanceState: Bundle?,
     ) {
-        super.onViewCreated(view, savedInstanceState)
         screenLifecycleEventEmitter = stackScreen.createAppearanceEventsEmitter(viewLifecycleOwner)
     }
 
-    override fun onDestroyView() {
+    override fun onRuntimeDestroyView() {
         val coordinatorLayout = view
         check(coordinatorLayout is StackHeaderCoordinatorLayout) {
             "[RNScreens] Unexpected fragment view type: $view"
         }
         coordinatorLayout.tearDown()
-        super.onDestroyView()
         screenLifecycleEventEmitter = null
     }
 
-    override fun onDestroy() {
-        super.onDestroy()
-
+    override fun onRuntimeDestroy() {
         // Destroying an outer StackScreen also destroys all Fragments in its child manager. Those
         // nested screens were not independently popped and must not emit another native dismissal.
         if (generateSequence(parentFragment) { it.parentFragment }.none { it.isRemoving }) {

--- a/android/src/test/java/com/lynxscreens/screens/screen/StackScreenFragmentTest.kt
+++ b/android/src/test/java/com/lynxscreens/screens/screen/StackScreenFragmentTest.kt
@@ -1,0 +1,27 @@
+package com.lynxscreens.screens.screen
+
+import androidx.fragment.app.FragmentFactory
+import java.lang.reflect.Modifier
+import org.junit.Assert.assertTrue
+import org.junit.Test
+
+class StackScreenFragmentTest {
+    @Test
+    fun defaultFragmentFactoryCreatesRestoredPlaceholder() {
+        val fragment =
+            FragmentFactory().instantiate(
+                checkNotNull(StackScreenFragment::class.java.classLoader),
+                StackScreenFragment::class.java.name,
+            )
+
+        assertTrue(fragment is StackScreenFragment)
+        assertTrue((fragment as StackScreenFragment).isRestoredPlaceholder)
+    }
+
+    @Test
+    fun noArgumentConstructorIsPublic() {
+        val constructor = StackScreenFragment::class.java.getConstructor()
+
+        assertTrue(Modifier.isPublic(constructor.modifiers))
+    }
+}


### PR DESCRIPTION
## Summary

Prevent AndroidX `FragmentManager` from crashing when it restores
`StackScreenFragment` after the host Activity is recreated.

The fix is contained entirely within `lynx-screens`; host applications do not
need to install or compose a custom `FragmentFactory`.

Fixes #126

## Problem

`StackScreenFragment` previously required `StackScreenComponent` and
`canNavigateBack` as constructor parameters.

When Android recreates an Activity after a configuration change or process
reclamation, `FragmentManager` restores saved fragments through the default
`FragmentFactory`. Because `StackScreenFragment` did not expose a public
no-argument constructor, restoration failed with a `FragmentInstantiationException`
caused by `NoSuchMethodException`.

Adding only a no-argument constructor would not be sufficient: a restored
instance would still have no live `StackScreenComponent`, while its lifecycle,
back handling, appearance, and dismiss logic depend on that runtime state.

## Solution

This PR introduces a library-owned `NonRestorableLynxFragment<State>` abstraction:

- Fragments created by the current Lynx component tree receive their runtime
  state through the normal constructor path.
- `StackScreenFragment` exposes a public `@Keep` no-argument constructor for
  AndroidX restoration.
- Instances created through that constructor are treated as restored placeholders.
- Restored placeholders remove themselves in `onCreate()` and never enter
  runtime-only lifecycle callbacks.
- `StackContainer` ignores restored placeholders when determining and updating
  the active fragment.
- Unit tests verify default `FragmentFactory` instantiation and constructor
  visibility.

## Behavior after Activity recreation

`StackScreenFragment` contains references to the current Lynx component tree
and cannot be reconstructed independently from Android saved state.

Restored native fragments are therefore discarded, and the newly created Lynx
page creates its fragment tree again. This prevents the crash but does not add
native persistence for the JavaScript navigation stack. Navigation-state
persistence remains the responsibility of the application.

## Compatibility

- No host-side integration is required.
- Normal runtime-created `StackScreenFragment` behavior is unchanged.
- Restored placeholders do not create views, register back callbacks, or emit
  appearance or dismiss events.
- Other host fragments and Activity saved state are unaffected.

## Validation

### Automated checks

- [x] The default `FragmentFactory` can instantiate `StackScreenFragment`.
- [x] The no-argument constructor is public.
- [x] Android library unit tests pass.
- [x] Debug and Release AARs assemble successfully.
- [x] The example bundle and Debug APK build successfully.
- [x] The Debug APK installs and launches on a physical Android device.

### Normal navigation regression

- [x] Cold-start a page containing a Stack; the initial screen renders normally.
- [x] Push at least two screens; rendering and transitions remain normal.
- [x] Pop a screen from Lynx/JavaScript; the correct previous screen becomes active.
- [x] Use Android back navigation; only the top screen handles the action.

### Activity recreation

The following scenarios were tested with an active three-screen Stack:

- [x] Rotate the device between portrait and landscape.
- [x] Switch between gesture navigation and three-button navigation.
- [x] Enable "Don't keep activities", background the app, and return.
- [x] Background the app, terminate its process, and restore the task.

All tested recreation scenarios completed without a Fragment instantiation
crash or an unusable page. After Activity recreation, the example may reload
its initial test-case route according to its JavaScript initialization behavior.

## Known limitation

Restored `BackStackRecord` entries currently survive after their placeholder
fragments are discarded. After Activity recreation, each orphaned entry may
consume one Back press without changing the newly rendered page. Cleaning up
these entries safely requires explicit ownership boundaries and will be handled
separately as a follow-up.
