### PR TITLE
refactor(Android, FormSheet v5): Extract the native controller interface

### DIFF
--- a/android/src/main/java/com/lynxscreens/screens/formsheet/core/FormSheetDialogManager.kt
+++ b/android/src/main/java/com/lynxscreens/screens/formsheet/core/FormSheetDialogManager.kt
@@ -3,18 +3,18 @@ package com.lynxscreens.screens.formsheet.core
 import android.content.Context
 import android.view.ContextThemeWrapper
 import android.view.View
-import com.lynxscreens.screens.formsheet.interfaces.FormSheetContentSizeChangeDelegate
+import com.lynxscreens.screens.formsheet.interfaces.FormSheetController
 import com.lynxscreens.screens.formsheet.interfaces.FormSheetDialogEventEmitter
 import com.lynxscreens.screens.formsheet.model.FormSheetConfig
 import com.lynxscreens.screens.formsheet.presentation.FormSheetDimmingManager
 import com.lynxscreens.screens.formsheet.presentation.FormSheetPresentation
 import com.lynxscreens.screens.formsheet.presentation.FormSheetPresentationManager
-import kotlin.properties.Delegates
 
 internal class FormSheetDialogManager(
     context: Context,
     contentView: View,
-) {
+    private val eventEmitter: FormSheetDialogEventEmitter,
+) : FormSheetController {
     private var formSheetConfig = FormSheetConfig()
     private val themedContext =
         ContextThemeWrapper(
@@ -28,38 +28,37 @@ internal class FormSheetDialogManager(
         FormSheetPresentationManager(
             presentationFactory = ::createPresentation,
             dimmingManager = dimmingManager,
-            onDismiss = { isNativeDismiss -> eventEmitter?.emitOnDismissEvent(isNativeDismiss) },
+            onDismiss = eventEmitter::emitOnDismissEvent,
         )
     private val presentationCallbacks =
         object : FormSheetPresentation.Callbacks {
-            override fun onDetentChanged(index: Int) = eventEmitter?.emitOnDetentChanged(index) ?: Unit
+            override fun onDetentChanged(index: Int) = eventEmitter.emitOnDetentChanged(index)
 
             override fun onNativeDismissAllowed() = presentationManager.handleNativeDismiss()
 
-            override fun onNativeDismissPrevented() = eventEmitter?.emitOnNativeDismissPreventedEvent() ?: Unit
+            override fun onNativeDismissPrevented() = eventEmitter.emitOnNativeDismissPreventedEvent()
         }
 
-    internal var eventEmitter: FormSheetDialogEventEmitter? by Delegates.observable(null) { _, _, value ->
-        presentationManager.appearanceEventEmitter = value
+    init {
+        presentationManager.appearanceEventEmitter = eventEmitter
     }
-
-    internal val contentSizeChangeDelegate =
-        FormSheetContentSizeChangeDelegate { height ->
-            lastContentHeight = height
-            presentationManager.currentPresentation?.onContentHeightChanged(height)
-        }
 
     private fun createPresentation(): FormSheetPresentation =
         FormSheetPresentation(themedContext, container, presentationCallbacks).also {
             it.applyInitialConfig(formSheetConfig, lastContentHeight)
         }
 
-    internal fun applyConfig(config: FormSheetConfig) {
+    override fun apply(config: FormSheetConfig) {
         val oldConfig = formSheetConfig
         formSheetConfig = config
         presentationManager.currentPresentation?.applyConfigUpdate(oldConfig, config)
         if (oldConfig.isOpen != config.isOpen) presentationManager.requestProgrammaticStateUpdate(config.isOpen)
     }
 
-    internal fun destroy() = presentationManager.destroy()
+    override fun onContentHeightChanged(height: Int) {
+        lastContentHeight = height
+        presentationManager.currentPresentation?.onContentHeightChanged(height)
+    }
+
+    override fun dispose() = presentationManager.destroy()
 }

--- a/android/src/main/java/com/lynxscreens/screens/formsheet/host/FormSheetHostComponent.kt
+++ b/android/src/main/java/com/lynxscreens/screens/formsheet/host/FormSheetHostComponent.kt
@@ -13,6 +13,8 @@ import com.lynx.tasm.behavior.ui.LynxUI
 import com.lynx.tasm.behavior.ui.UIGroup
 import com.lynxscreens.screens.common.ShadowStateProxy
 import com.lynxscreens.screens.formsheet.core.FormSheetDialogManager
+import com.lynxscreens.screens.formsheet.interfaces.FormSheetContentSizeChangeDelegate
+import com.lynxscreens.screens.formsheet.interfaces.FormSheetController
 import com.lynxscreens.screens.formsheet.model.FormSheetConfig
 
 @LynxElement(name = "ls-form-sheet")
@@ -20,7 +22,7 @@ internal class FormSheetHostComponent(context: LynxContext) : UIGroup<FormSheetH
     private val eventEmitter by lazy { FormSheetHostEventEmitter(lynxContext, sign) }
     private val shadowStateProxy by lazy { ShadowStateProxy(lynxContext, sign) }
     private lateinit var sheetContentView: FormSheetContentView
-    private lateinit var dialogManager: FormSheetDialogManager
+    private lateinit var controller: FormSheetController
 
     private var isOpen = false
     private var detents: List<Double> = emptyList()
@@ -45,9 +47,6 @@ internal class FormSheetHostComponent(context: LynxContext) : UIGroup<FormSheetH
                 },
                 dispatchLynxTouchEvent = ::dispatchDialogTouchEvent,
             )
-        dialogManager = FormSheetDialogManager(lynxContext, sheetContentView)
-        dialogManager.eventEmitter = eventEmitter
-        sheetContentView.contentSizeChangeDelegate = dialogManager.contentSizeChangeDelegate
         return FormSheetHostView(lynxContext)
     }
 
@@ -79,7 +78,12 @@ internal class FormSheetHostComponent(context: LynxContext) : UIGroup<FormSheetH
 
     override fun onPropsUpdated() {
         super.onPropsUpdated()
-        dialogManager.applyConfig(
+        if (!::controller.isInitialized) {
+            controller = FormSheetDialogManager(lynxContext, sheetContentView, eventEmitter)
+            sheetContentView.contentSizeChangeDelegate =
+                FormSheetContentSizeChangeDelegate(controller::onContentHeightChanged)
+        }
+        controller.apply(
             FormSheetConfig(
                 isOpen = isOpen,
                 detents = detents,
@@ -93,7 +97,7 @@ internal class FormSheetHostComponent(context: LynxContext) : UIGroup<FormSheetH
     }
 
     override fun destroy() {
-        if (::dialogManager.isInitialized) dialogManager.destroy()
+        if (::controller.isInitialized) controller.dispose()
         super.destroy()
     }
 

--- a/android/src/main/java/com/lynxscreens/screens/formsheet/interfaces/FormSheetController.kt
+++ b/android/src/main/java/com/lynxscreens/screens/formsheet/interfaces/FormSheetController.kt
@@ -1,0 +1,22 @@
+package com.lynxscreens.screens.formsheet.interfaces
+
+import android.content.Context
+import android.view.View
+import com.lynxscreens.screens.formsheet.model.FormSheetConfig
+
+/** Runtime-independent interface of the native FormSheet module. */
+internal interface FormSheetController {
+    fun apply(config: FormSheetConfig)
+
+    fun onContentHeightChanged(height: Int)
+
+    fun dispose()
+}
+
+internal fun interface FormSheetControllerFactory {
+    fun create(
+        context: Context,
+        contentView: View,
+        eventEmitter: FormSheetDialogEventEmitter,
+    ): FormSheetController
+}


### PR DESCRIPTION
Stacked on #128.

## Summary

- Extract a runtime-independent `FormSheetController` contract from the Lynx host component.
- Move dialog ownership and presentation orchestration into `FormSheetDialogManager`.
- Keep `FormSheetHostComponent` focused on Lynx props, content mounting, measurements, and event integration.

## Motivation

This ports the controller boundary introduced in RNScreens and establishes the logical seam required by the replaceable backend work discussed in #104.

Related discussion: https://github.com/software-mansion-labs/lynx-screens/discussions/104
Related RNScreens commit: https://github.com/software-mansion/react-native-screens/commit/d91508209551b7f97a20770313367eed16337bcf

## Validation

- Built the Android library with the extracted controller interface.
- Verified that the default FormSheet behavior remains backed by `FormSheetDialogManager`.