### PR TITLE
feat: add navigation trace instrumentation

### DIFF
--- a/android/build.gradle.kts
+++ b/android/build.gradle.kts
@@ -34,6 +34,7 @@ android {
 
 dependencies {
     implementation("org.lynxsdk.lynx:lynx:4.0.1")
+    implementation("org.lynxsdk.lynx:lynx-trace:4.0.1")
     implementation("org.lynxsdk.lynx:service-api:4.0.1")
     kapt("org.lynxsdk.lynx:lynx-processor:4.0.1")
 

--- a/android/src/formSheetMaterial/java/com/lynxscreens/screens/formsheet/core/FormSheetDialogManager.kt
+++ b/android/src/formSheetMaterial/java/com/lynxscreens/screens/formsheet/core/FormSheetDialogManager.kt
@@ -15,6 +15,7 @@ internal class FormSheetDialogManager(
     contentView: View,
     private val eventEmitter: FormSheetDialogEventEmitter,
 ) : FormSheetController {
+    private val navigationTrace = (eventEmitter as? com.lynxscreens.screens.formsheet.host.FormSheetHostEventEmitter)?.navigationTrace
     private var formSheetConfig = FormSheetConfig()
     private val themedContext =
         ContextThemeWrapper(
@@ -27,6 +28,7 @@ internal class FormSheetDialogManager(
     private val presentationManager =
         FormSheetPresentationManager(
             presentationFactory = ::createPresentation,
+            navigationTrace = navigationTrace,
             dimmingManager = dimmingManager,
             onNativeDismiss = eventEmitter::emitOnNativeDismissEvent,
             onDismiss = eventEmitter::emitOnDismissEvent,
@@ -35,9 +37,19 @@ internal class FormSheetDialogManager(
         object : FormSheetPresentation.Callbacks {
             override fun onDetentChanged(index: Int) = eventEmitter.emitOnDetentChanged(index)
 
-            override fun onNativeDismissAllowed() = presentationManager.handleNativeDismiss()
+            override fun onNativeDismissAllowed() {
+                navigationTrace?.beginNativeDismiss()
+                presentationManager.handleNativeDismiss()
+            }
 
-            override fun onNativeDismissPrevented() = eventEmitter.emitOnNativeDismissPreventedEvent()
+            override fun onNativeDismissPrevented() {
+                navigationTrace?.beginNativeDismiss()
+                val operation = navigationTrace?.operation
+                navigationTrace?.nativeDismissPrevented()
+                val trace = navigationTrace
+                if (trace != null) trace.withOperation(operation) { eventEmitter.emitOnNativeDismissPreventedEvent() }
+                else eventEmitter.emitOnNativeDismissPreventedEvent()
+            }
         }
 
     init {

--- a/android/src/formSheetMaterial/java/com/lynxscreens/screens/formsheet/presentation/FormSheetPresentationManager.kt
+++ b/android/src/formSheetMaterial/java/com/lynxscreens/screens/formsheet/presentation/FormSheetPresentationManager.kt
@@ -9,6 +9,7 @@ import com.google.android.material.bottomsheet.BottomSheetBehavior
 import com.lynxscreens.screens.common.event.ViewAppearanceEventEmitter
 
 internal class FormSheetPresentationManager(
+    private val navigationTrace: com.lynxscreens.screens.formsheet.FormSheetNavigationTrace?,
     private val presentationFactory: () -> FormSheetPresentation,
     private val dimmingManager: FormSheetDimmingManager,
     private val onNativeDismiss: () -> Unit,
@@ -23,12 +24,14 @@ internal class FormSheetPresentationManager(
 
     private var state = FormSheetPresentationState.DISMISSED
     private var shouldBeOpen = false
+    private var requestedTraceBatch: com.lynxscreens.screens.common.trace.TraceBatch? = null
     private var shouldSkipExitAnimation = false
     private var dismissalOrigin = FormSheetDismissalOrigin.UNSPECIFIED
     private val animatorFactory = FormSheetAnimatorFactory(dimmingManager)
     private var currentSheetAnimator: Animator? = null
 
     internal fun requestProgrammaticStateUpdate(shouldBeOpen: Boolean) {
+        if (this.shouldBeOpen != shouldBeOpen) requestedTraceBatch = navigationTrace?.captureBatch()
         updatePresentationState(
             shouldBeOpen,
             if (shouldBeOpen) FormSheetDismissalOrigin.UNSPECIFIED else FormSheetDismissalOrigin.PROGRAMMATIC,
@@ -54,7 +57,10 @@ internal class FormSheetPresentationManager(
 
     private fun presentIfNeeded() {
         if (state != FormSheetPresentationState.DISMISSED) return
+        navigationTrace?.beginPresent(requestedTraceBatch)
+        requestedTraceBatch = null
         state = FormSheetPresentationState.PRESENTING
+        val traceOperation = navigationTrace?.operation
         val presentation = presentationFactory().also { currentPresentation = it }
         presentation.sheetBehavior?.let(dimmingManager::attachToBehavior)
         FormSheetStackRegistry.register(this)
@@ -63,13 +69,15 @@ internal class FormSheetPresentationManager(
         presentation.dialog.setOnShowListener {
             presentation.dialog.setOnShowListener(null)
             dimmingManager.attachDimming(FormSheetStackRegistry.sheetBelow(this)?.bottomSheetView)
-            startEnterAnimation()
+            startEnterAnimation(traceOperation)
         }
         presentation.dialog.show()
     }
 
     private fun dismissIfNeeded() {
         if (state != FormSheetPresentationState.PRESENTED) return
+        if (dismissalOrigin == FormSheetDismissalOrigin.PROGRAMMATIC) navigationTrace?.beginProgrammaticDismiss(requestedTraceBatch)
+        requestedTraceBatch = null
         state = FormSheetPresentationState.DISMISSING
         FormSheetStackRegistry.sheetsAbove(this).asReversed().forEach { it.handleDismissFromCascade() }
         FormSheetStackRegistry.unregister(this)
@@ -86,6 +94,7 @@ internal class FormSheetPresentationManager(
 
     private fun handleDismissFromCascade() {
         if (state == FormSheetPresentationState.DISMISSING || state == FormSheetPresentationState.DISMISSED) return
+        navigationTrace?.beginNativeDismiss(com.lynxscreens.screens.common.trace.NativeTransitionOrigin.CASCADE)
         shouldSkipExitAnimation = true
         updatePresentationState(false, FormSheetDismissalOrigin.USER)
     }
@@ -103,12 +112,14 @@ internal class FormSheetPresentationManager(
         }
     }
 
-    private fun startEnterAnimation() {
+    private fun startEnterAnimation(traceOperation: com.lynxscreens.screens.common.trace.NativeTransitionContext?) {
         val view = bottomSheetView
         if (view == null) {
-            onPresentationComplete()
+            navigationTrace?.start(false, traceOperation)
+            onPresentationComplete(traceOperation)
             return
         }
+        navigationTrace?.start(true, traceOperation)
         val isInterrupting = currentSheetAnimator?.isRunning == true
         currentSheetAnimator?.removeAllListeners()
         currentSheetAnimator?.cancel()
@@ -120,7 +131,7 @@ internal class FormSheetPresentationManager(
                         override fun onAnimationEnd(animation: Animator) {
                             dimmingManager.isTransitionAnimationRunning = false
                             if (currentSheetAnimator === this@apply) currentSheetAnimator = null
-                            onPresentationComplete()
+                            onPresentationComplete(traceOperation)
                         }
                     },
                 )
@@ -129,9 +140,11 @@ internal class FormSheetPresentationManager(
     }
 
     private fun startExitAnimation() {
+        val traceOperation = navigationTrace?.operation
+        navigationTrace?.start(true, traceOperation)
         val view = bottomSheetView
         if (view == null) {
-            performDismiss()
+            performDismiss(traceOperation)
             return
         }
         val isInterrupting = currentSheetAnimator?.isRunning == true
@@ -145,7 +158,7 @@ internal class FormSheetPresentationManager(
                         override fun onAnimationEnd(animation: Animator) {
                             dimmingManager.isTransitionAnimationRunning = false
                             if (currentSheetAnimator === this@apply) currentSheetAnimator = null
-                            performDismiss()
+                            performDismiss(traceOperation)
                         }
                     },
                 )
@@ -153,17 +166,19 @@ internal class FormSheetPresentationManager(
             }
     }
 
-    private fun performDismiss() {
+    private fun performDismiss(traceOperation: com.lynxscreens.screens.common.trace.NativeTransitionContext? = navigationTrace?.operation) {
+        navigationTrace?.start(false, traceOperation)
         shouldSkipExitAnimation = false
         dimmingManager.detachDimming()
         currentPresentation?.destroy()
+        navigationTrace?.dismissCommittedAndComplete(traceOperation)
         currentPresentation = null
         if (state == FormSheetPresentationState.DISMISSING) {
             state = FormSheetPresentationState.DISMISSED
-            appearanceEventEmitter?.emitOnDidDisappear()
+            withTrace(traceOperation) { appearanceEventEmitter?.emitOnDidDisappear() }
             when (dismissalOrigin) {
-                FormSheetDismissalOrigin.USER -> onNativeDismiss()
-                FormSheetDismissalOrigin.PROGRAMMATIC -> onDismiss()
+                FormSheetDismissalOrigin.USER -> withTrace(traceOperation) { onNativeDismiss() }
+                FormSheetDismissalOrigin.PROGRAMMATIC -> withTrace(traceOperation) { onDismiss() }
                 FormSheetDismissalOrigin.UNSPECIFIED ->
                     Log.e(
                         "[RNScreens]",
@@ -175,15 +190,22 @@ internal class FormSheetPresentationManager(
         }
     }
 
-    private fun onPresentationComplete() {
+    private fun onPresentationComplete(traceOperation: com.lynxscreens.screens.common.trace.NativeTransitionContext?) {
+        navigationTrace?.complete(traceOperation)
         if (state == FormSheetPresentationState.PRESENTING) {
             state = FormSheetPresentationState.PRESENTED
-            appearanceEventEmitter?.emitOnDidAppear()
+            withTrace(traceOperation) { appearanceEventEmitter?.emitOnDidAppear() }
             resolvePresentationState()
         }
     }
 
+    private fun withTrace(context: com.lynxscreens.screens.common.trace.NativeTransitionContext?, block: () -> Unit) {
+        val trace = navigationTrace
+        if (trace != null) trace.withOperation(context, block) else block()
+    }
+
     internal fun destroy() {
+        navigationTrace?.dispose("container_destroyed")
         FormSheetStackRegistry.unregister(this)
         dimmingManager.detachDimming()
         currentSheetAnimator?.cancel()

--- a/android/src/main/java/com/lynxscreens/screens/common/trace/LynxScreensTrace.kt
+++ b/android/src/main/java/com/lynxscreens/screens/common/trace/LynxScreensTrace.kt
@@ -1,0 +1,93 @@
+package com.lynxscreens.screens.common.trace
+
+import com.lynx.tasm.base.TraceEvent
+
+internal object LynxScreensTrace {
+    internal const val STACK_OPERATION_REQUESTED = "LynxScreens.Stack.OperationRequested"
+    internal const val STACK_OPERATION_BATCH_PREPARED = "LynxScreens.Stack.OperationBatchPrepared"
+    internal const val STACK_APPLY_OPERATIONS = "LynxScreens.Stack.ApplyOperations"
+    internal const val STACK_NATIVE_BACK_REQUESTED = "LynxScreens.Stack.NativeBackRequested"
+    internal const val STACK_TRANSITION_CALLBACK_RECEIVED =
+        "LynxScreens.Stack.TransitionCallbackReceived"
+    internal const val STACK_NATIVE_TRANSITION_START = "LynxScreens.Stack.NativeTransitionStart"
+    internal const val STACK_NATIVE_TRANSITION_END = "LynxScreens.Stack.NativeTransitionEnd"
+    internal const val STACK_NATIVE_TRANSITION_CANCELLED =
+        "LynxScreens.Stack.NativeTransitionCancelled"
+    internal const val STACK_NATIVE_DISMISS_COMMITTED = "LynxScreens.Stack.NativeDismissCommitted"
+    internal const val STACK_NATIVE_DISMISS_PREVENTED = "LynxScreens.Stack.NativeDismissPrevented"
+    internal const val STACK_LIFECYCLE_EVENT_EMITTED = "LynxScreens.Stack.LifecycleEventEmitted"
+    internal const val STACK_DISMISS_EVENT_EMITTED = "LynxScreens.Stack.DismissEventEmitted"
+
+    internal const val FORM_SHEET_PRESENT_REQUESTED = "LynxScreens.FormSheet.PresentRequested"
+    internal const val FORM_SHEET_DISMISS_REQUESTED = "LynxScreens.FormSheet.DismissRequested"
+    internal const val FORM_SHEET_NATIVE_TRANSITION_START =
+        "LynxScreens.FormSheet.NativeTransitionStart"
+    internal const val FORM_SHEET_NATIVE_TRANSITION_END =
+        "LynxScreens.FormSheet.NativeTransitionEnd"
+    internal const val FORM_SHEET_NATIVE_TRANSITION_CANCELLED =
+        "LynxScreens.FormSheet.NativeTransitionCancelled"
+    internal const val FORM_SHEET_NATIVE_DISMISS_COMMITTED =
+        "LynxScreens.FormSheet.NativeDismissCommitted"
+    internal const val FORM_SHEET_NATIVE_DISMISS_PREVENTED =
+        "LynxScreens.FormSheet.NativeDismissPrevented"
+    internal const val FORM_SHEET_LIFECYCLE_EVENT_EMITTED =
+        "LynxScreens.FormSheet.LifecycleEventEmitted"
+    internal const val FORM_SHEET_DISMISS_EVENT_EMITTED =
+        "LynxScreens.FormSheet.DismissEventEmitted"
+
+    private const val CATEGORY = "lynx"
+
+    internal fun isEnabled(): Boolean =
+        try {
+            TraceEvent.categoryEnabled(CATEGORY)
+        } catch (_: Exception) {
+            false
+        }
+
+    internal fun instant(name: String, arguments: () -> Map<String, String>) {
+        if (!isEnabled()) {
+            return
+        }
+        try {
+            TraceEvent.instant(CATEGORY, name, arguments())
+        } catch (_: Exception) {
+            /* Observation only. */
+        }
+    }
+
+    internal fun <T> section(
+        name: String,
+        arguments: () -> Map<String, String>,
+        block: () -> T,
+    ): T {
+        if (!isEnabled()) {
+            return block()
+        }
+
+        val began =
+            try {
+                TraceEvent.beginSection(CATEGORY, name, arguments())
+                true
+            } catch (_: Exception) {
+                false
+            }
+        return try {
+            block()
+        } finally {
+            if (began)
+                try {
+                    TraceEvent.endSection(CATEGORY, name)
+                } catch (_: Exception) {
+                    /* Observation only. */
+                }
+        }
+    }
+
+    internal fun argumentsOf(vararg entries: Pair<String, Any?>): Map<String, String> = buildMap {
+        entries.forEach { (key, value) ->
+            if (value != null) {
+                put(key, value.toString())
+            }
+        }
+    }
+}

--- a/android/src/main/java/com/lynxscreens/screens/common/trace/NativeTransitionContext.kt
+++ b/android/src/main/java/com/lynxscreens/screens/common/trace/NativeTransitionContext.kt
@@ -1,0 +1,153 @@
+package com.lynxscreens.screens.common.trace
+
+import java.util.concurrent.atomic.AtomicLong
+
+internal enum class NativeTransitionOperation(internal val traceValue: String) {
+    PUSH("push"),
+    POP("pop"),
+    BATCH("batch"),
+    PRESENT("present"),
+    DISMISS("dismiss"),
+}
+
+internal enum class NativeTransitionOrigin(internal val traceValue: String) {
+    LYNX_PATCH("lynx_patch"),
+    NATIVE_BACK("native_back"),
+    NATIVE_DISMISS("native_dismiss"),
+    CASCADE("cascade"),
+}
+
+internal enum class NativeTransitionPresentation(internal val traceValue: String) {
+    STACK("stack"),
+    FORM_SHEET("form_sheet"),
+}
+
+internal class NativeTransitionContext
+private constructor(
+    internal val id: String,
+    internal val navigationTraceId: String?,
+    internal val preloadTraceId: String?,
+    internal val containerId: String,
+    internal val presentation: NativeTransitionPresentation,
+    internal val operation: NativeTransitionOperation,
+    internal val origin: NativeTransitionOrigin,
+    internal val sourceScreenKey: String?,
+    internal val targetScreenKey: String?,
+    internal val popCount: Int,
+    internal val pushCount: Int,
+    internal val targetReused: Boolean,
+    internal val session: TraceSession?,
+    internal val contents: Map<String, ContentTraceIdentity>,
+) {
+    internal val traceIdentity =
+        NavigationTraceIdentity(
+            navigationTraceId = navigationTraceId,
+            preloadTraceId = preloadTraceId,
+            nativeTransitionId = id,
+            containerId = containerId,
+            runtimeId = session?.runtimeId,
+            navigatorKey = session?.navigatorKey,
+        )
+
+    internal fun identityFor(screenKey: String?): NavigationTraceIdentity =
+        contents[screenKey]?.identity(containerId, traceIdentity)
+            ?: traceIdentity.copy(screenKey = screenKey)
+
+    internal enum class State {
+        PREPARED,
+        STARTED,
+        COMPLETED,
+        CANCELLED,
+        PREVENTED,
+    }
+
+    internal var state: State = State.PREPARED
+        private set
+
+    internal fun markStarted(): Boolean {
+        if (state != State.PREPARED) {
+            return false
+        }
+        state = State.STARTED
+        return true
+    }
+
+    internal fun markCompleted(): Boolean {
+        if (state == State.COMPLETED || state == State.CANCELLED || state == State.PREVENTED) {
+            return false
+        }
+        state = State.COMPLETED
+        return true
+    }
+
+    internal fun markCancelled(): Boolean {
+        if (state == State.COMPLETED || state == State.CANCELLED || state == State.PREVENTED) {
+            return false
+        }
+        state = State.CANCELLED
+        return true
+    }
+
+    internal fun markPrevented(): Boolean {
+        if (state == State.COMPLETED || state == State.CANCELLED || state == State.PREVENTED) {
+            return false
+        }
+        state = State.PREVENTED
+        return true
+    }
+
+    internal fun traceArguments(vararg additional: Pair<String, Any?>): Map<String, String> =
+        LynxScreensTrace.argumentsOf(
+            "runtime_id" to session?.runtimeId,
+            "navigator_key" to session?.navigatorKey,
+            "navigation_trace_id" to navigationTraceId,
+            "preload_trace_id" to preloadTraceId,
+            "native_transition_id" to id,
+            "container_id" to containerId,
+            "presentation" to presentation.traceValue,
+            "operation" to operation.traceValue,
+            "origin" to origin.traceValue,
+            "source_screen_key" to sourceScreenKey,
+            "target_screen_key" to targetScreenKey,
+            "pop_count" to popCount,
+            "push_count" to pushCount,
+            "target_reused" to targetReused,
+            *additional,
+        )
+
+    internal companion object {
+        private val nextId = AtomicLong()
+
+        internal fun create(
+            containerId: String,
+            presentation: NativeTransitionPresentation,
+            operation: NativeTransitionOperation,
+            origin: NativeTransitionOrigin,
+            sourceScreenKey: String?,
+            targetScreenKey: String?,
+            popCount: Int = 0,
+            pushCount: Int = 0,
+            targetReused: Boolean = false,
+            navigationTraceId: String? = null,
+            preloadTraceId: String? = null,
+            session: TraceSession? = null,
+            contents: Map<String, ContentTraceIdentity> = emptyMap(),
+        ): NativeTransitionContext =
+            NativeTransitionContext(
+                id = "$containerId:transition:${nextId.incrementAndGet()}",
+                navigationTraceId = navigationTraceId,
+                preloadTraceId = preloadTraceId,
+                containerId = containerId,
+                presentation = presentation,
+                operation = operation,
+                origin = origin,
+                sourceScreenKey = sourceScreenKey,
+                targetScreenKey = targetScreenKey,
+                popCount = popCount,
+                pushCount = pushCount,
+                targetReused = targetReused,
+                session = session,
+                contents = contents.toMap(),
+            )
+    }
+}

--- a/android/src/main/java/com/lynxscreens/screens/common/trace/NavigationTraceContext.kt
+++ b/android/src/main/java/com/lynxscreens/screens/common/trace/NavigationTraceContext.kt
@@ -1,0 +1,136 @@
+package com.lynxscreens.screens.common.trace
+
+import com.lynx.tasm.event.LynxCustomEvent
+import java.util.UUID
+
+internal data class NavigationTraceContext(
+    val navigationTraceId: String,
+    val sequence: Long,
+    val action: String,
+    val sourceScreenKey: String?,
+    val targetScreenKey: String?,
+    val preloadTraceId: String? = null,
+    val session: TraceSession? = null,
+    val expectedChange: ExpectedTraceChange? = null,
+)
+
+internal data class NavigationTraceIdentity(
+    val navigationTraceId: String?,
+    val nativeTransitionId: String?,
+    val preloadTraceId: String? = null,
+    val containerId: String = "",
+    val runtimeId: String? = null,
+    val navigatorKey: String? = null,
+    val screenKey: String? = null,
+    val contentScopeId: String? = null,
+) {
+    // A View lifecycle notification is not necessarily caused by navigation.
+    fun withoutOperation() =
+        copy(navigationTraceId = null, nativeTransitionId = null, preloadTraceId = null)
+
+    fun addTo(event: LynxCustomEvent) {
+        if (containerId.isEmpty()) return
+        val values = linkedMapOf<String, Any>("version" to 1, "containerId" to containerId)
+        listOf(
+                "runtimeId" to runtimeId,
+                "navigatorKey" to navigatorKey,
+                "navigationTraceId" to navigationTraceId,
+                "nativeTransitionId" to nativeTransitionId,
+                "preloadTraceId" to preloadTraceId,
+                "screenKey" to screenKey,
+                "contentScopeId" to contentScopeId,
+            )
+            .forEach { (key, value) -> if (value != null) values[key] = value }
+        try {
+            event.addDetail("traceIdentity", values)
+        } catch (_: Exception) {
+            /* Observation only. */
+        }
+    }
+
+    fun arguments(vararg fields: Pair<String, Any?>): Map<String, String> =
+        LynxScreensTrace.argumentsOf(
+            "runtime_id" to runtimeId,
+            "navigator_key" to navigatorKey,
+            "container_id" to containerId,
+            "navigation_trace_id" to navigationTraceId,
+            "native_transition_id" to nativeTransitionId,
+            "preload_trace_id" to preloadTraceId,
+            "screen_key" to screenKey,
+            "content_scope_id" to contentScopeId,
+            *fields,
+        )
+}
+
+internal class NavigationTraceContextStore {
+    var session: TraceSession? = null
+        private set
+
+    private var current: TraceBatch? = null
+    private var lastSequence = -1L
+
+    fun setSession(value: String?) {
+        val next = TraceSession.parse(value)
+        if (next != session) {
+            current = null
+            lastSequence = -1
+            session = next
+        }
+    }
+
+    fun update(serialized: String?) {
+        current = null
+        val json = traceObject(serialized) ?: return
+        val active = session ?: return
+        if (
+            json.traceId("runtimeId") != active.runtimeId ||
+                json.traceId("navigatorKey") != active.navigatorKey
+        )
+            return
+        val number = json.opt("sequence") as? Number ?: return
+        val sequence = number.toLong()
+        if (
+            sequence < 0 ||
+                sequence > 9007199254740991L ||
+                number.toDouble() != sequence.toDouble() ||
+                sequence <= lastSequence
+        )
+            return
+        val array = json.optJSONArray("bindings") ?: return
+        if (array.length() > 256) return
+        val bindings =
+            (0 until array.length()).map { i ->
+                val value = array.optJSONObject(i) ?: return
+                NavigationTraceContext(
+                    value.traceId("navigationTraceId") ?: return,
+                    sequence,
+                    value.traceId("actionType") ?: return,
+                    value.traceId("sourceScreenKey"),
+                    value.traceId("targetScreenKey"),
+                    value.traceId("preloadTraceId"),
+                    active,
+                    ExpectedTraceChange.parse(value.optJSONObject("expectedChange") ?: return)
+                        ?: return,
+                )
+            }
+        lastSequence = sequence
+        current = TraceBatch(active, sequence, bindings)
+    }
+
+    fun captureBatch(): TraceBatch? = current
+
+    fun endBatch(batch: TraceBatch?) {
+        if (current === batch) current = null
+    }
+
+    fun clear() {
+        current = null
+        session = null
+        lastSequence = -1
+    }
+}
+
+internal object NativeNavigationTraceIdGenerator {
+    @Suppress("UNUSED_PARAMETER")
+    fun create(containerId: String): String = "native:${UUID.randomUUID()}"
+}

--- a/android/src/main/java/com/lynxscreens/screens/common/trace/TraceProtocol.kt
+++ b/android/src/main/java/com/lynxscreens/screens/common/trace/TraceProtocol.kt
@@ -1,0 +1,131 @@
+package com.lynxscreens.screens.common.trace
+
+import android.content.Context
+import java.lang.ref.WeakReference
+import java.util.WeakHashMap
+import org.json.JSONObject
+
+internal fun JSONObject.traceId(key: String): String? =
+    (opt(key) as? String)?.takeIf { it.isNotEmpty() && it.length <= 1024 }
+
+internal fun traceObject(serialized: String?): JSONObject? =
+    try {
+        serialized
+            ?.takeIf { it.length <= 65536 }
+            ?.let(::JSONObject)
+            ?.takeIf { it.opt("version") == 1 }
+    } catch (_: Exception) {
+        null
+    }
+
+internal data class TraceSession(val runtimeId: String, val navigatorKey: String) {
+    companion object {
+        fun parse(value: String?): TraceSession? {
+            val json = traceObject(value) ?: return null
+            if (json.opt("enabled") != true) return null
+            return TraceSession(
+                json.traceId("runtimeId") ?: return null,
+                json.traceId("navigatorKey") ?: return null,
+            )
+        }
+    }
+}
+
+internal data class ContentTraceIdentity(
+    val session: TraceSession,
+    val screenKey: String,
+    val contentScopeId: String,
+) {
+    fun identity(containerId: String, transition: NavigationTraceIdentity? = null) =
+        NavigationTraceIdentity(
+            transition?.navigationTraceId,
+            transition?.nativeTransitionId,
+            transition?.preloadTraceId,
+            containerId,
+            session.runtimeId,
+            session.navigatorKey,
+            screenKey,
+            contentScopeId,
+        )
+
+    companion object {
+        fun parse(value: String?): ContentTraceIdentity? {
+            val json = traceObject(value) ?: return null
+            return ContentTraceIdentity(
+                TraceSession(
+                    json.traceId("runtimeId") ?: return null,
+                    json.traceId("navigatorKey") ?: return null,
+                ),
+                json.traceId("screenKey") ?: return null,
+                json.traceId("contentScopeId") ?: return null,
+            )
+        }
+    }
+}
+
+internal sealed class ExpectedTraceChange {
+    data class Stack(val before: List<String>, val after: List<String>) : ExpectedTraceChange()
+
+    data class Sheet(val screenKey: String, val fromOpen: Boolean, val toOpen: Boolean) :
+        ExpectedTraceChange()
+
+    companion object {
+        fun parse(json: JSONObject): ExpectedTraceChange? {
+            fun keys(name: String): List<String>? {
+                val array = json.optJSONArray(name) ?: return null
+                if (array.length() > 256) return null
+                return (0 until array.length()).map {
+                    (array.opt(it) as? String)?.takeIf { key ->
+                        key.isNotEmpty() && key.length <= 1024
+                    } ?: return null
+                }
+            }
+            return when (json.optString("kind")) {
+                "stack" ->
+                    Stack(
+                        keys("beforeScreenKeys") ?: return null,
+                        keys("afterScreenKeys") ?: return null,
+                    )
+                "sheet" ->
+                    Sheet(
+                        json.traceId("screenKey") ?: return null,
+                        json.opt("fromOpen") as? Boolean ?: return null,
+                        json.opt("toOpen") as? Boolean ?: return null,
+                    )
+                else -> null
+            }
+        }
+    }
+}
+
+/** One immutable envelope from the current UI update; consumption is per receiving target. */
+internal class TraceBatch(
+    val session: TraceSession,
+    val sequence: Long,
+    val bindings: List<NavigationTraceContext>,
+) {
+    private val consumed = mutableSetOf<String>()
+
+    fun consume(target: String, expected: ExpectedTraceChange): NavigationTraceContext? {
+        if (target in consumed) return null
+        consumed.add(target)
+        return bindings.filter { it.expectedChange == expected }.singleOrNull()
+    }
+}
+
+/** Weak context keys isolate Lynx instances. Only the live Host owns its scope strongly. */
+internal object NavigatorTraceScopes {
+    private val hosts =
+        WeakHashMap<Context, MutableMap<TraceSession, WeakReference<NavigationTraceContextStore>>>()
+
+    fun register(context: Context, session: TraceSession, store: NavigationTraceContextStore) {
+        hosts.getOrPut(context) { mutableMapOf() }[session] = WeakReference(store)
+    }
+
+    fun find(context: Context, session: TraceSession?): NavigationTraceContextStore? =
+        session?.let { hosts[context]?.get(it)?.get() }
+
+    fun remove(context: Context, session: TraceSession?, store: NavigationTraceContextStore) {
+        if (find(context, session) === store) hosts[context]?.remove(session)
+    }
+}

--- a/android/src/main/java/com/lynxscreens/screens/formsheet/FormSheetNavigationTrace.kt
+++ b/android/src/main/java/com/lynxscreens/screens/formsheet/FormSheetNavigationTrace.kt
@@ -1,0 +1,240 @@
+package com.lynxscreens.screens.formsheet
+
+import com.lynxscreens.screens.common.trace.ContentTraceIdentity
+import com.lynxscreens.screens.common.trace.ExpectedTraceChange
+import com.lynxscreens.screens.common.trace.LynxScreensTrace
+import com.lynxscreens.screens.common.trace.NativeNavigationTraceIdGenerator
+import com.lynxscreens.screens.common.trace.NativeTransitionContext
+import com.lynxscreens.screens.common.trace.NativeTransitionOperation
+import com.lynxscreens.screens.common.trace.NativeTransitionOrigin
+import com.lynxscreens.screens.common.trace.NativeTransitionPresentation
+import com.lynxscreens.screens.common.trace.NavigationTraceContextStore
+import com.lynxscreens.screens.common.trace.NavigationTraceIdentity
+import com.lynxscreens.screens.common.trace.TraceBatch
+
+/** Owns FormSheet trace context construction, state transitions, and common arguments. */
+internal class FormSheetNavigationTrace(
+    private val containerIdProvider: () -> String,
+    private val screenKeyProvider: () -> String?,
+    private val navigationTraceContextStore: NavigationTraceContextStore,
+    private val batchProvider: () -> TraceBatch? = { null },
+    private val contentProvider: () -> ContentTraceIdentity? = { null },
+) {
+    private val traceIdentity
+        get() = containerIdProvider()
+
+    private var activeContext: NativeTransitionContext? = null
+    private var recentContext: NativeTransitionContext? = null
+    private var eventOverride: NativeTransitionContext? = null
+    private var overriding = false
+    internal val operation
+        get() = activeContext
+
+    internal fun <T> withOperation(context: NativeTransitionContext?, block: () -> T): T {
+        val previous = eventOverride
+        val previousFlag = overriding
+        eventOverride = context
+        overriding = true
+        try {
+            return block()
+        } finally {
+            eventOverride = previous
+            overriding = previousFlag
+        }
+    }
+
+    private fun identity(context: NativeTransitionContext?) =
+        context?.identityFor(screenKeyProvider())
+
+    internal val eventTraceIdentity: NavigationTraceIdentity?
+        get() = identity(if (overriding) eventOverride else activeContext ?: recentContext)
+
+    internal fun captureBatch(): TraceBatch? = batchProvider()
+
+    internal fun beginPresent(batch: TraceBatch? = batchProvider()) {
+        if (navigationTraceContextStore.session == null) {
+            return
+        }
+        cancel("superseded")
+        recentContext = null
+        val screenKey = screenKeyProvider()
+        val navigationTraceContext =
+            screenKey?.let {
+                batch?.consume(traceIdentity, ExpectedTraceChange.Sheet(it, false, true))
+            }
+        val context =
+            NativeTransitionContext.create(
+                containerId = traceIdentity,
+                session = navigationTraceContextStore.session,
+                contents = listOfNotNull(contentProvider()).associateBy { it.screenKey },
+                presentation = NativeTransitionPresentation.FORM_SHEET,
+                operation = NativeTransitionOperation.PRESENT,
+                origin = NativeTransitionOrigin.LYNX_PATCH,
+                sourceScreenKey = navigationTraceContext?.sourceScreenKey,
+                targetScreenKey = screenKey ?: traceIdentity,
+                pushCount = 1,
+                navigationTraceId = navigationTraceContext?.navigationTraceId,
+            )
+        activeContext = context
+        context.contents.values.forEach { content ->
+            LynxScreensTrace.instant("LynxScreens.FormSheet.ScreenContentBound") {
+                content.identity(context.containerId).arguments()
+            }
+        }
+        LynxScreensTrace.instant(LynxScreensTrace.FORM_SHEET_PRESENT_REQUESTED) {
+            context.traceArguments()
+        }
+    }
+
+    internal fun beginProgrammaticDismiss(batch: TraceBatch? = batchProvider()) {
+        beginDismiss(NativeTransitionOrigin.LYNX_PATCH, batch)
+    }
+
+    internal fun beginNativeDismiss(
+        origin: NativeTransitionOrigin = NativeTransitionOrigin.NATIVE_DISMISS
+    ) {
+        beginDismiss(origin)
+    }
+
+    private fun beginDismiss(origin: NativeTransitionOrigin, batch: TraceBatch? = batchProvider()) {
+        if (navigationTraceContextStore.session == null) {
+            return
+        }
+        cancel("superseded")
+        recentContext = null
+        val screenKey = screenKeyProvider()
+        val navigationTraceContext =
+            if (origin == NativeTransitionOrigin.LYNX_PATCH)
+                screenKey?.let {
+                    batch?.consume(traceIdentity, ExpectedTraceChange.Sheet(it, true, false))
+                }
+            else null
+        val context =
+            NativeTransitionContext.create(
+                containerId = traceIdentity,
+                session = navigationTraceContextStore.session,
+                contents = listOfNotNull(contentProvider()).associateBy { it.screenKey },
+                presentation = NativeTransitionPresentation.FORM_SHEET,
+                operation = NativeTransitionOperation.DISMISS,
+                origin = origin,
+                sourceScreenKey = screenKey ?: traceIdentity,
+                targetScreenKey = navigationTraceContext?.targetScreenKey,
+                popCount = 1,
+                navigationTraceId =
+                    navigationTraceContext?.navigationTraceId
+                        ?: if (origin != NativeTransitionOrigin.LYNX_PATCH) {
+                            NativeNavigationTraceIdGenerator.create(traceIdentity)
+                        } else {
+                            null
+                        },
+            )
+        activeContext = context
+        context.contents.values.forEach { content ->
+            LynxScreensTrace.instant("LynxScreens.FormSheet.ScreenContentBound") {
+                content.identity(context.containerId).arguments()
+            }
+        }
+        LynxScreensTrace.instant(LynxScreensTrace.FORM_SHEET_DISMISS_REQUESTED) {
+            context.traceArguments()
+        }
+    }
+
+    internal fun start(
+        isAnimated: Boolean,
+        operation: NativeTransitionContext? = if (overriding) eventOverride else activeContext,
+    ) {
+        val context = operation ?: return
+        if (!context.markStarted()) {
+            return
+        }
+        LynxScreensTrace.instant(LynxScreensTrace.FORM_SHEET_NATIVE_TRANSITION_START) {
+            context.traceArguments("is_animated" to isAnimated)
+        }
+    }
+
+    internal fun complete(
+        operation: NativeTransitionContext? = if (overriding) eventOverride else activeContext
+    ) {
+        val context = operation ?: return
+        if (!context.markCompleted()) {
+            return
+        }
+        LynxScreensTrace.instant(LynxScreensTrace.FORM_SHEET_NATIVE_TRANSITION_END) {
+            context.traceArguments("status" to "completed")
+        }
+        recentContext = context
+        if (activeContext === context) activeContext = null
+    }
+
+    internal fun cancel(
+        reason: String,
+        operation: NativeTransitionContext? = if (overriding) eventOverride else activeContext,
+    ) {
+        val context = operation ?: return
+        if (!context.markCancelled()) {
+            return
+        }
+        LynxScreensTrace.instant(LynxScreensTrace.FORM_SHEET_NATIVE_TRANSITION_CANCELLED) {
+            context.traceArguments("status" to "cancelled", "reason" to reason)
+        }
+        recentContext = context
+        if (activeContext === context) activeContext = null
+    }
+
+    internal fun nativeDismissPrevented() {
+        val context = activeContext ?: return
+        if (!context.markPrevented()) {
+            return
+        }
+        LynxScreensTrace.instant(LynxScreensTrace.FORM_SHEET_NATIVE_DISMISS_PREVENTED) {
+            context.traceArguments(
+                "screen_key" to (screenKeyProvider() ?: traceIdentity),
+                "status" to "prevented",
+            )
+        }
+        recentContext = context
+        if (activeContext === context) activeContext = null
+    }
+
+    internal fun dismissCommittedAndComplete(
+        operation: NativeTransitionContext? = if (overriding) eventOverride else activeContext
+    ) {
+        val context = operation
+        LynxScreensTrace.instant(LynxScreensTrace.FORM_SHEET_NATIVE_DISMISS_COMMITTED) {
+            context?.traceArguments("screen_key" to (screenKeyProvider() ?: traceIdentity))
+                ?: LynxScreensTrace.argumentsOf(
+                    "container_id" to traceIdentity,
+                    "presentation" to NativeTransitionPresentation.FORM_SHEET.traceValue,
+                    "screen_key" to (screenKeyProvider() ?: traceIdentity),
+                )
+        }
+        complete(context)
+    }
+
+    internal fun dispose(reason: String) {
+        cancel(reason)
+    }
+
+    internal fun eventEmitted(eventName: String, isLifecycleEvent: Boolean, channel: String?) {
+        if (navigationTraceContextStore.session == null) return
+        val traceName =
+            if (isLifecycleEvent) {
+                LynxScreensTrace.FORM_SHEET_LIFECYCLE_EVENT_EMITTED
+            } else {
+                LynxScreensTrace.FORM_SHEET_DISMISS_EVENT_EMITTED
+            }
+        LynxScreensTrace.instant(traceName) {
+            val identity = eventTraceIdentity
+            (identity?.arguments() ?: emptyMap()) +
+                LynxScreensTrace.argumentsOf(
+                    "navigation_trace_id" to identity?.navigationTraceId,
+                    "native_transition_id" to identity?.nativeTransitionId,
+                    "container_id" to traceIdentity,
+                    "presentation" to NativeTransitionPresentation.FORM_SHEET.traceValue,
+                    "screen_key" to (screenKeyProvider() ?: traceIdentity),
+                    "event_name" to eventName,
+                    "channel" to channel,
+                )
+        }
+    }
+}

--- a/android/src/main/java/com/lynxscreens/screens/formsheet/host/FormSheetHostComponent.kt
+++ b/android/src/main/java/com/lynxscreens/screens/formsheet/host/FormSheetHostComponent.kt
@@ -19,11 +19,12 @@ import com.lynxscreens.screens.formsheet.model.FormSheetConfig
 
 @LynxElement(name = "ls-form-sheet")
 internal class FormSheetHostComponent(context: LynxContext) : UIGroup<FormSheetHostView>(context) {
-    private val eventEmitter by lazy { FormSheetHostEventEmitter(lynxContext, sign) }
+    private val eventEmitter by lazy { FormSheetHostEventEmitter(lynxContext, sign, view.navigationTrace) }
     private val shadowStateProxy by lazy { ShadowStateProxy(lynxContext, sign) }
     private lateinit var sheetContentView: FormSheetContentView
     private lateinit var controller: FormSheetController
 
+    private var traceScreenKey: String? = null
     private var isOpen = false
     private var detents: List<Double> = emptyList()
     private var prefersGrabberVisible = false
@@ -47,7 +48,7 @@ internal class FormSheetHostComponent(context: LynxContext) : UIGroup<FormSheetH
                 },
                 dispatchLynxTouchEvent = ::dispatchDialogTouchEvent,
             )
-        return FormSheetHostView(lynxContext)
+        return FormSheetHostView(lynxContext, "form-sheet-$sign") { traceScreenKey }
     }
 
     // Adaptation: retain Lynx's logical child tree while mounting native child views in the dialog.
@@ -104,6 +105,21 @@ internal class FormSheetHostComponent(context: LynxContext) : UIGroup<FormSheetH
     override fun destroy() {
         if (::controller.isInitialized) controller.dispose()
         super.destroy()
+    }
+
+    @LynxProp(name = "traceSession")
+    fun setTraceSession(value: String?) { view.setTraceSession(value) }
+    @LynxProp(name = "contentTraceContext")
+    fun setContentTraceContext(value: String?) { view.setContentTraceContext(value) }
+
+    @LynxProp(name = "traceScreenKey")
+    fun setTraceScreenKey(value: String?) {
+        traceScreenKey = value
+    }
+
+    @LynxProp(name = "navigationTraceContext")
+    fun setNavigationTraceContext(value: String?) {
+        view.setNavigationTraceContext(value)
     }
 
     @LynxProp(name = "isOpen")

--- a/android/src/main/java/com/lynxscreens/screens/formsheet/host/FormSheetHostEventEmitter.kt
+++ b/android/src/main/java/com/lynxscreens/screens/formsheet/host/FormSheetHostEventEmitter.kt
@@ -1,5 +1,6 @@
 package com.lynxscreens.screens.formsheet.host
 
+import com.lynxscreens.screens.formsheet.FormSheetNavigationTrace
 import com.lynx.tasm.behavior.LynxContext
 import com.lynx.tasm.event.LynxCustomEvent
 import com.lynxscreens.screens.formsheet.interfaces.FormSheetDialogEventEmitter
@@ -7,6 +8,7 @@ import com.lynxscreens.screens.formsheet.interfaces.FormSheetDialogEventEmitter
 internal class FormSheetHostEventEmitter(
     private val lynxContext: LynxContext,
     private val sign: Int,
+    internal val navigationTrace: FormSheetNavigationTrace,
 ) : FormSheetDialogEventEmitter {
     override fun emitOnWillAppear() = emit(EVENT_WILL_APPEAR)
 
@@ -26,8 +28,17 @@ internal class FormSheetHostEventEmitter(
 
     private fun emit(name: String, details: Map<String, Any>? = null) {
         val event = LynxCustomEvent(sign, name)
+        navigationTrace.eventTraceIdentity?.addTo(event)
         details?.forEach { (key, value) -> event.addDetail(key, value) }
         lynxContext.eventEmitter.sendCustomEvent(event)
+        if (name != EVENT_DETENT_CHANGED) {
+            navigationTrace.eventEmitted(
+                name,
+                name == EVENT_WILL_APPEAR || name == EVENT_DID_APPEAR ||
+                    name == EVENT_WILL_DISAPPEAR || name == EVENT_DID_DISAPPEAR,
+                details?.get("channel")?.toString(),
+            )
+        }
     }
 
     companion object {

--- a/android/src/main/java/com/lynxscreens/screens/formsheet/host/FormSheetHostView.kt
+++ b/android/src/main/java/com/lynxscreens/screens/formsheet/host/FormSheetHostView.kt
@@ -1,11 +1,37 @@
 package com.lynxscreens.screens.formsheet.host
 
 import android.annotation.SuppressLint
+import com.lynxscreens.screens.common.trace.LynxScreensTrace
+import com.lynxscreens.screens.common.trace.NavigationTraceContextStore
+import com.lynxscreens.screens.formsheet.FormSheetNavigationTrace
 import com.lynx.tasm.behavior.LynxContext
 import com.lynx.tasm.behavior.ui.view.AndroidView
 
 @SuppressLint("ViewConstructor")
-internal class FormSheetHostView(context: LynxContext) : AndroidView(context) {
+internal class FormSheetHostView(
+    context: LynxContext,
+    @Suppress("UNUSED_PARAMETER") traceIdentity: String,
+    screenKeyProvider: () -> String?,
+) : AndroidView(context) {
+    private val navigationTraceContextStore = NavigationTraceContextStore()
+    private val traceContainerId by lazy { "sheet:${java.util.UUID.randomUUID()}" }
+    internal var contentTraceIdentity: com.lynxscreens.screens.common.trace.ContentTraceIdentity? = null
+    internal val navigationTrace = FormSheetNavigationTrace({ traceContainerId }, screenKeyProvider, navigationTraceContextStore,
+        { com.lynxscreens.screens.common.trace.NavigatorTraceScopes.find(context, navigationTraceContextStore.session)?.captureBatch() },
+        { contentTraceIdentity?.takeIf { it.session == navigationTraceContextStore.session } })
+    internal fun setTraceSession(value: String?) { navigationTraceContextStore.setSession(value) }
+    internal fun setContentTraceContext(value: String?) { contentTraceIdentity = com.lynxscreens.screens.common.trace.ContentTraceIdentity.parse(value) }
+
+
+    internal fun setNavigationTraceContext(value: String?) {
+        navigationTraceContextStore.update(value)
+    }
+
+    override fun onDetachedFromWindow() {
+        navigationTrace.dispose("view_detached")
+        super.onDetachedFromWindow()
+    }
+
     // Adaptation: children are laid out by Lynx after being teleported to the dialog window.
     override fun onLayout(changed: Boolean, left: Int, top: Int, right: Int, bottom: Int) = Unit
 }

--- a/android/src/main/java/com/lynxscreens/screens/host/StackContainer.kt
+++ b/android/src/main/java/com/lynxscreens/screens/host/StackContainer.kt
@@ -8,11 +8,16 @@ import android.widget.FrameLayout
 import androidx.fragment.app.FragmentManager
 import com.lynxscreens.screens.common.container.Container
 import com.lynxscreens.screens.common.container.ParentContainerItemRegistry
+import com.lynxscreens.screens.common.trace.LynxScreensTrace
+import com.lynxscreens.screens.common.trace.NavigationTraceContextStore
+import com.lynxscreens.screens.common.trace.NavigationTraceIdentity
 import com.lynxscreens.screens.ext.isMeasured
 import com.lynxscreens.screens.helpers.FragmentManagerHelper
 import com.lynxscreens.screens.helpers.ViewIdGenerator
 import com.lynxscreens.screens.screen.StackScreenComponent
 import com.lynxscreens.screens.screen.StackScreenFragment
+import com.lynxscreens.screens.screen.StackScreenTraceDelegate
+import com.lynxscreens.screens.screen.StackTransitionRole
 import java.lang.ref.WeakReference
 
 @SuppressLint("ViewConstructor") // Only we construct this view, it is never inflated.
@@ -21,7 +26,8 @@ internal class StackContainer(
     private val delegate: WeakReference<StackContainerDelegate>,
 ) : FrameLayout(context),
     Container,
-    FragmentManager.OnBackStackChangedListener {
+    FragmentManager.OnBackStackChangedListener,
+    StackScreenTraceDelegate {
     private var fragmentManager: FragmentManager? = null
 
     private fun requireFragmentManager(): FragmentManager =
@@ -48,6 +54,31 @@ internal class StackContainer(
 
     private val fragmentOpExecutor: FragmentOperationExecutor = FragmentOperationExecutor()
     private val fragmentOps: MutableList<FragmentOperation> = arrayListOf()
+    internal val navigationTraceContextStore = NavigationTraceContextStore()
+    private val traceContainerId by lazy { "stack:${java.util.UUID.randomUUID()}" }
+    private var pendingTraceBatch: com.lynxscreens.screens.common.trace.TraceBatch? = null
+    private var preparedTraceOperation: com.lynxscreens.screens.common.trace.NativeTransitionContext? = null
+    private var traceBatchCaptured = false
+    private var traceBatchAmbiguous = false
+    internal fun captureTraceBatch() {
+        val batch = navigationTraceContextStore.captureBatch()
+        if (traceBatchCaptured && pendingTraceBatch !== batch) traceBatchAmbiguous = true
+        traceBatchCaptured = true
+        pendingTraceBatch = batch
+    }
+    internal fun setTraceSession(value: String?) {
+        val previous = navigationTraceContextStore.session
+        com.lynxscreens.screens.common.trace.NavigatorTraceScopes.remove(context, previous, navigationTraceContextStore)
+        navigationTraceContextStore.setSession(value)
+        navigationTraceContextStore.session?.let { com.lynxscreens.screens.common.trace.NavigatorTraceScopes.register(context, it, navigationTraceContextStore) }
+    }
+    private fun contentIdentities() = (stackModel.map { it.stackScreen } + pendingPushOperations.map { it.screen }).mapNotNull { it.contentTraceIdentity?.takeIf { content -> content.session == navigationTraceContextStore.session } }.associateBy { it.screenKey }
+
+    private val navigationTrace =
+        StackNavigationTrace(
+            containerIdProvider = { traceContainerId },
+            navigationTraceContextStore = navigationTraceContextStore,
+        )
 
     init {
         id = ViewIdGenerator.generateViewId()
@@ -75,6 +106,7 @@ internal class StackContainer(
     }
 
     override fun onDetachedFromWindow() {
+        navigationTrace.cancel("container_detached")
         super.onDetachedFromWindow()
         requireFragmentManager().removeOnBackStackChangedListener(this)
         fragmentManager = null
@@ -110,9 +142,31 @@ internal class StackContainer(
         pendingPopOperations.add(PopOperation(stackScreen))
     }
 
+    internal fun setNavigationTraceContext(value: String?) {
+        navigationTraceContextStore.update(value)
+    }
+
     private fun performOperations(fragmentManager: FragmentManager) {
-        applyOperationsAndComputeFragmentManagerOperations()
-        fragmentOpExecutor.executeOperations(fragmentManager, fragmentOps, flushSync = false)
+        val popCount = pendingPopOperations.size
+        val pushCount = pendingPushOperations.size
+        val sourceScreenKey = stackModel.lastOrNull()?.stackScreen?.screenKey
+        val targetScreenKey =
+            pendingPushOperations.lastOrNull()?.screen?.screenKey
+                ?: stackModel.getOrNull(stackModel.size - popCount - 1)?.stackScreen?.screenKey
+
+        val before = stackModel.mapNotNull { it.stackScreen.screenKey }
+        val after = before.dropLast(popCount) + pendingPushOperations.mapNotNull { it.screen.screenKey }
+        val operation = navigationTrace.prepareOperations(sourceScreenKey, targetScreenKey, popCount, pushCount,
+            before, after, contentIdentities(), if (traceBatchAmbiguous) null else pendingTraceBatch, isLaidOut)
+        pendingTraceBatch = null
+        traceBatchCaptured = false
+        traceBatchAmbiguous = false
+        preparedTraceOperation = operation
+        if (navigationTraceContextStore.session != null) stackModel.forEach { it.bindTraceOperation(operation, traceContainerId) }
+        navigationTrace.traceApplyOperations(operation) {
+            applyOperationsAndComputeFragmentManagerOperations()
+            fragmentOpExecutor.executeOperations(fragmentManager, fragmentOps, flushSync = false)
+        }
 
         dumpStackModel()
     }
@@ -135,9 +189,10 @@ internal class StackContainer(
             // when last operation of the batch is "pop". Empty commit with only onCommit callback
             // attached is not a "pop" commit, therefore JS-pop commits have not been properly
             // recognized.
+            val traceOperation = preparedTraceOperation
             fragmentOps.add(
                 OnCommitCallbackOp(
-                    { updateTopFragment() },
+                    { updateTopFragment(); navigationTrace.committed(traceOperation) },
                     allowStateLoss = true,
                     flushSync = false,
                 ),
@@ -203,6 +258,8 @@ internal class StackContainer(
         canNavigateBack: Boolean,
     ): StackScreenFragment =
         StackScreenFragment(screen, canNavigateBack).also {
+            it.traceDelegate = this
+            if (navigationTraceContextStore.session != null) it.bindTraceOperation(preparedTraceOperation, traceContainerId)
             Log.d(TAG, "Created Fragment $it for screen ${screen.screenKey}")
         }
 
@@ -261,13 +318,46 @@ internal class StackContainer(
         while (stackModel.size > 1) {
             val topFragment = stackModel.last()
             if (addedFragments.contains(topFragment)) {
-                return
+                break
             }
 
+            navigationTrace.nativeDismissCommitted(topFragment.traceOperation, topFragment.stackScreen.screenKey)
             delegate.get()?.onScreenDismissCommitted(topFragment.stackScreen)
             onNativeFragmentPop(topFragment)
         }
+        stackModel.lastOrNull()?.traceOperation?.let { navigationTrace.committed(it) }
     }
+
+    // region StackScreenTraceDelegate
+
+    override fun onNativeTransition(context: com.lynxscreens.screens.common.trace.NativeTransitionContext?, screenKey: String?, role: StackTransitionRole, phase: String) {
+        navigationTrace.platformCallback(context, screenKey, role, phase)
+    }
+
+    override fun onNativeBackPressed(fragment: StackScreenFragment) {
+        val sourceIndex = stackModel.indexOf(fragment)
+        if (sourceIndex <= 0 || sourceIndex != stackModel.lastIndex) {
+            return
+        }
+        val operation = navigationTrace.nativeBackRequested(
+            sourceScreenKey = fragment.stackScreen.screenKey,
+            targetScreenKey = stackModel[sourceIndex - 1].stackScreen.screenKey,
+            contents = contentIdentities(), animated = isLaidOut,
+        )
+        if (navigationTraceContextStore.session != null) stackModel.forEach { it.bindTraceOperation(operation, traceContainerId) }
+    }
+
+    override fun onNativeDismissPrevented(fragment: StackScreenFragment) {
+        val sourceIndex = stackModel.indexOf(fragment)
+        val operation = navigationTrace.nativeDismissPrevented(
+            sourceScreenKey = fragment.stackScreen.screenKey,
+            targetScreenKey = stackModel.getOrNull(sourceIndex - 1)?.stackScreen?.screenKey,
+            contents = contentIdentities(),
+        )
+        if (operation != null) fragment.bindTraceOperation(operation, traceContainerId)
+    }
+
+    // endregion
 
     internal fun forceSubtreeMeasureAndLayoutPass() {
         measure(

--- a/android/src/main/java/com/lynxscreens/screens/host/StackHostComponent.kt
+++ b/android/src/main/java/com/lynxscreens/screens/host/StackHostComponent.kt
@@ -5,6 +5,7 @@ import android.util.Log
 import android.view.View
 import com.lynx.tasm.behavior.LynxContext
 import com.lynx.tasm.behavior.LynxElement
+import com.lynx.tasm.behavior.LynxProp
 import com.lynx.tasm.behavior.PatchFinishListener
 import com.lynx.tasm.behavior.event.EventTarget
 import com.lynx.tasm.behavior.ui.LynxBaseUI
@@ -22,7 +23,11 @@ internal class StackHostComponent(context: LynxContext) : UIGroup<StackHostView>
 
     override fun createView(context: Context?): StackHostView {
         val lynxContext = context as LynxContext
-        container = StackContainer(lynxContext, WeakReference(this))
+        container =
+            StackContainer(
+                context = lynxContext,
+                delegate = WeakReference(this),
+            )
 
         return StackHostView(lynxContext, container)
     }
@@ -196,6 +201,33 @@ internal class StackHostComponent(context: LynxContext) : UIGroup<StackHostView>
 
     override fun onPatchFinish() {
         containerUpdateCoordinator.executePendingOperationsIfNeeded(container, renderedScreens)
+    }
+
+    @LynxProp(name = "traceSession")
+    fun setTraceSession(value: String?) { container.setTraceSession(value) }
+
+    private var traceEnvelope: String? = null
+    private var traceEnvelopeUpdated = false
+
+    @LynxProp(name = "navigationTraceContext")
+    fun setNavigationTraceContext(value: String?) {
+        traceEnvelope = value
+        traceEnvelopeUpdated = true
+    }
+
+    override fun onPropsUpdated() {
+        super.onPropsUpdated()
+        if (traceEnvelopeUpdated) {
+            traceEnvelopeUpdated = false
+            container.setNavigationTraceContext(traceEnvelope)
+            val batch = container.navigationTraceContextStore.captureBatch()
+            view.post { container.navigationTraceContextStore.endBatch(batch) }
+        }
+    }
+
+    override fun destroy() {
+        container.setTraceSession(null)
+        super.destroy()
     }
 
     companion object {

--- a/android/src/main/java/com/lynxscreens/screens/host/StackHostContainerUpdateCoordinator.kt
+++ b/android/src/main/java/com/lynxscreens/screens/host/StackHostContainerUpdateCoordinator.kt
@@ -10,6 +10,7 @@ internal class StackHostContainerUpdateCoordinator {
         get() = pendingPushOperations.isNotEmpty() || pendingPopOperations.isNotEmpty()
 
     internal fun addPushOperation(stackScreen: StackScreenComponent) {
+        if (stackScreen.traceSession != null) StackNavigationTrace.pushRequested(stackScreen.screenKey)
         // If a Push operation is detected for a screen already scheduled for a Pop,
         // both operations are canceled.
         val index = pendingPopOperations.indexOfFirst { it.screen == stackScreen }
@@ -22,6 +23,7 @@ internal class StackHostContainerUpdateCoordinator {
     }
 
     internal fun addPopOperation(stackScreen: StackScreenComponent) {
+        if (stackScreen.traceSession != null) StackNavigationTrace.popRequested(stackScreen.screenKey)
         // If a Pop operation is detected for a screen already scheduled for a Push,
         // both operations are canceled.
         val index = pendingPushOperations.indexOfFirst { it.screen == stackScreen }
@@ -52,6 +54,7 @@ internal class StackHostContainerUpdateCoordinator {
             .sortedBy { it.first }
             .forEach { (_, operation) -> container.enqueuePushOperation(operation.screen) }
 
+        container.captureTraceBatch()
         container.performContainerUpdateIfNeeded()
 
         pendingPopOperations.clear()

--- a/android/src/main/java/com/lynxscreens/screens/host/StackNavigationTrace.kt
+++ b/android/src/main/java/com/lynxscreens/screens/host/StackNavigationTrace.kt
@@ -1,0 +1,303 @@
+package com.lynxscreens.screens.host
+
+import com.lynxscreens.screens.common.trace.*
+import com.lynxscreens.screens.screen.StackTransitionRole
+
+/** Mutable ownership is used only while preparing an operation; callbacks carry its handle. */
+internal class StackNavigationTrace(
+    private val containerIdProvider: () -> String,
+    private val navigationTraceContextStore: NavigationTraceContextStore,
+) {
+    internal var activeContext: NativeTransitionContext? = null
+        private set
+
+    private val participants = java.util.WeakHashMap<NativeTransitionContext, MutableSet<String>>()
+    private val ended = java.util.WeakHashMap<NativeTransitionContext, MutableSet<String>>()
+    private val containerId
+        get() = containerIdProvider()
+
+    internal fun prepareOperations(
+        sourceScreenKey: String?,
+        targetScreenKey: String?,
+        popCount: Int,
+        pushCount: Int,
+        before: List<String>,
+        after: List<String>,
+        contents: Map<String, ContentTraceIdentity>,
+        batch: TraceBatch?,
+        animated: Boolean,
+    ): NativeTransitionContext? {
+        val session = navigationTraceContextStore.session ?: return null
+        cancel("superseded")
+        val binding =
+            batch
+                ?.takeIf { it.session == session }
+                ?.consume(containerId, ExpectedTraceChange.Stack(before, after))
+        val context =
+            NativeTransitionContext.create(
+                containerId,
+                NativeTransitionPresentation.STACK,
+                resolveOperation(popCount, pushCount),
+                NativeTransitionOrigin.LYNX_PATCH,
+                sourceScreenKey,
+                targetScreenKey,
+                popCount,
+                pushCount,
+                pushCount == 0,
+                binding?.navigationTraceId,
+                binding?.preloadTraceId,
+                session,
+                contents,
+            )
+        activeContext = context
+        context.contents.values.forEach { content ->
+            LynxScreensTrace.instant("LynxScreens.Stack.ScreenContentBound") {
+                content.identity(context.containerId).arguments()
+            }
+        }
+        participants[context] =
+            if (animated) listOfNotNull(sourceScreenKey, targetScreenKey).toMutableSet()
+            else mutableSetOf()
+        LynxScreensTrace.instant(LynxScreensTrace.STACK_OPERATION_BATCH_PREPARED) {
+            context.traceArguments(
+                "unlinked_reason" to if (binding == null) "missing_or_ambiguous_binding" else null
+            )
+        }
+        return context
+    }
+
+    internal fun <T> traceApplyOperations(context: NativeTransitionContext?, block: () -> T): T =
+        if (context == null) block()
+        else
+            LynxScreensTrace.section(
+                LynxScreensTrace.STACK_APPLY_OPERATIONS,
+                { context.traceArguments() },
+                block,
+            )
+
+    internal fun committed(context: NativeTransitionContext?) {
+        if (context != null && participants[context]?.isEmpty() == true) {
+            start(context, false)
+            complete(context)
+        }
+    }
+
+    internal fun platformCallback(
+        context: NativeTransitionContext?,
+        screenKey: String?,
+        role: StackTransitionRole,
+        phase: String,
+    ) {
+        if (context == null) return
+        LynxScreensTrace.instant(LynxScreensTrace.STACK_TRANSITION_CALLBACK_RECEIVED) {
+            context
+                .identityFor(screenKey)
+                .arguments("phase" to phase, "transition_role" to role.traceValue)
+        }
+        when (phase) {
+            "start" -> start(context, true)
+            "cancel" -> cancel(context, "platform_transition_cancelled")
+            "end" -> {
+                screenKey?.let { ended.getOrPut(context) { mutableSetOf() }.add(it) }
+                val required = participants[context]
+                if (
+                    required != null &&
+                        required.isNotEmpty() &&
+                        ended[context]?.containsAll(required) == true
+                )
+                    complete(context)
+            }
+        }
+    }
+
+    internal fun nativeBackRequested(
+        sourceScreenKey: String?,
+        targetScreenKey: String?,
+        contents: Map<String, ContentTraceIdentity>,
+        animated: Boolean,
+    ): NativeTransitionContext? {
+        val session = navigationTraceContextStore.session ?: return null
+        cancel("superseded")
+        val context =
+            NativeTransitionContext.create(
+                containerId,
+                NativeTransitionPresentation.STACK,
+                NativeTransitionOperation.POP,
+                NativeTransitionOrigin.NATIVE_BACK,
+                sourceScreenKey,
+                targetScreenKey,
+                popCount = 1,
+                targetReused = true,
+                navigationTraceId = NativeNavigationTraceIdGenerator.create(containerId),
+                session = session,
+                contents = contents,
+            )
+        activeContext = context
+        context.contents.values.forEach { content ->
+            LynxScreensTrace.instant("LynxScreens.Stack.ScreenContentBound") {
+                content.identity(context.containerId).arguments()
+            }
+        }
+        participants[context] =
+            if (animated) listOfNotNull(sourceScreenKey, targetScreenKey).toMutableSet()
+            else mutableSetOf()
+        LynxScreensTrace.instant(LynxScreensTrace.STACK_NATIVE_BACK_REQUESTED) {
+            context.traceArguments()
+        }
+        return context
+    }
+
+    internal fun nativeDismissPrevented(
+        sourceScreenKey: String?,
+        targetScreenKey: String?,
+        contents: Map<String, ContentTraceIdentity>,
+    ): NativeTransitionContext? {
+        val context =
+            nativeBackRequested(sourceScreenKey, targetScreenKey, contents, false) ?: return null
+        if (context.markPrevented())
+            LynxScreensTrace.instant(LynxScreensTrace.STACK_NATIVE_DISMISS_PREVENTED) {
+                context.traceArguments("status" to "prevented")
+            }
+        return context
+    }
+
+    internal fun nativeDismissCommitted(context: NativeTransitionContext?, screenKey: String?) {
+        if (context != null)
+            LynxScreensTrace.instant(LynxScreensTrace.STACK_NATIVE_DISMISS_COMMITTED) {
+                context.identityFor(screenKey).arguments()
+            }
+    }
+
+    internal fun cancel(reason: String) {
+        activeContext?.let { cancel(it, reason) }
+    }
+
+    private fun start(context: NativeTransitionContext, animated: Boolean) {
+        if (context.markStarted())
+            LynxScreensTrace.instant(LynxScreensTrace.STACK_NATIVE_TRANSITION_START) {
+                context.traceArguments("is_animated" to animated)
+            }
+    }
+
+    private fun complete(context: NativeTransitionContext) {
+        if (!context.markCompleted()) return
+        LynxScreensTrace.instant(LynxScreensTrace.STACK_NATIVE_TRANSITION_END) {
+            context.traceArguments("status" to "completed")
+        }
+        release(context)
+    }
+
+    private fun cancel(context: NativeTransitionContext, reason: String) {
+        if (!context.markCancelled()) return
+        LynxScreensTrace.instant(LynxScreensTrace.STACK_NATIVE_TRANSITION_CANCELLED) {
+            context.traceArguments("reason" to reason)
+        }
+        release(context)
+    }
+
+    private fun release(context: NativeTransitionContext) {
+        participants.remove(context)
+        ended.remove(context)
+        if (activeContext === context) activeContext = null
+    }
+
+    internal companion object {
+        internal fun transitionMatches(
+            context: NativeTransitionContext,
+            screenKey: String?,
+            role: StackTransitionRole,
+        ): Boolean =
+            when (context.operation) {
+                NativeTransitionOperation.PUSH ->
+                    context.targetScreenKey == screenKey && role == StackTransitionRole.ENTER
+                NativeTransitionOperation.POP ->
+                    (context.sourceScreenKey == screenKey && role == StackTransitionRole.RETURN) ||
+                        (context.targetScreenKey == screenKey &&
+                            role == StackTransitionRole.REENTER)
+                NativeTransitionOperation.BATCH ->
+                    (context.sourceScreenKey == screenKey &&
+                        (role == StackTransitionRole.EXIT || role == StackTransitionRole.RETURN)) ||
+                        (context.targetScreenKey == screenKey &&
+                            (role == StackTransitionRole.ENTER ||
+                                role == StackTransitionRole.REENTER))
+                NativeTransitionOperation.PRESENT,
+                NativeTransitionOperation.DISMISS -> false
+            }
+
+        internal fun pushRequested(screenKey: String?) {
+            operationRequested(NativeTransitionOperation.PUSH, screenKey)
+        }
+
+        internal fun popRequested(screenKey: String?) {
+            operationRequested(NativeTransitionOperation.POP, screenKey)
+        }
+
+        internal fun lifecycleEventEmitted(
+            traceIdentity: NavigationTraceIdentity?,
+            screenKey: String?,
+            eventName: String,
+        ) {
+            eventEmitted(
+                traceName = LynxScreensTrace.STACK_LIFECYCLE_EVENT_EMITTED,
+                traceIdentity = traceIdentity,
+                screenKey = screenKey,
+                eventName = eventName,
+                isNative = null,
+            )
+        }
+
+        internal fun dismissEventEmitted(
+            traceIdentity: NavigationTraceIdentity?,
+            screenKey: String?,
+            eventName: String,
+            isNative: Any?,
+        ) {
+            eventEmitted(
+                traceName = LynxScreensTrace.STACK_DISMISS_EVENT_EMITTED,
+                traceIdentity = traceIdentity,
+                screenKey = screenKey,
+                eventName = eventName,
+                isNative = isNative,
+            )
+        }
+
+        private fun operationRequested(operation: NativeTransitionOperation, screenKey: String?) {
+            LynxScreensTrace.instant(LynxScreensTrace.STACK_OPERATION_REQUESTED) {
+                LynxScreensTrace.argumentsOf(
+                    "presentation" to NativeTransitionPresentation.STACK.traceValue,
+                    "operation" to operation.traceValue,
+                    "origin" to NativeTransitionOrigin.LYNX_PATCH.traceValue,
+                    "screen_key" to screenKey,
+                )
+            }
+        }
+
+        private fun eventEmitted(
+            traceName: String,
+            traceIdentity: NavigationTraceIdentity?,
+            screenKey: String?,
+            eventName: String,
+            isNative: Any?,
+        ) {
+            if (traceIdentity == null) return
+            LynxScreensTrace.instant(traceName) {
+                traceIdentity.arguments() +
+                    LynxScreensTrace.argumentsOf(
+                        "navigation_trace_id" to traceIdentity.navigationTraceId,
+                        "native_transition_id" to traceIdentity.nativeTransitionId,
+                        "presentation" to NativeTransitionPresentation.STACK.traceValue,
+                        "screen_key" to screenKey,
+                        "event_name" to eventName,
+                        "is_native" to isNative,
+                    )
+            }
+        }
+
+        private fun resolveOperation(popCount: Int, pushCount: Int): NativeTransitionOperation =
+            when {
+                popCount > 0 && pushCount > 0 -> NativeTransitionOperation.BATCH
+                pushCount > 0 -> NativeTransitionOperation.PUSH
+                else -> NativeTransitionOperation.POP
+            }
+    }
+}

--- a/android/src/main/java/com/lynxscreens/screens/screen/PreventNativeDismissCallback.kt
+++ b/android/src/main/java/com/lynxscreens/screens/screen/PreventNativeDismissCallback.kt
@@ -9,6 +9,10 @@ import androidx.lifecycle.LifecycleOwner
 internal class PreventNativeDismissCallback(
     lifecycleOwner: LifecycleOwner,
     private val screen: StackScreenComponent,
+    private val canNavigateBack: Boolean,
+    private val onNativeBackPressed: () -> Unit,
+    private val onNativeDismissPrevented: () -> Unit,
+    private val forwardBackPressed: () -> Unit,
     canBeEnabled: Boolean
 ) : OnBackPressedCallback(false),
     LifecycleEventObserver,
@@ -24,7 +28,9 @@ internal class PreventNativeDismissCallback(
         }
 
     private val shouldBeEnabled
-        get() = canBeEnabled && screen.isPreventNativeDismissEnabled
+        get() =
+            canBeEnabled &&
+                (screen.isPreventNativeDismissEnabled || canNavigateBack)
 
     init {
         lifecycleOwner.lifecycle.addObserver(this)
@@ -32,7 +38,23 @@ internal class PreventNativeDismissCallback(
 
     override fun handleOnBackPressed() {
         Log.i("RNScreens", "PreventNativeDismissCallback called for screen ${screen.screenKey}")
-        screen.onNativeDismissPrevented()
+        if (screen.isPreventNativeDismissEnabled) {
+            onNativeDismissPrevented()
+            screen.onNativeDismissPrevented()
+            return
+        }
+
+        if (!canNavigateBack) {
+            return
+        }
+
+        onNativeBackPressed()
+        isEnabled = false
+        try {
+            forwardBackPressed()
+        } finally {
+            determineEnabledStatus()
+        }
     }
 
     override fun onStateChanged(

--- a/android/src/main/java/com/lynxscreens/screens/screen/StackScreenComponent.kt
+++ b/android/src/main/java/com/lynxscreens/screens/screen/StackScreenComponent.kt
@@ -9,6 +9,7 @@ import com.lynx.tasm.behavior.ui.LynxBaseUI
 import com.lynx.tasm.behavior.ui.UIGroup
 import com.lynx.tasm.event.LynxCustomEvent
 import com.lynxscreens.screens.common.ShadowStateProxy
+import com.lynxscreens.screens.common.trace.NavigationTraceIdentity
 import com.lynxscreens.screens.header.config.OnHeaderConfigurationAttachListener
 import com.lynxscreens.screens.header.config.StackHeaderConfigComponent
 import com.lynxscreens.screens.host.StackHostComponent
@@ -45,7 +46,15 @@ internal class StackScreenComponent(context: LynxContext) : UIGroup<StackScreenV
         }
     }
 
+    internal var traceSession: com.lynxscreens.screens.common.trace.TraceSession? = null
+    internal var contentTraceIdentity: com.lynxscreens.screens.common.trace.ContentTraceIdentity? = null
+    @LynxProp(name = "traceSession")
+    fun setTraceSession(value: String?) { traceSession = com.lynxscreens.screens.common.trace.TraceSession.parse(value) }
+    @LynxProp(name = "contentTraceContext")
+    fun setContentTraceContext(value: String?) { contentTraceIdentity = com.lynxscreens.screens.common.trace.ContentTraceIdentity.parse(value) }
+
     internal var screenKey: String? = null
+    internal var traceIdentityProvider: (() -> NavigationTraceIdentity?)? = null
 
     private val shadowStateProxy: ShadowStateProxy by lazy {
         ShadowStateProxy(lynxContext, sign)
@@ -119,7 +128,12 @@ internal class StackScreenComponent(context: LynxContext) : UIGroup<StackScreenV
     }
 
     private val eventEmitter: StackScreenEventEmitter by lazy {
-        StackScreenEventEmitter(lynxContext, sign)
+        StackScreenEventEmitter(
+            lynxContext = lynxContext,
+            sign = sign,
+            screenKeyProvider = { screenKey },
+            traceIdentityProvider = { traceIdentityProvider?.invoke() },
+        )
     }
 
     /**
@@ -128,7 +142,7 @@ internal class StackScreenComponent(context: LynxContext) : UIGroup<StackScreenV
     internal var preventNativeDismissChangeObserver: PreventNativeDismissChangeObserver? = null
 
     internal fun createAppearanceEventsEmitter(viewLifecycleOwner: LifecycleOwner) =
-        StackScreenAppearanceEventsEmitter(viewLifecycleOwner.lifecycle, eventEmitter)
+        StackScreenAppearanceEventsEmitter(viewLifecycleOwner.lifecycle, eventEmitter.forViewLifecycle())
 
     override fun createView(context: Context?): StackScreenView =
         StackScreenView(context as LynxContext).also { view ->

--- a/android/src/main/java/com/lynxscreens/screens/screen/StackScreenEventEmitter.kt
+++ b/android/src/main/java/com/lynxscreens/screens/screen/StackScreenEventEmitter.kt
@@ -3,10 +3,14 @@ package com.lynxscreens.screens.screen
 import com.lynx.tasm.behavior.LynxContext
 import com.lynx.tasm.event.LynxCustomEvent
 import com.lynxscreens.screens.common.event.ViewAppearanceEventEmitter
+import com.lynxscreens.screens.common.trace.NavigationTraceIdentity
+import com.lynxscreens.screens.host.StackNavigationTrace
 
 internal class StackScreenEventEmitter(
     private val lynxContext: LynxContext,
-    private val sign: Int
+    private val sign: Int,
+    private val screenKeyProvider: () -> String?,
+    private val traceIdentityProvider: () -> NavigationTraceIdentity?,
 ) : ViewAppearanceEventEmitter {
     companion object {
         private const val EVENT_WILL_APPEAR = "OnWillAppear"
@@ -15,6 +19,12 @@ internal class StackScreenEventEmitter(
         private const val EVENT_DID_DISAPPEAR = "OnDidDisappear"
         private const val EVENT_ON_DISMISS = "OnDismiss"
         private const val EVENT_ON_NATIVE_DISMISS_PREVENTED = "OnNativeDismissPrevented"
+    }
+
+    internal fun forViewLifecycle(): StackScreenEventEmitter {
+        val identity = traceIdentityProvider()?.withoutOperation()
+        val key = screenKeyProvider()
+        return StackScreenEventEmitter(lynxContext, sign, { key }, { identity })
     }
 
     override fun emitOnWillAppear() {
@@ -43,9 +53,36 @@ internal class StackScreenEventEmitter(
 
     private fun emit(name: String, params: Map<String, Any>? = null) {
         val event = LynxCustomEvent(sign, name)
+        val traceIdentity = traceIdentityProvider()
+        traceIdentity?.addTo(event)
         params?.forEach { (key, value) ->
             event.addDetail(key, value)
         }
         lynxContext.eventEmitter.sendCustomEvent(event)
+        traceEventEmitted(name, params, traceIdentity)
+    }
+
+    private fun traceEventEmitted(
+        name: String,
+        params: Map<String, Any>?,
+        traceIdentity: NavigationTraceIdentity?,
+    ) {
+        when (name) {
+            EVENT_WILL_APPEAR,
+            EVENT_DID_APPEAR,
+            EVENT_WILL_DISAPPEAR,
+            EVENT_DID_DISAPPEAR,
+            -> StackNavigationTrace.lifecycleEventEmitted(
+                traceIdentity = traceIdentity,
+                screenKey = screenKeyProvider(),
+                eventName = name,
+            )
+            else -> StackNavigationTrace.dismissEventEmitted(
+                traceIdentity = traceIdentity,
+                screenKey = screenKeyProvider(),
+                eventName = name,
+                isNative = params?.get("isNativeDismiss"),
+            )
+        }
     }
 }

--- a/android/src/main/java/com/lynxscreens/screens/screen/StackScreenFragment.kt
+++ b/android/src/main/java/com/lynxscreens/screens/screen/StackScreenFragment.kt
@@ -47,17 +47,38 @@ internal class StackScreenFragment @Keep constructor() :
         get() = checkNotNull(preventNativeDismissBackPressedCallback) { "[RNScreens] Attempt to require nullish OnBackPressedCallback" }
 
     private var isTopFragment: Boolean = false
+    private val navigationTrace =
+        StackScreenNavigationTrace(
+            fragment = this,
+        )
+
+    internal var traceDelegate: StackScreenTraceDelegate?
+        get() = navigationTrace.delegate
+        set(value) {
+            navigationTrace.delegate = value
+        }
+
+    internal val traceOperation get() = navigationTrace.operation
+    internal fun bindTraceOperation(context: com.lynxscreens.screens.common.trace.NativeTransitionContext?, containerId: String) {
+        navigationTrace.operation = context
+        navigationTrace.containerId = containerId
+        if (isAdded) configureTransitions()
+    }
+    private fun configureTransitions() {
+        enterTransition = Slide(Gravity.RIGHT).also { it.addListener(navigationTrace.transitionListener(StackTransitionRole.ENTER)) }
+        exitTransition = Slide(Gravity.LEFT).also { it.addListener(navigationTrace.transitionListener(StackTransitionRole.EXIT)) }
+        returnTransition = Slide(Gravity.RIGHT).also { it.addListener(navigationTrace.transitionListener(StackTransitionRole.RETURN)) }
+        reenterTransition = Slide(Gravity.LEFT).also { it.addListener(navigationTrace.transitionListener(StackTransitionRole.REENTER)) }
+    }
 
     override fun onRuntimeCreate(savedInstanceState: Bundle?) {
+        stackScreen.traceIdentityProvider = navigationTrace.traceIdentityProvider
         setupPreventNativeDismissCallback()
 
         allowEnterTransitionOverlap = true
         allowReturnTransitionOverlap = true
 
-        enterTransition = Slide(Gravity.RIGHT)
-        exitTransition = Slide(Gravity.LEFT)
-        returnTransition = Slide(Gravity.RIGHT)
-        reenterTransition = Slide(Gravity.LEFT)
+        configureTransitions()
     }
 
     override fun onCreateRuntimeView(
@@ -88,6 +109,10 @@ internal class StackScreenFragment @Keep constructor() :
         if (generateSequence(parentFragment) { it.parentFragment }.none { it.isRemoving }) {
             stackScreen.onDismiss()
         }
+        if (stackScreen.traceIdentityProvider === navigationTrace.traceIdentityProvider) {
+            stackScreen.traceIdentityProvider = null
+        }
+        navigationTrace.dispose()
         teardownPreventNativeDismissCallback()
     }
 
@@ -119,7 +144,15 @@ internal class StackScreenFragment @Keep constructor() :
 
     private fun setupPreventNativeDismissCallback() {
         preventNativeDismissBackPressedCallback =
-            PreventNativeDismissCallback(this, stackScreen, canBeEnabled = false)
+            PreventNativeDismissCallback(
+                lifecycleOwner = this,
+                screen = stackScreen,
+                canNavigateBack = canNavigateBack,
+                onNativeBackPressed = navigationTrace::onNativeBackPressed,
+                onNativeDismissPrevented = navigationTrace::onNativeDismissPrevented,
+                forwardBackPressed = { requireActivity().onBackPressedDispatcher.onBackPressed() },
+                canBeEnabled = false,
+            )
         requireActivity().onBackPressedDispatcher.addCallback(
             requireNativeDismissBackPressedCallback,
         )

--- a/android/src/main/java/com/lynxscreens/screens/screen/StackScreenNavigationTrace.kt
+++ b/android/src/main/java/com/lynxscreens/screens/screen/StackScreenNavigationTrace.kt
@@ -1,0 +1,63 @@
+package com.lynxscreens.screens.screen
+
+import androidx.transition.Transition
+import com.lynxscreens.screens.common.trace.*
+import java.lang.ref.WeakReference
+
+internal enum class StackTransitionRole(val traceValue: String) {
+    ENTER("enter"),
+    EXIT("exit"),
+    RETURN("return"),
+    REENTER("reenter"),
+}
+
+internal class StackScreenNavigationTrace(private val fragment: StackScreenFragment) {
+    private var delegateReference = WeakReference<StackScreenTraceDelegate>(null)
+    var delegate: StackScreenTraceDelegate?
+        get() = delegateReference.get()
+        set(value) {
+            delegateReference = WeakReference(value)
+        }
+
+    var operation: NativeTransitionContext? = null
+    var containerId: String? = null
+    val traceIdentityProvider: () -> NavigationTraceIdentity? = {
+        operation?.identityFor(fragment.stackScreen.screenKey)
+    }
+
+    fun transitionListener(role: StackTransitionRole): Transition.TransitionListener {
+        val context = operation
+        val key = fragment.stackScreen.screenKey
+        val owner = delegateReference
+        return object : Transition.TransitionListener {
+            override fun onTransitionStart(transition: Transition) {
+                owner.get()?.onNativeTransition(context, key, role, "start")
+            }
+
+            override fun onTransitionEnd(transition: Transition) {
+                owner.get()?.onNativeTransition(context, key, role, "end")
+            }
+
+            override fun onTransitionCancel(transition: Transition) {
+                owner.get()?.onNativeTransition(context, key, role, "cancel")
+            }
+
+            override fun onTransitionPause(transition: Transition) = Unit
+
+            override fun onTransitionResume(transition: Transition) = Unit
+        }
+    }
+
+    fun onNativeBackPressed() {
+        delegate?.onNativeBackPressed(fragment)
+    }
+
+    fun onNativeDismissPrevented() {
+        delegate?.onNativeDismissPrevented(fragment)
+    }
+
+    fun dispose() {
+        operation = null
+        delegate = null
+    }
+}

--- a/android/src/main/java/com/lynxscreens/screens/screen/StackScreenTraceDelegate.kt
+++ b/android/src/main/java/com/lynxscreens/screens/screen/StackScreenTraceDelegate.kt
@@ -1,0 +1,16 @@
+package com.lynxscreens.screens.screen
+
+import com.lynxscreens.screens.common.trace.NativeTransitionContext
+
+internal interface StackScreenTraceDelegate {
+    fun onNativeTransition(
+        context: NativeTransitionContext?,
+        screenKey: String?,
+        role: StackTransitionRole,
+        phase: String,
+    )
+
+    fun onNativeBackPressed(fragment: StackScreenFragment)
+
+    fun onNativeDismissPrevented(fragment: StackScreenFragment)
+}

--- a/android/src/test/java/com/lynxscreens/screens/common/trace/NativeTransitionContextTest.kt
+++ b/android/src/test/java/com/lynxscreens/screens/common/trace/NativeTransitionContextTest.kt
@@ -1,0 +1,87 @@
+package com.lynxscreens.screens.common.trace
+
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertFalse
+import org.junit.Assert.assertNotEquals
+import org.junit.Assert.assertTrue
+import org.junit.Test
+
+class NativeTransitionContextTest {
+    @Test
+    fun transitionStateCanOnlyReachOneTerminalState() {
+        val context = createContext()
+
+        assertEquals(NativeTransitionContext.State.PREPARED, context.state)
+        assertTrue(context.markStarted())
+        assertFalse(context.markStarted())
+        assertTrue(context.markCompleted())
+        assertFalse(context.markCancelled())
+        assertFalse(context.markPrevented())
+        assertEquals(NativeTransitionContext.State.COMPLETED, context.state)
+    }
+
+    @Test
+    fun transitionIdsAreUniqueWithinTheProcess() {
+        val first = createContext()
+        val second = createContext()
+
+        assertNotEquals(first.id, second.id)
+    }
+
+    @Test
+    fun traceArgumentsExcludeNullValues() {
+        val context =
+            NativeTransitionContext.create(
+                containerId = "stack-1",
+                presentation = NativeTransitionPresentation.STACK,
+                operation = NativeTransitionOperation.PUSH,
+                origin = NativeTransitionOrigin.LYNX_PATCH,
+                sourceScreenKey = null,
+                targetScreenKey = "target",
+                pushCount = 1,
+                navigationTraceId = "js:stack:7",
+                preloadTraceId = "js:stack:6",
+            )
+
+        val arguments = context.traceArguments("optional" to null)
+
+        assertFalse(arguments.containsKey("source_screen_key"))
+        assertFalse(arguments.containsKey("optional"))
+        assertEquals("target", arguments["target_screen_key"])
+        assertEquals("js:stack:7", arguments["navigation_trace_id"])
+        assertEquals("js:stack:6", arguments["preload_trace_id"])
+        assertEquals("1", arguments["push_count"])
+    }
+
+    @Test
+    fun viewLifecycleSnapshotDoesNotGuessWhichNavigationCausedIt() {
+        val operation =
+            NavigationTraceIdentity(
+                "js:1",
+                "transition:1",
+                containerId = "stack:1",
+                runtimeId = "runtime",
+                navigatorKey = "navigator",
+                screenKey = "A",
+                contentScopeId = "content:1",
+            )
+        val lifecycle = operation.withoutOperation()
+        assertEquals(null, lifecycle.navigationTraceId)
+        assertEquals(null, lifecycle.nativeTransitionId)
+        assertEquals("content:1", lifecycle.contentScopeId)
+        assertEquals("stack:1", lifecycle.containerId)
+        assertEquals("js:1", operation.navigationTraceId)
+    }
+
+    private fun createContext(): NativeTransitionContext =
+        NativeTransitionContext.create(
+            containerId = "stack-1",
+            presentation = NativeTransitionPresentation.STACK,
+            operation = NativeTransitionOperation.POP,
+            origin = NativeTransitionOrigin.NATIVE_BACK,
+            sourceScreenKey = "source",
+            targetScreenKey = "target",
+            popCount = 1,
+            targetReused = true,
+        )
+}

--- a/android/src/test/java/com/lynxscreens/screens/common/trace/NavigationTraceContextStoreTest.kt
+++ b/android/src/test/java/com/lynxscreens/screens/common/trace/NavigationTraceContextStoreTest.kt
@@ -1,0 +1,58 @@
+package com.lynxscreens.screens.common.trace
+
+import org.junit.Assert.*
+import org.junit.Test
+
+class NavigationTraceContextStoreTest {
+    private val session = TraceSession("runtime", "navigator")
+    private val stack = ExpectedTraceChange.Stack(listOf("A", "B"), listOf("A", "C"))
+
+    private fun binding(id: String, change: ExpectedTraceChange) =
+        NavigationTraceContext(
+            id,
+            1,
+            "REPLACE",
+            "B",
+            "C",
+            session = session,
+            expectedChange = change,
+        )
+
+    @Test
+    fun matchesTheWholeStackRatherThanJustEndpoints() {
+        val batch = TraceBatch(session, 1, listOf(binding("one", stack)))
+        assertNull(
+            batch.consume("stack:1", ExpectedTraceChange.Stack(listOf("X", "B"), listOf("X", "C")))
+        )
+    }
+
+    @Test
+    fun consumesExactlyOncePerContainer() {
+        val batch = TraceBatch(session, 1, listOf(binding("one", stack)))
+        assertEquals("one", batch.consume("stack:1", stack)?.navigationTraceId)
+        assertNull(batch.consume("stack:1", stack))
+        assertEquals("one", batch.consume("stack:2", stack)?.navigationTraceId)
+    }
+
+    @Test
+    fun ambiguousBindingsStayUnlinked() {
+        val batch = TraceBatch(session, 1, listOf(binding("one", stack), binding("two", stack)))
+        assertNull(batch.consume("stack:1", stack))
+    }
+
+    @Test
+    fun sheetAndStackConsumeIndependently() {
+        val sheet = ExpectedTraceChange.Sheet("S", true, false)
+        val batch = TraceBatch(session, 1, listOf(binding("one", stack), binding("one", sheet)))
+        assertNotNull(batch.consume("stack:1", stack))
+        assertNotNull(batch.consume("sheet:1", sheet))
+    }
+
+    @Test
+    fun aDelayedOperationRetainsItsOriginalBatch() {
+        val captured = TraceBatch(session, 1, listOf(binding("old", stack)))
+        val newer = TraceBatch(session, 2, listOf(binding("new", stack)))
+        assertEquals("old", captured.consume("stack:1", stack)?.navigationTraceId)
+        assertEquals("new", newer.consume("stack:1", stack)?.navigationTraceId)
+    }
+}

--- a/android/src/test/java/com/lynxscreens/screens/common/trace/NavigationTraceStoreOwnershipTest.kt
+++ b/android/src/test/java/com/lynxscreens/screens/common/trace/NavigationTraceStoreOwnershipTest.kt
@@ -1,0 +1,19 @@
+package com.lynxscreens.screens.common.trace
+
+import com.lynxscreens.screens.formsheet.host.FormSheetHostView
+import com.lynxscreens.screens.host.StackContainer
+import org.junit.Assert.assertFalse
+import org.junit.Test
+
+class NavigationTraceStoreOwnershipTest {
+    @Test
+    fun nativeViewsDoNotReceiveTraceStoreThroughConstructor() {
+        assertFalse(StackContainer::class.java.hasTraceStoreConstructorParameter())
+        assertFalse(FormSheetHostView::class.java.hasTraceStoreConstructorParameter())
+    }
+
+    private fun Class<*>.hasTraceStoreConstructorParameter(): Boolean =
+        declaredConstructors.any { constructor ->
+            constructor.parameterTypes.contains(NavigationTraceContextStore::class.java)
+        }
+}

--- a/android/src/test/java/com/lynxscreens/screens/host/StackNavigationTraceTest.kt
+++ b/android/src/test/java/com/lynxscreens/screens/host/StackNavigationTraceTest.kt
@@ -1,0 +1,71 @@
+package com.lynxscreens.screens.host
+
+import com.lynxscreens.screens.common.trace.NativeTransitionContext
+import com.lynxscreens.screens.common.trace.NativeTransitionOperation
+import com.lynxscreens.screens.common.trace.NativeTransitionOrigin
+import com.lynxscreens.screens.common.trace.NativeTransitionPresentation
+import com.lynxscreens.screens.screen.StackTransitionRole
+import org.junit.Assert.assertFalse
+import org.junit.Assert.assertTrue
+import org.junit.Test
+
+class StackNavigationTraceTest {
+    @Test
+    fun popMatchesOutgoingReturnAndIncomingReenterCallbacks() {
+        val context = context(NativeTransitionOperation.POP)
+
+        assertTrue(
+            StackNavigationTrace.transitionMatches(
+                context,
+                screenKey = "details",
+                role = StackTransitionRole.RETURN,
+            )
+        )
+        assertTrue(
+            StackNavigationTrace.transitionMatches(
+                context,
+                screenKey = "home",
+                role = StackTransitionRole.REENTER,
+            )
+        )
+        assertFalse(
+            StackNavigationTrace.transitionMatches(
+                context,
+                screenKey = "details",
+                role = StackTransitionRole.EXIT,
+            )
+        )
+    }
+
+    @Test
+    fun pushOnlyMatchesIncomingEnterCallback() {
+        val context = context(NativeTransitionOperation.PUSH)
+
+        assertTrue(
+            StackNavigationTrace.transitionMatches(
+                context,
+                screenKey = "home",
+                role = StackTransitionRole.ENTER,
+            )
+        )
+        assertFalse(
+            StackNavigationTrace.transitionMatches(
+                context,
+                screenKey = "details",
+                role = StackTransitionRole.EXIT,
+            )
+        )
+    }
+
+    private fun context(operation: NativeTransitionOperation): NativeTransitionContext =
+        NativeTransitionContext.create(
+            containerId = "stack-1",
+            presentation = NativeTransitionPresentation.STACK,
+            operation = operation,
+            origin = NativeTransitionOrigin.LYNX_PATCH,
+            sourceScreenKey = "details",
+            targetScreenKey = "home",
+            popCount = if (operation == NativeTransitionOperation.POP) 1 else 0,
+            pushCount = if (operation == NativeTransitionOperation.PUSH) 1 else 0,
+        )
+}

--- a/docs/navigation-trace.md
+++ b/docs/navigation-trace.md
@@ -30,6 +30,28 @@ not distinguish drag, backdrop and back dismissal sources: these use
 changes use `origin=lynx_patch`. The external FormSheet backend must supply its
 own instrumentation; the built-in backend is the reference implementation.
 
+## iOS
+
+`RNSNavigationTrace` writes through `LynxTraceEvent` when its header and the trace
+category are available. The current implementation covers Stack; there is no
+iOS FormSheet implementation in the base branch.
+
+Stack implements the events above except `NativeDismissPrevented`, since the
+current iOS Stack has no corresponding prevention hook. Raw operation requests
+are recorded before reconciliation. `ApplyOperations` surrounds the existing
+synchronous UIKit calls. `TransitionCallbackReceived` records the transition
+coordinator completion (end or cancel); it is separate from the guarded terminal
+event. A missing coordinator permits synchronous completion, while an unavailable
+completion registration cancels observation rather than claiming completion.
+
+Lifecycle emitters capture their operation/content identity. Later host
+lifecycle notifications do not revive a completed operation. Native removal is
+recorded at the existing parent-removal callback.
+
+The new trace header is private in the Pod. The existing explicit `common`
+source glob includes the implementation; no additional platform dependencies or
+new exported source directories are needed.
+
 ## Correlation
 
 `traceSession` enables navigation observation for a runtime and navigator.

--- a/docs/navigation-trace.md
+++ b/docs/navigation-trace.md
@@ -11,18 +11,18 @@ is still open for discussion.
 sections through `beginSection` / `endSection`, using the `lynx` category.
 A section encloses only the synchronous native work, including exception paths.
 
-| Prefix | Event suffix | Boundary |
-| --- | --- | --- |
-| `LynxScreens.Stack` | `OperationRequested` | A raw push/pop request, before reconciliation. |
-| `LynxScreens.Stack` | `OperationBatchPrepared` | The actual stack operation batch is prepared. |
-| `LynxScreens.Stack` | `ApplyOperations` | Synchronous submission of the batch (section). |
-| `LynxScreens.Stack` | `NativeBackRequested` | A native back intent is observed. |
-| `LynxScreens.Stack` | `TransitionCallbackReceived` | A Fragment transition callback, with screen, role and phase. |
-| `LynxScreens.FormSheet` | `PresentRequested`, `DismissRequested` | Presentation/dismissal intent at the Material backend boundary. |
-| Both | `NativeTransitionStart`, `NativeTransitionEnd`, `NativeTransitionCancelled` | Container transition start, completion or cancellation. |
-| Both | `NativeDismissCommitted`, `NativeDismissPrevented` | Removal is committed, or a native dismissal is prevented. |
-| Both | `LifecycleEventEmitted`, `DismissEventEmitted` | Native sends an existing lifecycle/dismissal message to JS. |
-| Both | `ScreenContentBound` | Available content identity is associated with the native operation's screen context. |
+| Prefix                  | Event suffix                                                                | Boundary                                                                             |
+| ----------------------- | --------------------------------------------------------------------------- | ------------------------------------------------------------------------------------ |
+| `LynxScreens.Stack`     | `OperationRequested`                                                        | A raw push/pop request, before reconciliation.                                       |
+| `LynxScreens.Stack`     | `OperationBatchPrepared`                                                    | The actual stack operation batch is prepared.                                        |
+| `LynxScreens.Stack`     | `ApplyOperations`                                                           | Synchronous submission of the batch (section).                                       |
+| `LynxScreens.Stack`     | `NativeBackRequested`                                                       | A native back intent is observed.                                                    |
+| `LynxScreens.Stack`     | `TransitionCallbackReceived`                                                | A Fragment transition callback, with screen, role and phase.                         |
+| `LynxScreens.FormSheet` | `PresentRequested`, `DismissRequested`                                      | Presentation/dismissal intent at the Material backend boundary.                      |
+| Both                    | `NativeTransitionStart`, `NativeTransitionEnd`, `NativeTransitionCancelled` | Container transition start, completion or cancellation.                              |
+| Both                    | `NativeDismissCommitted`, `NativeDismissPrevented`                          | Removal is committed, or a native dismissal is prevented.                            |
+| Both                    | `LifecycleEventEmitted`, `DismissEventEmitted`                              | Native sends an existing lifecycle/dismissal message to JS.                          |
+| Both                    | `ScreenContentBound`                                                        | Available content identity is associated with the native operation's screen context. |
 
 All events except `ApplyOperations` are points. Android's Material callback does
 not distinguish drag, backdrop and back dismissal sources: these use
@@ -75,3 +75,46 @@ navigation operation.
 Submitting operations, completing a transition and sending a lifecycle event
 are separate facts. None proves that pixels have been presented. This change has
 no first-frame probe and does not calculate screen performance metrics.
+
+## JS bridge
+
+The navigation adapter supplies `internalTrace` on the existing
+`StackHostNativeComponent`, `StackScreenNativeComponent` and
+`FormSheetNativeComponent` roots. Host props contain the session and operation
+envelope; screen props contain the session, optional content identity and
+optional bridge observer. A FormSheet needs a `traceScreenKey`, which can also
+be derived from its supplied content identity. The Host envelope remains the
+channel for a Sheet that is removed during an update.
+
+The bridge encodes native attributes and forwards callback context. It does not
+create navigation IDs, implement the navigation adapter or write JS trace
+events. `onRootCommitted` observes the JS wrapper's effect, not a native commit
+or a completed draw. `onEventForwarded` observes the current native message;
+observer failures do not suppress the original handler or catch its errors.
+
+Stack dismissal callbacks keep `screenKey` as their first argument and add an
+optional `NativeEventContext` as the second. FormSheet dismissal callbacks gain
+an optional context argument. Existing raw lifecycle/prevention handlers receive
+the original event. The exported `UNSTABLE_decodeNativeTraceEvent` helper can
+extract the versioned identity without relying on the latest navigation state.
+Missing or malformed trace data remains unlinked.
+
+Content identity is optional and independent of timing flags. This bridge does
+not generate or inject FCP timing flags, add layout nodes or install first-frame
+observers.
+
+## Validation and manual acceptance
+
+Use the library's `typecheck` and lint commands, build the example bundle and
+native examples, and run Android `testDebugUnitTest`. Codec tests run with
+`node --experimental-strip-types --test tests/navigation-trace.test.mjs` on Node
+22.6 or newer. Native builds and protocol tests do not establish runtime event
+ordering or confirm the absence of navigation regressions.
+
+With an adapter providing the versioned props, record push/pop, batched changes,
+preloaded screen activation, native back, dismissal prevention, rapid successive
+transitions and nested-container teardown. On Android also cover Material Sheet
+present/dismiss and cascading dismissal. Verify operation identities across
+callbacks, a single terminal event, unlinked ambiguous batches and unchanged
+behavior when observation is disabled. No screen FCP or presentation metric is
+claimed by these events.

--- a/docs/navigation-trace.md
+++ b/docs/navigation-trace.md
@@ -1,0 +1,55 @@
+# Navigation trace instrumentation
+
+This draft adds diagnostic events to the existing native containers. Events use
+fixed names, with identities and other values in trace arguments. The writer
+calls Lynx trace APIs; the interface for future sharing with React Native Screens
+is still open for discussion.
+
+## Android
+
+`LynxScreensTrace` emits points through `TraceEvent.instant` and synchronous
+sections through `beginSection` / `endSection`, using the `lynx` category.
+A section encloses only the synchronous native work, including exception paths.
+
+| Prefix | Event suffix | Boundary |
+| --- | --- | --- |
+| `LynxScreens.Stack` | `OperationRequested` | A raw push/pop request, before reconciliation. |
+| `LynxScreens.Stack` | `OperationBatchPrepared` | The actual stack operation batch is prepared. |
+| `LynxScreens.Stack` | `ApplyOperations` | Synchronous submission of the batch (section). |
+| `LynxScreens.Stack` | `NativeBackRequested` | A native back intent is observed. |
+| `LynxScreens.Stack` | `TransitionCallbackReceived` | A Fragment transition callback, with screen, role and phase. |
+| `LynxScreens.FormSheet` | `PresentRequested`, `DismissRequested` | Presentation/dismissal intent at the Material backend boundary. |
+| Both | `NativeTransitionStart`, `NativeTransitionEnd`, `NativeTransitionCancelled` | Container transition start, completion or cancellation. |
+| Both | `NativeDismissCommitted`, `NativeDismissPrevented` | Removal is committed, or a native dismissal is prevented. |
+| Both | `LifecycleEventEmitted`, `DismissEventEmitted` | Native sends an existing lifecycle/dismissal message to JS. |
+| Both | `ScreenContentBound` | Available content identity is associated with the native operation's screen context. |
+
+All events except `ApplyOperations` are points. Android's Material callback does
+not distinguish drag, backdrop and back dismissal sources: these use
+`origin=native_dismiss`; cascading dismissal uses `origin=cascade`. Programmatic
+changes use `origin=lynx_patch`. The external FormSheet backend must supply its
+own instrumentation; the built-in backend is the reference implementation.
+
+## Correlation
+
+`traceSession` enables navigation observation for a runtime and navigator.
+`navigationTraceContext` carries a versioned envelope, sequence and expected
+container changes. The native layer consumes a unique matching binding once per
+container. Missing or ambiguous bindings remain unlinked. The framework can
+supply `contentTraceContext` to identify the screen's content instance.
+
+`navigation_trace_id` identifies one logical request; `native_transition_id`
+identifies one native operation. They are not interchangeable. Native back and
+dismissal requests create a native request identity. Existing native messages
+carry the captured identity as `detail.traceIdentity` for the navigation adapter
+to reuse when synchronizing JS state.
+
+Delayed transition callbacks retain their operation handle. A completed,
+cancelled or prevented operation cannot claim another terminal event. Generic
+Android View lifecycle notifications retain their screen/container identity and
+omit request/transition IDs because those callbacks do not identify a specific
+navigation operation.
+
+Submitting operations, completing a transition and sending a lifecycle event
+are separate facts. None proves that pixels have been presented. This change has
+no first-frame probe and does not calculate screen performance metrics.

--- a/ios/LynxScreens.podspec
+++ b/ios/LynxScreens.podspec
@@ -19,5 +19,7 @@ Pod::Spec.new do |s|
 
   s.source_files = 'common/**/*.{h,m,mm}', 'header/**/*.{h,m,mm}', 'helpers/**/*.{h,m,mm}', 'host/**/*.{h,m,mm}', 'screen/**/*.{h,m,mm}', 'scroll-view-marker/**/*.{h,m,mm}', 'utils/**/*.{h,m,mm}'
 
+  s.private_header_files = 'common/trace/*.h'
+
   s.dependency 'Lynx'
 end

--- a/ios/common/trace/RNSNavigationTrace.h
+++ b/ios/common/trace/RNSNavigationTrace.h
@@ -1,0 +1,41 @@
+#import <UIKit/UIKit.h>
+NS_ASSUME_NONNULL_BEGIN
+FOUNDATION_EXPORT NSDictionary *_Nullable RNSTraceParse(NSString *_Nullable value);
+FOUNDATION_EXPORT NSDictionary *_Nullable RNSTraceSession(NSString *_Nullable value);
+FOUNDATION_EXPORT NSDictionary *_Nullable RNSTraceContent(NSString *_Nullable value);
+FOUNDATION_EXPORT BOOL RNSTraceEnabled(void);
+FOUNDATION_EXPORT void RNSTraceInstant(NSString *name, NSDictionary *fields);
+FOUNDATION_EXPORT void RNSTraceSection(NSString *name, NSDictionary *fields, void (^block)(void));
+FOUNDATION_EXPORT NSDictionary *RNSTraceFields(NSDictionary *identity);
+
+@interface RNSTraceBatch : NSObject
+@property(nonatomic, copy, readonly) NSDictionary *session;
+- (nullable NSDictionary *)consumeForContainer:(NSString *)container expected:(NSDictionary *)expected;
+@end
+@interface RNSNavigatorTraceScope : NSObject
+@property(nonatomic, copy, readonly) NSDictionary *session;
++ (instancetype)scopeWithContext:(id)context session:(NSDictionary *)session;
++ (nullable instancetype)findWithContext:(id)context session:(nullable NSDictionary *)session;
+- (nullable RNSTraceBatch *)stage:(nullable NSString *)envelope;
+- (nullable RNSTraceBatch *)capture;
+- (void)endBatch:(nullable RNSTraceBatch *)batch;
+@end
+@interface RNSNavigationTraceOperation : NSObject
+@property(nonatomic, copy, readonly) NSDictionary *identity;
+@property(nonatomic, copy, readonly) NSString *prefix;
+@property(nonatomic, readonly) BOOL terminal;
+- (instancetype)initWithPrefix:(NSString *)prefix
+                     container:(NSString *)container
+                       session:(NSDictionary *)session
+                     operation:(NSString *)operation
+                        origin:(NSString *)origin
+                       binding:(nullable NSDictionary *)binding
+                      contents:(NSDictionary<NSString *, NSDictionary *> *)contents
+                 nativeRequest:(BOOL)nativeRequest;
+- (NSDictionary *)identityForScreen:(nullable NSString *)screen;
+- (NSDictionary *)lifecycleIdentityForScreen:(nullable NSString *)screen;
+- (void)mark:(NSString *)event fields:(NSDictionary *)fields;
+- (void)start:(BOOL)animated;
+- (void)finish:(NSString *)status reason:(nullable NSString *)reason;
+@end
+NS_ASSUME_NONNULL_END

--- a/ios/common/trace/RNSNavigationTrace.mm
+++ b/ios/common/trace/RNSNavigationTrace.mm
@@ -1,0 +1,331 @@
+#import "RNSNavigationTrace.h"
+#import <math.h>
+#if __has_include(<Lynx/LynxTraceEvent.h>)
+#import <Lynx/LynxTraceEvent.h>
+#define RNS_HAS_TRACE 1
+#else
+#define RNS_HAS_TRACE 0
+#endif
+
+static BOOL RNSID(id value)
+{
+    return [value isKindOfClass:NSString.class] && [value length] > 0 && [value length] <= 1024;
+}
+NSDictionary *RNSTraceParse(NSString *value)
+{
+    if (![value isKindOfClass:NSString.class] || value.length > 65536)
+        return nil;
+    id json = [NSJSONSerialization JSONObjectWithData:[value dataUsingEncoding:NSUTF8StringEncoding]
+                                              options:0
+                                                error:NULL];
+    return [json isKindOfClass:NSDictionary.class] && [json[@"version"] isEqual:@1] ? json : nil;
+}
+NSDictionary *RNSTraceSession(NSString *value)
+{
+    NSDictionary *json = RNSTraceParse(value);
+    return RNSID(json[@"runtimeId"]) && RNSID(json[@"navigatorKey"]) && [json[@"enabled"] isEqual:@YES] ? json : nil;
+}
+NSDictionary *RNSTraceContent(NSString *value)
+{
+    NSDictionary *json = RNSTraceParse(value);
+    return RNSID(json[@"runtimeId"]) && RNSID(json[@"navigatorKey"]) && RNSID(json[@"screenKey"]) &&
+                   RNSID(json[@"contentScopeId"])
+               ? json
+               : nil;
+}
+static NSArray *RNSSessionKey(NSDictionary *session) { return @[ session[@"runtimeId"], session[@"navigatorKey"] ]; }
+BOOL RNSTraceEnabled(void)
+{
+#if RNS_HAS_TRACE
+    @try
+    {
+        return [LynxTraceEvent categoryEnabled:@"lynx"];
+    }
+    @catch (NSException *exception)
+    {
+        return NO;
+    }
+#else
+    return NO;
+#endif
+}
+void RNSTraceInstant(NSString *name, NSDictionary *fields)
+{
+#if RNS_HAS_TRACE
+    if (!RNSTraceEnabled())
+        return;
+    @try
+    {
+        [LynxTraceEvent instant:@"lynx" withName:name debugInfo:fields];
+    }
+    @catch (NSException *exception)
+    {
+    }
+#endif
+}
+void RNSTraceSection(NSString *name, NSDictionary *fields, void (^block)(void))
+{
+    BOOL began = NO;
+#if RNS_HAS_TRACE
+    @try
+    {
+        if (RNSTraceEnabled())
+        {
+            [LynxTraceEvent beginSection:@"lynx" withName:name debugInfo:fields];
+            began = YES;
+        }
+    }
+    @catch (NSException *exception)
+    {
+    }
+#endif
+    @try
+    {
+        block();
+    }
+    @finally
+    {
+#if RNS_HAS_TRACE
+        @try
+        {
+            if (began)
+                [LynxTraceEvent endSection:@"lynx" withName:name];
+        }
+        @catch (NSException *exception)
+        {
+        }
+#endif
+    }
+}
+NSDictionary *RNSTraceFields(NSDictionary *identity)
+{
+    NSDictionary *keys = @{
+        @"runtimeId" : @"runtime_id",
+        @"navigatorKey" : @"navigator_key",
+        @"containerId" : @"container_id",
+        @"navigationTraceId" : @"navigation_trace_id",
+        @"nativeTransitionId" : @"native_transition_id",
+        @"screenKey" : @"screen_key",
+        @"contentScopeId" : @"content_scope_id",
+        @"operation" : @"operation",
+        @"origin" : @"origin"
+    };
+    NSMutableDictionary *fields = [NSMutableDictionary new];
+    for (NSString *key in keys)
+        if (identity[key])
+            fields[keys[key]] = identity[key];
+    return fields;
+}
+@implementation RNSTraceBatch
+{
+    NSArray<NSDictionary *> *_bindings;
+    NSMutableSet<NSString *> *_consumed;
+}
+- (instancetype)initWithSession:(NSDictionary *)session bindings:(NSArray *)bindings
+{
+    if (self = [super init])
+    {
+        _session = [session copy];
+        _bindings = [bindings copy];
+        _consumed = [NSMutableSet new];
+    }
+    return self;
+}
+- (NSDictionary *)consumeForContainer:(NSString *)container expected:(NSDictionary *)expected
+{
+    if ([_consumed containsObject:container])
+        return nil;
+    [_consumed addObject:container];
+    NSDictionary *match = nil;
+    for (NSDictionary *binding in _bindings)
+        if ([binding[@"expectedChange"] isEqual:expected])
+        {
+            if (match)
+                return nil;
+            match = binding;
+        }
+    return match;
+}
+@end
+static NSMapTable *RNSScopes(void)
+{
+    static NSMapTable *scopes;
+    static dispatch_once_t once;
+    dispatch_once(&once, ^{
+      scopes = [NSMapTable weakToStrongObjectsMapTable];
+    });
+    return scopes;
+}
+@implementation RNSNavigatorTraceScope
+{
+    RNSTraceBatch *_batch;
+    double _lastSequence;
+}
++ (instancetype)scopeWithContext:(id)context session:(NSDictionary *)session
+{
+    RNSNavigatorTraceScope *scope = [self findWithContext:context session:session];
+    if (scope)
+        return scope;
+    scope = [self new];
+    scope->_session = [session copy];
+    scope->_lastSequence = -1;
+    NSMapTable *entries = [RNSScopes() objectForKey:context];
+    if (!entries)
+    {
+        entries = [NSMapTable strongToWeakObjectsMapTable];
+        [RNSScopes() setObject:entries forKey:context];
+    }
+    [entries setObject:scope forKey:RNSSessionKey(session)];
+    return scope;
+}
++ (instancetype)findWithContext:(id)context session:(NSDictionary *)session
+{
+    if (!context || !session)
+        return nil;
+    return [[RNSScopes() objectForKey:context] objectForKey:RNSSessionKey(session)];
+}
+- (RNSTraceBatch *)stage:(NSString *)envelope
+{
+    _batch = nil;
+    NSDictionary *json = RNSTraceParse(envelope);
+    if (![json[@"runtimeId"] isEqual:_session[@"runtimeId"]] ||
+        ![json[@"navigatorKey"] isEqual:_session[@"navigatorKey"]])
+        return nil;
+    NSNumber *sequence = json[@"sequence"];
+    if (![sequence isKindOfClass:NSNumber.class] || !isfinite(sequence.doubleValue) ||
+        floor(sequence.doubleValue) != sequence.doubleValue || sequence.doubleValue < 0 ||
+        sequence.doubleValue > 9007199254740991.0 || sequence.doubleValue <= _lastSequence)
+        return nil;
+    NSArray *bindings = json[@"bindings"];
+    if (![bindings isKindOfClass:NSArray.class] || bindings.count > 256)
+        return nil;
+    for (id binding in bindings)
+    {
+        if (![binding isKindOfClass:NSDictionary.class] || !RNSID(binding[@"navigationTraceId"]) ||
+            !RNSID(binding[@"actionType"]))
+            return nil;
+        NSDictionary *change = binding[@"expectedChange"];
+        if (![change isKindOfClass:NSDictionary.class])
+            return nil;
+        if ([change[@"kind"] isEqual:@"stack"])
+        {
+            for (NSString *key in @[ @"beforeScreenKeys", @"afterScreenKeys" ])
+            {
+                NSArray *screens = change[key];
+                if (![screens isKindOfClass:NSArray.class] || screens.count > 256)
+                    return nil;
+                for (id screen in screens)
+                    if (!RNSID(screen))
+                        return nil;
+            }
+        }
+        else if ([change[@"kind"] isEqual:@"sheet"])
+        {
+            if (!RNSID(change[@"screenKey"]) || ![change[@"fromOpen"] isKindOfClass:NSNumber.class] ||
+                ![change[@"toOpen"] isKindOfClass:NSNumber.class])
+                return nil;
+        }
+        else
+            return nil;
+    }
+    _lastSequence = sequence.doubleValue;
+    _batch = [[RNSTraceBatch alloc] initWithSession:_session bindings:bindings];
+    return _batch;
+}
+- (RNSTraceBatch *)capture
+{
+    return _batch;
+}
+- (void)endBatch:(RNSTraceBatch *)batch
+{
+    if (_batch == batch)
+        _batch = nil;
+}
+@end
+@implementation RNSNavigationTraceOperation
+{
+    NSDictionary<NSString *, NSDictionary *> *_contents;
+    BOOL _started;
+}
+- (instancetype)initWithPrefix:(NSString *)prefix
+                     container:(NSString *)container
+                       session:(NSDictionary *)session
+                     operation:(NSString *)operation
+                        origin:(NSString *)origin
+                       binding:(NSDictionary *)binding
+                      contents:(NSDictionary *)contents
+                 nativeRequest:(BOOL)nativeRequest
+{
+    if (self = [super init])
+    {
+        _prefix = [prefix copy];
+        NSMutableDictionary *matchingContents = [NSMutableDictionary new];
+        for (NSString *key in contents)
+        {
+            NSDictionary *content = contents[key];
+            if ([content[@"runtimeId"] isEqual:session[@"runtimeId"]] &&
+                [content[@"navigatorKey"] isEqual:session[@"navigatorKey"]])
+                matchingContents[key] = content;
+        }
+        _contents = [matchingContents copy];
+        NSMutableDictionary *identity = [@{
+            @"version" : @1,
+            @"containerId" : container,
+            @"runtimeId" : session[@"runtimeId"],
+            @"navigatorKey" : session[@"navigatorKey"],
+            @"nativeTransitionId" : [NSString stringWithFormat:@"%@:transition:%@", container, NSUUID.UUID.UUIDString],
+            @"operation" : operation,
+            @"origin" : origin
+        } mutableCopy];
+        if (nativeRequest)
+            identity[@"navigationTraceId"] = [@"native:" stringByAppendingString:NSUUID.UUID.UUIDString];
+        else if (binding[@"navigationTraceId"])
+            identity[@"navigationTraceId"] = binding[@"navigationTraceId"];
+        _identity = [identity copy];
+        for (NSString *key in _contents)
+            RNSTraceInstant([prefix stringByAppendingString:@".ScreenContentBound"],
+                            RNSTraceFields([self identityForScreen:key]));
+    }
+    return self;
+}
+- (NSDictionary *)identityForScreen:(NSString *)screen
+{
+    NSMutableDictionary *identity = [_identity mutableCopy];
+    if (screen)
+        identity[@"screenKey"] = screen;
+    if (_contents[screen ?: @""][@"contentScopeId"])
+        identity[@"contentScopeId"] = _contents[screen][@"contentScopeId"];
+    return [identity copy];
+}
+- (NSDictionary *)lifecycleIdentityForScreen:(NSString *)screen
+{
+    NSMutableDictionary *identity = [[self identityForScreen:screen] mutableCopy];
+    // A later host/window lifecycle change must not revive a completed operation.
+    if (_terminal)
+        [identity removeObjectsForKeys:@[ @"navigationTraceId", @"nativeTransitionId", @"operation", @"origin" ]];
+    return [identity copy];
+}
+- (void)mark:(NSString *)event fields:(NSDictionary *)fields
+{
+    NSMutableDictionary *args = [RNSTraceFields(_identity) mutableCopy];
+    [args addEntriesFromDictionary:fields];
+    RNSTraceInstant([_prefix stringByAppendingFormat:@".%@", event], args);
+}
+- (void)start:(BOOL)animated
+{
+    if (_terminal || _started)
+        return;
+    _started = YES;
+    [self mark:@"NativeTransitionStart" fields:@{@"is_animated" : @(animated)}];
+}
+- (void)finish:(NSString *)status reason:(NSString *)reason
+{
+    if (_terminal)
+        return;
+    _terminal = YES;
+    NSString *event = [status isEqual:@"completed"]   ? @"NativeTransitionEnd"
+                      : [status isEqual:@"prevented"] ? @"NativeDismissPrevented"
+                                                      : @"NativeTransitionCancelled";
+    [self mark:event fields:reason ? @{@"status" : status, @"reason" : reason} : @{@"status" : status}];
+}
+@end

--- a/ios/host/RNSStackHostComponent.mm
+++ b/ios/host/RNSStackHostComponent.mm
@@ -4,6 +4,7 @@
 
 #import <Lynx/LynxComponentRegistry.h>
 #import <Lynx/LynxLog.h>
+#import <Lynx/LynxPropsProcessor.h>
 
 #import "RNSStackNavigationController.h"
 #import "RNSStackOperationCoordinator.h"
@@ -14,6 +15,10 @@
     RNSStackOperationCoordinator *_Nonnull _stackOperationCoordinator;
     NSMutableArray<RNSStackScreenComponent *> *_Nonnull _renderedScreens;
     BOOL _isMountingTransactionPending;
+    RNSNavigatorTraceScope *_traceScope;
+    NSDictionary *_traceSession;
+    NSString *_traceEnvelope;
+    BOOL _traceEnvelopeUpdated;
 }
 
 #pragma mark - Init
@@ -32,6 +37,30 @@
     _stackOperationCoordinator = [RNSStackOperationCoordinator new];
     _renderedScreens = [NSMutableArray new];
     _isMountingTransactionPending = NO;
+}
+
+LYNX_PROP_SETTER("traceSession", setTraceSession, NSString *)
+{
+    _traceSession = requestReset ? nil : RNSTraceSession(value);
+    _stackNavigationController.traceSession = _traceSession;
+    _traceScope = _traceSession ? [RNSNavigatorTraceScope scopeWithContext:self.context session:_traceSession] : nil;
+}
+LYNX_PROP_SETTER("navigationTraceContext", setNavigationTraceContext, NSString *)
+{
+    _traceEnvelope = requestReset ? nil : value;
+    _traceEnvelopeUpdated = YES;
+}
+- (void)propsDidUpdate
+{
+    if (_traceEnvelopeUpdated) {
+        _traceEnvelopeUpdated = NO;
+        RNSTraceBatch *batch = [_traceScope stage:_traceEnvelope];
+        [_stackOperationCoordinator captureTraceBatch:batch];
+        RNSNavigatorTraceScope *scope = _traceScope;
+        dispatch_async(dispatch_get_main_queue(), ^{
+          [scope endBatch:batch];
+        });
+    }
 }
 
 #pragma mark - View Management

--- a/ios/host/RNSStackNavigationController.h
+++ b/ios/host/RNSStackNavigationController.h
@@ -1,6 +1,7 @@
 #pragma once
 
 #import "RNSContainer.h"
+#import "RNSNavigationTrace.h"
 #import "RNSStackNavigationBarCoordinator.h"
 #import "RNSStackScreenComponent.h"
 
@@ -11,6 +12,9 @@
 @property (nonatomic, weak, nullable) id<RNSViewFrameChangeDelegate> navigationBarFrameChangeDelegate;
 
 @property (nonatomic, readonly, nonnull) RNSStackNavigationBarCoordinator *navigationBarCoordinator;
+
+@property(nonatomic, copy, nullable) NSDictionary *traceSession;
+@property(nonatomic, strong, nullable) RNSTraceBatch *traceBatch;
 
 - (void)enqueuePushOperation:(nonnull RNSStackScreenComponent *)stackScreen;
 

--- a/ios/host/RNSStackNavigationController.mm
+++ b/ios/host/RNSStackNavigationController.mm
@@ -10,6 +10,9 @@
     NSMutableArray<RNSPushOperation *> *_Nonnull _pendingPushOperations;
     NSMutableArray<RNSPopOperation *> *_Nonnull _pendingPopOperations;
     RNSParentContainerItemRegistry *_Nonnull _parentContainerRegistry;
+    NSString *_traceContainerId;
+    RNSNavigationTraceOperation *_traceOperation;
+    BOOL _applyingJSOperations;
 }
 
 - (instancetype)init
@@ -81,6 +84,82 @@
     [_pendingPopOperations addObject:operation];
 }
 
+- (RNSNavigationTraceOperation *)prepareTraceFrom:(NSArray *)before to:(NSArray *)after native:(BOOL)native
+{
+    if (!self.traceSession)
+        return nil;
+    if (!_traceContainerId)
+        _traceContainerId = [@"stack:" stringByAppendingString:NSUUID.UUID.UUIDString];
+    NSMutableArray *beforeKeys = [NSMutableArray new], *afterKeys = [NSMutableArray new];
+    NSMutableDictionary *contents = [NSMutableDictionary new];
+    for (RNSStackScreenController *controller in [before arrayByAddingObjectsFromArray:after]) {
+        RNSStackScreenComponent *screen = controller.screenComponent;
+        if (screen.screenKey && screen.traceContent)
+            contents[screen.screenKey] = screen.traceContent;
+    }
+    for (RNSStackScreenController *controller in before)
+        if (controller.screenComponent.screenKey)
+            [beforeKeys addObject:controller.screenComponent.screenKey];
+    for (RNSStackScreenController *controller in after)
+        if (controller.screenComponent.screenKey)
+            [afterKeys addObject:controller.screenComponent.screenKey];
+    NSDictionary *expected = @{@"kind" : @"stack", @"beforeScreenKeys" : beforeKeys, @"afterScreenKeys" : afterKeys};
+    NSDictionary *binding = native ? nil : [self.traceBatch consumeForContainer:_traceContainerId expected:expected];
+    [_traceOperation finish:@"cancelled" reason:@"superseded"];
+    NSString *operation = after.count < before.count ? @"pop" : after.count > before.count ? @"push" : @"replace";
+    _traceOperation = [[RNSNavigationTraceOperation alloc] initWithPrefix:@"LynxScreens.Stack"
+                                                                container:_traceContainerId
+                                                                  session:self.traceSession
+                                                                operation:operation
+                                                                   origin:native ? @"native_back" : @"lynx_patch"
+                                                                  binding:binding
+                                                                 contents:contents
+                                                            nativeRequest:native];
+    for (RNSStackScreenController *controller in [before arrayByAddingObjectsFromArray:after])
+        controller.screenComponent.traceOperation = _traceOperation;
+    [_traceOperation mark:native ? @"NativeBackRequested" : @"OperationBatchPrepared"
+                   fields:binding || native ? @{} : @{@"unlinked_reason" : @"missing_context"}];
+    return _traceOperation;
+}
+
+- (void)completeTrace:(RNSNavigationTraceOperation *)operation animated:(BOOL)animated
+{
+    if (!operation)
+        return;
+    [operation start:animated];
+    id<UIViewControllerTransitionCoordinator> coordinator = self.transitionCoordinator;
+    if (coordinator) {
+        BOOL registered =
+            [coordinator animateAlongsideTransition:nil
+                                         completion:^(id<UIViewControllerTransitionCoordinatorContext> context) {
+                                           [operation mark:@"TransitionCallbackReceived"
+                                                    fields:@{@"phase" : context.isCancelled ? @"cancel" : @"end"}];
+                                           [operation finish:context.isCancelled ? @"cancelled" : @"completed"
+                                                      reason:context.isCancelled ? @"interactive_cancelled" : nil];
+                                         }];
+        if (!registered)
+            [operation finish:@"cancelled" reason:@"completion_unavailable"];
+    } else {
+        [operation finish:@"completed" reason:nil];
+    }
+}
+
+- (UIViewController *)popViewControllerAnimated:(BOOL)animated
+{
+    if (_applyingJSOperations || !self.traceSession || self.viewControllers.count < 2)
+        return [super popViewControllerAnimated:animated];
+    NSArray *before = self.viewControllers;
+    RNSNavigationTraceOperation *operation =
+        [self prepareTraceFrom:before to:[before subarrayWithRange:NSMakeRange(0, before.count - 1)] native:YES];
+    [operation start:animated];
+    UIViewController *result = [super popViewControllerAnimated:animated];
+    if (result)
+        [self completeTrace:operation animated:animated];
+    else
+        [operation finish:@"cancelled" reason:@"no_native_change"];
+    return result;
+}
+
 - (void)performContainerUpdateIfNeeded
 {
     // NOTE: We consider UINavigationController.viewControllers to be part of
@@ -101,30 +180,48 @@
     // animated transition eagerly) every animated call would defer the
     // following ones, serializing one animation per operation and re-breaking
     // the synchronous update assumption.
-    BOOL hasPendingPushes = _pendingPushOperations.count > 0;
+    NSMutableArray *after = [self.viewControllers mutableCopy];
+    for (RNSPopOperation *op in _pendingPopOperations)
+        [after removeObject:op.stackScreen.controller];
+    for (RNSPushOperation *op in _pendingPushOperations)
+        [after addObject:op.stackScreen.controller];
+    RNSNavigationTraceOperation *operation = [self prepareTraceFrom:self.viewControllers to:after native:NO];
+    [operation start:YES];
+    _applyingJSOperations = YES;
+    void (^applyOperations)(void) = ^{
+      BOOL hasPendingPushes = self->_pendingPushOperations.count > 0;
 
-    NSUInteger popIndex = 0;
-    for (RNSPopOperation *op in _pendingPopOperations) {
-        UIViewController *controller = static_cast<UIViewController *>(op.stackScreen.controller);
-        NSAssert([self.viewControllers count] > 1, @"[RNScreens] Attempt to pop last screen from the stack");
-        NSAssert(self.topViewController == controller, @"[RNScreens] Attempt to pop non-top screen");
-        BOOL isFinalOperation =
-            !hasPendingPushes && popIndex == _pendingPopOperations.count - 1;
-        [self popViewControllerAnimated:isFinalOperation];
-        popIndex += 1;
+      NSUInteger popIndex = 0;
+      for (RNSPopOperation *op in self->_pendingPopOperations) {
+          UIViewController *controller = static_cast<UIViewController *>(op.stackScreen.controller);
+          NSAssert([self.viewControllers count] > 1, @"[RNScreens] Attempt to pop last screen from the stack");
+          NSAssert(self.topViewController == controller, @"[RNScreens] Attempt to pop non-top screen");
+          BOOL isFinalOperation = !hasPendingPushes && popIndex == self->_pendingPopOperations.count - 1;
+          [self popViewControllerAnimated:isFinalOperation];
+          popIndex += 1;
+      }
+
+      NSUInteger pushIndex = 0;
+      for (RNSPushOperation *op in self->_pendingPushOperations) {
+          UIViewController *controller = static_cast<UIViewController *>(op.stackScreen.controller);
+          BOOL isFinalOperation = pushIndex == self->_pendingPushOperations.count - 1;
+          [self pushViewController:controller animated:isFinalOperation];
+          pushIndex += 1;
+      }
+
+      NSAssert([self.viewControllers count] > 0, @"[RNScreens] Stack should never be empty after updates");
+
+      [self dumpStackModel];
+    };
+    @try {
+        if (operation)
+            RNSTraceSection(@"LynxScreens.Stack.ApplyOperations", RNSTraceFields(operation.identity), applyOperations);
+        else
+            applyOperations();
+    } @finally {
+        _applyingJSOperations = NO;
     }
-
-    NSUInteger pushIndex = 0;
-    for (RNSPushOperation *op in _pendingPushOperations) {
-        UIViewController *controller = static_cast<UIViewController *>(op.stackScreen.controller);
-        BOOL isFinalOperation = pushIndex == _pendingPushOperations.count - 1;
-        [self pushViewController:controller animated:isFinalOperation];
-        pushIndex += 1;
-    }
-
-    NSAssert([self.viewControllers count] > 0, @"[RNScreens] Stack should never be empty after updates");
-
-    [self dumpStackModel];
+    [self completeTrace:operation animated:YES];
 
     [_pendingPopOperations removeAllObjects];
     [_pendingPushOperations removeAllObjects];
@@ -136,6 +233,11 @@
 {
     [super viewDidLayoutSubviews];
     [_navigationBarFrameChangeDelegate viewFrameDidChange:self.navigationBar];
+}
+
+- (void)dealloc
+{
+    [_traceOperation finish:@"cancelled" reason:@"destroyed"];
 }
 
 #pragma mark - Debug

--- a/ios/host/RNSStackOperationCoordinator.h
+++ b/ios/host/RNSStackOperationCoordinator.h
@@ -5,6 +5,8 @@
 
 @interface RNSStackOperationCoordinator : NSObject
 
+- (void)captureTraceBatch:(nullable RNSTraceBatch *)batch;
+
 - (void)addPushOperation:(nonnull RNSStackScreenComponent *)screen;
 
 - (void)addPopOperation:(nonnull RNSStackScreenComponent *)screen;

--- a/ios/host/RNSStackOperationCoordinator.mm
+++ b/ios/host/RNSStackOperationCoordinator.mm
@@ -6,6 +6,9 @@
 @implementation RNSStackOperationCoordinator {
     NSMutableArray<RNSPushOperation *> *_Nonnull _pendingPushOperations;
     NSMutableArray<RNSPopOperation *> *_Nonnull _pendingPopOperations;
+    RNSTraceBatch *_traceBatch;
+    BOOL _hasTraceBatch;
+    BOOL _ambiguousTraceBatch;
 }
 
 - (instancetype)init
@@ -22,6 +25,14 @@
     _pendingPopOperations = [NSMutableArray array];
 }
 
+- (void)captureTraceBatch:(RNSTraceBatch *)batch
+{
+    if (_hasTraceBatch && _traceBatch != batch)
+        _ambiguousTraceBatch = YES;
+    _hasTraceBatch = YES;
+    _traceBatch = batch;
+}
+
 - (BOOL)hasPendingOperations
 {
     return _pendingPushOperations.count > 0 || _pendingPopOperations.count > 0;
@@ -29,12 +40,26 @@
 
 - (void)addPushOperation:(nonnull RNSStackScreenComponent *)stackScreen
 {
+    if (stackScreen.traceSession) {
+        NSMutableDictionary *fields =
+            [NSMutableDictionary dictionaryWithDictionary:@{@"operation" : @"push", @"origin" : @"lynx_patch"}];
+        if (stackScreen.screenKey)
+            fields[@"screen_key"] = stackScreen.screenKey;
+        RNSTraceInstant(@"LynxScreens.Stack.OperationRequested", fields);
+    }
     RNSPushOperation *operation = [[RNSPushOperation alloc] initWithScreen:stackScreen];
     [_pendingPushOperations addObject:operation];
 }
 
 - (void)addPopOperation:(nonnull RNSStackScreenComponent *)stackScreen
 {
+    if (stackScreen.traceSession) {
+        NSMutableDictionary *fields =
+            [NSMutableDictionary dictionaryWithDictionary:@{@"operation" : @"pop", @"origin" : @"lynx_patch"}];
+        if (stackScreen.screenKey)
+            fields[@"screen_key"] = stackScreen.screenKey;
+        RNSTraceInstant(@"LynxScreens.Stack.OperationRequested", fields);
+    }
     RNSPopOperation *operation = [[RNSPopOperation alloc] initWithScreen:stackScreen];
     [_pendingPopOperations addObject:operation];
 }
@@ -53,6 +78,9 @@
                      withRenderedScreens:(nonnull NSMutableArray<RNSStackScreenComponent *> *)renderedScreens
 {
     if (![self hasPendingOperations]) {
+        _traceBatch = nil;
+        _hasTraceBatch = NO;
+        _ambiguousTraceBatch = NO;
         return;
     }
 
@@ -120,7 +148,12 @@
         [controller enqueuePushOperation:screen];
     }
 
+    controller.traceBatch = _ambiguousTraceBatch ? nil : _traceBatch;
     [controller performContainerUpdateIfNeeded];
+    controller.traceBatch = nil;
+    _traceBatch = nil;
+    _hasTraceBatch = NO;
+    _ambiguousTraceBatch = NO;
 
     [_pendingPopOperations removeAllObjects];
     [_pendingPushOperations removeAllObjects];

--- a/ios/screen/RNSStackScreenComponent.h
+++ b/ios/screen/RNSStackScreenComponent.h
@@ -5,6 +5,8 @@
 NS_ASSUME_NONNULL_BEGIN
 
 @class RNSStackScreenController;
+@class RNSNavigationTraceOperation;
+@class RNSStackScreenEventEmitter;
 @class RNSStackHostComponent;
 
 typedef NS_ENUM(int, RNSStackScreenActivityMode) {
@@ -26,6 +28,11 @@ typedef NS_ENUM(NSInteger, RNSScreenLifecycleEvent) {
 @property (nonatomic, weak, readwrite, nullable) RNSStackHostComponent *stackHost;
 @property (nonatomic, strong, readonly, nonnull) RNSStackScreenController *controller;
 @property (nonatomic) BOOL isNativelyDismissed;
+@property(nonatomic, copy, nullable) NSDictionary *traceSession;
+@property(nonatomic, copy, nullable) NSDictionary *traceContent;
+@property(nonatomic, strong, nullable) RNSNavigationTraceOperation *traceOperation;
+- (RNSStackScreenEventEmitter *)traceEventEmitter;
+- (RNSStackScreenEventEmitter *)lifecycleTraceEventEmitter;
 
 - (void)registerDescendantScrollView:(nonnull UIScrollView *)scrollView
                           fromMarker:(nonnull RNSScrollViewMarkerComponent *)marker;

--- a/ios/screen/RNSStackScreenComponent.mm
+++ b/ios/screen/RNSStackScreenComponent.mm
@@ -1,4 +1,5 @@
 #import "RNSStackScreenComponent.h"
+#import "RNSNavigationTrace.h"
 #import "RNSStackHeaderConfigComponent.h"
 #import "RNSStackHostComponent.h"
 #import "RNSStackScreenController.h"
@@ -73,6 +74,15 @@
 
 #pragma mark - Props
 
+LYNX_PROP_SETTER("traceSession", setTraceSession, NSString *)
+{
+    self.traceSession = requestReset ? nil : RNSTraceSession(value);
+}
+LYNX_PROP_SETTER("contentTraceContext", setContentTraceContext, NSString *)
+{
+    self.traceContent = requestReset ? nil : RNSTraceContent(value);
+}
+
 LYNX_PROP_SETTER("activityMode", setActivityMode, NSString *) {
     auto prevActivityMode = self.activityMode;
     
@@ -126,6 +136,16 @@ LYNX_PROP_SETTER("screenKey", setScreenKey, NSString *) {
                                                                       targetSign:[self sign]];
     }
     return _eventEmitter;
+}
+
+- (RNSStackScreenEventEmitter *)traceEventEmitter
+{
+    return [[self getEventEmitter] withTraceIdentity:[self.traceOperation identityForScreen:self.screenKey]];
+}
+
+- (RNSStackScreenEventEmitter *)lifecycleTraceEventEmitter
+{
+    return [[self getEventEmitter] withTraceIdentity:[self.traceOperation lifecycleIdentityForScreen:self.screenKey]];
 }
 
 - (void)notifyLifecycleChange:(RNSScreenLifecycleEvent)event {

--- a/ios/screen/RNSStackScreenController.mm
+++ b/ios/screen/RNSStackScreenController.mm
@@ -1,12 +1,17 @@
 #import "RNSStackScreenController.h"
-#import <Lynx/LynxLog.h>
 #import "RNSContainer.h"
 #import "RNSContainerItemSupport.h"
+#import "RNSNavigationTrace.h"
 #import "RNSStackScreenComponent.h"
+#import "RNSStackScreenEventEmitter.h"
 #import "RNSStackScreenHeaderCoordinator.h"
+#import <Lynx/LynxLog.h>
 
 @implementation RNSStackScreenController {
     RNSContainerItemSupport *_Nonnull _containerItemSupport;
+    RNSStackScreenEventEmitter *_appearEmitter;
+    RNSStackScreenEventEmitter *_disappearEmitter;
+    RNSNavigationTraceOperation *_disappearanceOperation;
 }
 
 - (instancetype)initWithComponent:(RNSStackScreenComponent *)component
@@ -47,25 +52,28 @@
 - (void)viewWillAppear:(BOOL)animated
 {
     [super viewWillAppear:animated];
-    [_screenComponent notifyLifecycleChange:RNSScreenLifecycleEventWillAppear];
+    _appearEmitter = [_screenComponent lifecycleTraceEventEmitter];
+    [_appearEmitter emitOnWillAppear];
 }
 
 - (void)viewDidAppear:(BOOL)animated
 {
     [super viewDidAppear:animated];
-    [_screenComponent notifyLifecycleChange:RNSScreenLifecycleEventDidAppear];
+    [_appearEmitter emitOnDidAppear];
 }
 
 - (void)viewWillDisappear:(BOOL)animated
 {
     [super viewWillDisappear:animated];
-    [_screenComponent notifyLifecycleChange:RNSScreenLifecycleEventWillDisappear];
+    _disappearanceOperation = _screenComponent.traceOperation.terminal ? nil : _screenComponent.traceOperation;
+    _disappearEmitter = [_screenComponent lifecycleTraceEventEmitter];
+    [_disappearEmitter emitOnWillDisappear];
 }
 
 - (void)viewDidDisappear:(BOOL)animated
 {
     [super viewDidDisappear:animated];
-    [_screenComponent notifyLifecycleChange:RNSScreenLifecycleEventDidDisappear];
+    [_disappearEmitter emitOnDidDisappear];
 }
 
 - (void)didMoveToParentViewController:(UIViewController *)parent
@@ -77,11 +85,12 @@
     [super didMoveToParentViewController:parent];
 
     if (parent == nil) {
+        [_disappearanceOperation mark:@"NativeDismissCommitted" fields:@{}];
         if (_screenComponent.activityMode == RNSStackScreenActivityModeDetached) {
-            [_screenComponent emitOnDismiss];
+            [(_disappearEmitter ?: [_screenComponent traceEventEmitter]) emitOnDismiss:NO];
         } else {
             _screenComponent.isNativelyDismissed = YES;
-            [_screenComponent emitOnNativeDismiss];
+            [(_disappearEmitter ?: [_screenComponent traceEventEmitter]) emitOnDismiss:YES];
         }
     }
 }

--- a/ios/screen/RNSStackScreenEventEmitter.h
+++ b/ios/screen/RNSStackScreenEventEmitter.h
@@ -8,6 +8,8 @@ NS_ASSUME_NONNULL_BEGIN
 - (instancetype)initWithEventEmitter:(LynxEventEmitter *)eventEmitter 
                           targetSign:(NSInteger)sign;
 
+- (instancetype)withTraceIdentity:(nullable NSDictionary *)identity;
+
 - (void)emitOnWillAppear;
 - (void)emitOnDidAppear;
 - (void)emitOnWillDisappear;

--- a/ios/screen/RNSStackScreenEventEmitter.mm
+++ b/ios/screen/RNSStackScreenEventEmitter.mm
@@ -1,8 +1,10 @@
 #import "RNSStackScreenEventEmitter.h"
+#import "RNSNavigationTrace.h"
 
 @implementation RNSStackScreenEventEmitter {
     __weak LynxEventEmitter *_eventEmitter;
     NSInteger _sign;
+    NSDictionary *_traceIdentity;
 }
 
 - (instancetype)initWithEventEmitter:(LynxEventEmitter *)eventEmitter
@@ -12,6 +14,13 @@
         _sign = sign;
     }
     return self;
+}
+
+- (instancetype)withTraceIdentity:(NSDictionary *)identity
+{
+    RNSStackScreenEventEmitter *snapshot = [[[self class] alloc] initWithEventEmitter:_eventEmitter targetSign:_sign];
+    snapshot->_traceIdentity = [identity copy];
+    return snapshot;
 }
 
 - (void)emitOnWillAppear {
@@ -36,10 +45,23 @@
 
 - (void)dispatch:(NSString *)name detail:(NSDictionary *)detail {
     if (_eventEmitter) {
+        if (_traceIdentity) {
+            NSMutableDictionary *enriched = [detail mutableCopy];
+            enriched[@"traceIdentity"] = _traceIdentity;
+            detail = enriched;
+        }
         LynxCustomEvent *event = [[LynxDetailEvent alloc] initWithName:name
                                                             targetSign:_sign
                                                                 detail:detail];
         [_eventEmitter dispatchCustomEvent:event];
+        if (_traceIdentity) {
+            NSMutableDictionary *fields = [RNSTraceFields(_traceIdentity) mutableCopy];
+            fields[@"event_name"] = name;
+            RNSTraceInstant([@"LynxScreens.Stack."
+                                stringByAppendingString:([name containsString:@"Dismiss"] ? @"DismissEventEmitted"
+                                                                                          : @"LifecycleEventEmitted")],
+                            fields);
+        }
     }
 }
 

--- a/src/index.ts
+++ b/src/index.ts
@@ -58,3 +58,19 @@ export type {
   StackHeaderMenuItemOptionsIOS,
   StackHeaderMenuOptionsIOS,
 } from './types/StackHeaderConfig';
+
+// Framework-only protocol; applications do not construct these identities.
+export type {
+  TraceSession,
+  NavigationTraceEnvelope,
+  NavigationOperationBinding,
+  ExpectedChange,
+  ContentIdentity,
+  NativeTraceIdentity,
+  NativeEventContext,
+  ScreenBridgeObserver,
+  ScreenContentTraceProps,
+  ScreenInternalTraceProps,
+  HostInternalTraceProps,
+} from './internal/trace/types.js';
+export { decodeNativeEvent as UNSTABLE_decodeNativeTraceEvent } from './internal/trace/codec.js';

--- a/src/internal/trace/bridge.ts
+++ b/src/internal/trace/bridge.ts
@@ -1,0 +1,52 @@
+import React from 'react';
+import { decodeNativeEvent, encodeTrace } from './codec.js';
+import type { ScreenInternalTraceProps } from './types.js';
+
+export function useScreenTrace(trace?: ScreenInternalTraceProps) {
+  const session = trace?.session;
+  const content = trace?.content;
+  const observer = trace?.observer;
+  React.useEffect(() => {
+    if (content) {
+      try {
+        observer?.onRootCommitted?.(content.identity);
+      } catch {
+        /* Observation only. */
+      }
+    }
+  }, [content, observer]);
+  const props = React.useMemo(
+    () =>
+      session
+        ? {
+            traceSession: encodeTrace(session),
+            contentTraceContext: encodeTrace(content?.identity),
+          }
+        : { traceSession: undefined, contentTraceContext: undefined },
+    [session, content],
+  );
+  return {
+    props,
+    context(event: unknown, name: string) {
+      const context = decodeNativeEvent(event, name);
+      try {
+        observer?.onEventForwarded?.(name, context.traceIdentity);
+      } catch {
+        /* Observation only. */
+      }
+      return context;
+    },
+    forward<T>(name: string, handler?: (event: T) => void) {
+      if (!trace) return handler;
+      return (event: T) => {
+        const context = decodeNativeEvent(event, name);
+        try {
+          observer?.onEventForwarded?.(name, context.traceIdentity);
+        } catch {
+          /* Observation only. */
+        }
+        handler?.(event);
+      };
+    },
+  };
+}

--- a/src/internal/trace/codec.ts
+++ b/src/internal/trace/codec.ts
@@ -1,0 +1,62 @@
+import type { NativeEventContext, NativeTraceIdentity } from './types.js';
+const MAX_SIZE = 65536;
+export function encodeTrace(value: unknown): string | undefined {
+  if (value == null) return undefined;
+  try {
+    const encoded = JSON.stringify(value);
+    return encoded.length <= MAX_SIZE ? encoded : undefined;
+  } catch {
+    return undefined;
+  }
+}
+const id = (value: unknown): value is string =>
+  typeof value === 'string' && value.length > 0 && value.length <= 1024;
+export function decodeNativeIdentity(
+  value: unknown,
+): NativeTraceIdentity | undefined {
+  if (value == null || typeof value !== 'object') return undefined;
+  const record = value as Record<string, unknown>;
+  if (record.version !== 1 || !id(record.containerId)) return undefined;
+  const result: Record<string, unknown> = {
+    version: 1,
+    containerId: record.containerId,
+  };
+  for (const key of [
+    'runtimeId',
+    'navigatorKey',
+    'navigationTraceId',
+    'nativeTransitionId',
+    'screenKey',
+    'contentScopeId',
+    'preloadTraceId',
+  ]) {
+    if (record[key] !== undefined) {
+      if (!id(record[key])) return undefined;
+      result[key] = record[key];
+    }
+  }
+  return Object.freeze(result) as NativeTraceIdentity;
+}
+export function decodeNativeEvent(
+  event: unknown,
+  nativeEvent: string,
+): NativeEventContext {
+  try {
+    const detail =
+      (event as { detail?: Record<string, unknown> })?.detail ?? {};
+    return Object.freeze({
+      nativeEvent,
+      traceIdentity: decodeNativeIdentity(detail.traceIdentity),
+      isNativeDismiss:
+        typeof detail.isNativeDismiss === 'boolean'
+          ? detail.isNativeDismiss
+          : undefined,
+      dismissCount: Number.isSafeInteger(detail.dismissCount)
+        ? (detail.dismissCount as number)
+        : undefined,
+      channel: typeof detail.channel === 'string' ? detail.channel : undefined,
+    });
+  } catch {
+    return { nativeEvent };
+  }
+}

--- a/src/internal/trace/types.ts
+++ b/src/internal/trace/types.ts
@@ -1,0 +1,75 @@
+/** Versioned framework protocol. Not application navigation state. */
+export type TraceSession = Readonly<{
+  version: 1;
+  runtimeId: string;
+  navigatorKey: string;
+  enabled: true;
+}>;
+export type ExpectedChange =
+  | Readonly<{
+      kind: 'stack';
+      beforeScreenKeys: readonly string[];
+      afterScreenKeys: readonly string[];
+    }>
+  | Readonly<{
+      kind: 'sheet';
+      screenKey: string;
+      fromOpen: boolean;
+      toOpen: boolean;
+    }>;
+export type NavigationOperationBinding = Readonly<{
+  navigationTraceId: string;
+  actionType: string;
+  sourceScreenKey?: string | undefined;
+  targetScreenKey?: string | undefined;
+  preloadTraceId?: string | undefined;
+  expectedChange: ExpectedChange;
+}>;
+export type NavigationTraceEnvelope = Readonly<{
+  version: 1;
+  runtimeId: string;
+  navigatorKey: string;
+  sequence: number;
+  bindings: readonly NavigationOperationBinding[];
+}>;
+export type ContentIdentity = Readonly<{
+  version: 1;
+  runtimeId: string;
+  navigatorKey: string;
+  screenKey: string;
+  contentScopeId: string;
+}>;
+export type NativeTraceIdentity = Readonly<{
+  version: 1;
+  containerId: string;
+  runtimeId?: string | undefined;
+  navigatorKey?: string | undefined;
+  navigationTraceId?: string | undefined;
+  nativeTransitionId?: string | undefined;
+  screenKey?: string | undefined;
+  contentScopeId?: string | undefined;
+  preloadTraceId?: string | undefined;
+}>;
+export type NativeEventContext = Readonly<{
+  traceIdentity?: NativeTraceIdentity | undefined;
+  nativeEvent: string;
+  isNativeDismiss?: boolean | undefined;
+  dismissCount?: number | undefined;
+  channel?: string | undefined;
+}>;
+export interface ScreenBridgeObserver {
+  onRootCommitted?(identity: ContentIdentity): void;
+  onEventForwarded?(event: string, identity?: NativeTraceIdentity): void;
+}
+export type ScreenContentTraceProps = Readonly<{
+  identity: ContentIdentity;
+}>;
+export type ScreenInternalTraceProps = Readonly<{
+  session: TraceSession;
+  content?: ScreenContentTraceProps | undefined;
+  observer?: ScreenBridgeObserver | undefined;
+}>;
+export type HostInternalTraceProps = Readonly<{
+  session: TraceSession;
+  envelope?: NavigationTraceEnvelope | undefined;
+}>;

--- a/src/lynx-elements.ts
+++ b/src/lynx-elements.ts
@@ -1,8 +1,13 @@
 import type { ReactNode, Ref } from '@lynx-js/react';
 import type * as Lynx from '@lynx-js/types';
+import type { NativeTraceIdentity } from './internal/trace/types.js';
 
-declare module "@lynx-js/types" {
+declare module '@lynx-js/types' {
   type EmptyEventPayload = Record<string, never>;
+
+  type NavigationTraceEventPayload = Readonly<{
+    traceIdentity?: NativeTraceIdentity | undefined;
+  }>;
 
   type StackHeaderIconIOSAttr =
     | {
@@ -35,9 +40,10 @@ declare module "@lynx-js/types" {
     children: (StackHeaderMenuAttr | StackHeaderMenuItemAttr)[];
   };
 
-  type OnDismissEventPayload = Readonly<{
-    isNativeDismiss: boolean;
-  }>;
+  type OnDismissEventPayload = NavigationTraceEventPayload &
+    Readonly<{
+      isNativeDismiss: boolean;
+    }>;
 
   type FormSheetDetentChangedEventPayload = Readonly<{
     index: number;
@@ -80,6 +86,10 @@ declare module "@lynx-js/types" {
 
   interface IntrinsicElements extends Lynx.IntrinsicElements {
     'ls-form-sheet': {
+      traceSession?: string | undefined;
+      contentTraceContext?: string | undefined;
+      traceScreenKey?: string | undefined;
+      navigationTraceContext?: string | undefined;
       className?: string | undefined;
       children?: ReactNode | undefined;
       id?: string | undefined;
@@ -93,13 +103,20 @@ declare module "@lynx-js/types" {
       prefersScrollingExpandsWhenScrolledToEdge?: boolean | undefined;
       preventNativeDismiss?: boolean | undefined;
       nativeContainerBackgroundColor?: string | undefined;
-      bindOnWillAppear?: Lynx.EventHandler<Lynx.BaseEventOrig<EmptyEventPayload>> | undefined;
-      bindOnDidAppear?: Lynx.EventHandler<Lynx.BaseEventOrig<EmptyEventPayload>> | undefined;
-      bindOnWillDisappear?: Lynx.EventHandler<Lynx.BaseEventOrig<EmptyEventPayload>> | undefined;
-      bindOnDidDisappear?: Lynx.EventHandler<Lynx.BaseEventOrig<EmptyEventPayload>> | undefined;
-      bindOnDismiss?: Lynx.EventHandler<Lynx.BaseEventOrig<EmptyEventPayload>> | undefined;
-      bindOnNativeDismiss?: Lynx.EventHandler<Lynx.BaseEventOrig<EmptyEventPayload>> | undefined;
-      bindOnNativeDismissPrevented?: Lynx.EventHandler<Lynx.BaseEventOrig<EmptyEventPayload>> | undefined;
+      bindOnWillAppear?:
+        Lynx.EventHandler<Lynx.BaseEventOrig<EmptyEventPayload>> | undefined;
+      bindOnDidAppear?:
+        Lynx.EventHandler<Lynx.BaseEventOrig<EmptyEventPayload>> | undefined;
+      bindOnWillDisappear?:
+        Lynx.EventHandler<Lynx.BaseEventOrig<EmptyEventPayload>> | undefined;
+      bindOnDidDisappear?:
+        Lynx.EventHandler<Lynx.BaseEventOrig<EmptyEventPayload>> | undefined;
+      bindOnDismiss?:
+        Lynx.EventHandler<Lynx.BaseEventOrig<EmptyEventPayload>> | undefined;
+      bindOnNativeDismiss?:
+        Lynx.EventHandler<Lynx.BaseEventOrig<EmptyEventPayload>> | undefined;
+      bindOnNativeDismissPrevented?:
+        Lynx.EventHandler<Lynx.BaseEventOrig<EmptyEventPayload>> | undefined;
       bindOnDetentChanged?:
         | Lynx.EventHandler<
             Lynx.BaseEventOrig<FormSheetDetentChangedEventPayload>
@@ -112,13 +129,17 @@ declare module "@lynx-js/types" {
       id?: string | undefined;
       style?: string | Lynx.CSSProperties | undefined;
     };
-    "ls-stack-host": {
+    'ls-stack-host': {
+      traceSession?: string | undefined;
       className?: string | undefined;
       children: ReactNode;
       id?: string | undefined;
       style?: string | Lynx.CSSProperties | undefined;
+      navigationTraceContext?: string | undefined;
     };
-    "ls-stack-screen": {
+    'ls-stack-screen': {
+      traceSession?: string | undefined;
+      contentTraceContext?: string | undefined;
       className?: string | undefined;
       children: ReactNode;
       id?: string | undefined;
@@ -127,16 +148,23 @@ declare module "@lynx-js/types" {
       activityMode?: 'detached' | 'attached' | undefined;
       screenKey?: string | undefined;
       // Events
-      bindOnWillAppear?: Lynx.EventHandler<Lynx.BaseEventOrig<EmptyEventPayload>> | undefined;
-      bindOnDidAppear?: Lynx.EventHandler<Lynx.BaseEventOrig<EmptyEventPayload>> | undefined;
-      bindOnWillDisappear?: Lynx.EventHandler<Lynx.BaseEventOrig<EmptyEventPayload>> | undefined;
-      bindOnDidDisappear?: Lynx.EventHandler<Lynx.BaseEventOrig<EmptyEventPayload>> | undefined;
-      bindOnDismiss?: Lynx.EventHandler<Lynx.BaseEventOrig<OnDismissEventPayload>> | undefined;
-      bindOnNativeDismissPrevented?: Lynx.EventHandler<Lynx.BaseEventOrig<EmptyEventPayload>> | undefined;
+      bindOnWillAppear?:
+        Lynx.EventHandler<Lynx.BaseEventOrig<EmptyEventPayload>> | undefined;
+      bindOnDidAppear?:
+        Lynx.EventHandler<Lynx.BaseEventOrig<EmptyEventPayload>> | undefined;
+      bindOnWillDisappear?:
+        Lynx.EventHandler<Lynx.BaseEventOrig<EmptyEventPayload>> | undefined;
+      bindOnDidDisappear?:
+        Lynx.EventHandler<Lynx.BaseEventOrig<EmptyEventPayload>> | undefined;
+      bindOnDismiss?:
+        | Lynx.EventHandler<Lynx.BaseEventOrig<OnDismissEventPayload>>
+        | undefined;
+      bindOnNativeDismissPrevented?:
+        Lynx.EventHandler<Lynx.BaseEventOrig<EmptyEventPayload>> | undefined;
       // Configuration
       preventNativeDismiss?: boolean | undefined;
     };
-    "ls-stack-header-config": {
+    'ls-stack-header-config': {
       ref?: Ref<Lynx.NodesRef> | undefined;
       className?: string | undefined;
       children?: ReactNode | undefined;
@@ -172,8 +200,7 @@ declare module "@lynx-js/types" {
         | undefined;
       toolbarMenuGroupDividerEnabled?: boolean | undefined;
       bindOnToolbarMenuItemPress?:
-        | Lynx.EventHandler<Lynx.BaseEventOrig<{ id: string }>>
-        | undefined;
+        Lynx.EventHandler<Lynx.BaseEventOrig<{ id: string }>> | undefined;
       bindOnToolbarMenuGroupSelectionChange?:
         | Lynx.EventHandler<
             Lynx.BaseEventOrig<{ groupId: string; selectedIds: string[] }>
@@ -191,13 +218,13 @@ declare module "@lynx-js/types" {
           >
         | undefined;
     };
-    "ls-scroll-view-marker": {
+    'ls-scroll-view-marker': {
       className?: string | undefined;
       children: ReactNode;
       id?: string | undefined;
       style?: string | Lynx.CSSProperties | undefined;
     };
-    "ls-stack-header-subview-android": {
+    'ls-stack-header-subview-android': {
       className?: string | undefined;
       children?: ReactNode | undefined;
       id?: string | undefined;
@@ -205,7 +232,7 @@ declare module "@lynx-js/types" {
       type?: 'background' | 'leading' | 'center' | 'trailing' | undefined;
       collapseMode?: 'off' | 'parallax' | undefined;
     };
-    "ls-stack-header-item-ios": {
+    'ls-stack-header-item-ios': {
       className?: string | undefined;
       children?: ReactNode | undefined;
       id?: string | undefined;
@@ -226,7 +253,7 @@ declare module "@lynx-js/types" {
         | Lynx.EventHandler<Lynx.BaseEventOrig<Record<string, never>>>
         | undefined;
     };
-    "ls-stack-header-item-spacer-ios": {
+    'ls-stack-header-item-spacer-ios': {
       className?: string | undefined;
       id?: string | undefined;
       style?: string | Lynx.CSSProperties | undefined;

--- a/src/native_components/FormSheetNativeComponent.tsx
+++ b/src/native_components/FormSheetNativeComponent.tsx
@@ -1,4 +1,5 @@
 import React from 'react';
+import { useScreenTrace } from '../internal/trace/bridge.js';
 import type * as Lynx from '@lynx-js/types';
 import type { FormSheetProps } from '../types/FormSheet.js';
 import {
@@ -14,6 +15,8 @@ type DetentChangedEventPayload = Readonly<{
 
 export const FormSheetNativeComponent = ({
   children,
+  internalTrace,
+  traceScreenKey,
   detents,
   initialDetentIndex,
   largestUndimmedDetentIndex,
@@ -29,6 +32,7 @@ export const FormSheetNativeComponent = ({
   onDetentChanged,
   ...rest
 }: FormSheetProps) => {
+  const trace = useScreenTrace(internalTrace);
   const nativeDetents = resolveNativeDetents(detents);
   const detentsCount = nativeDetents?.length ?? 0;
 
@@ -41,6 +45,11 @@ export const FormSheetNativeComponent = ({
 
   return (
     <ls-form-sheet
+      traceScreenKey={
+        traceScreenKey ?? internalTrace?.content?.identity.screenKey
+      }
+      traceSession={trace.props.traceSession}
+      contentTraceContext={trace.props.contentTraceContext}
       style={{ position: 'absolute', top: 0, left: 0 }}
       detents={nativeDetents}
       initialDetentIndex={resolveInitialDetentIndex(
@@ -53,13 +62,18 @@ export const FormSheetNativeComponent = ({
       )}
       preferredCornerRadius={resolveNativeCornerRadius(preferredCornerRadius)}
       nativeContainerBackgroundColor={nativeContainerStyle?.backgroundColor}
-      bindOnWillAppear={onWillAppear}
-      bindOnDidAppear={onDidAppear}
-      bindOnWillDisappear={onWillDisappear}
-      bindOnDidDisappear={onDidDisappear}
-      bindOnDismiss={onDismiss}
-      bindOnNativeDismiss={onNativeDismiss}
-      bindOnNativeDismissPrevented={onNativeDismissPrevented}
+      bindOnWillAppear={trace.forward('onWillAppear', onWillAppear)}
+      bindOnDidAppear={trace.forward('onDidAppear', onDidAppear)}
+      bindOnWillDisappear={trace.forward('onWillDisappear', onWillDisappear)}
+      bindOnDidDisappear={trace.forward('onDidDisappear', onDidDisappear)}
+      bindOnDismiss={(event) => onDismiss?.(trace.context(event, 'onDismiss'))}
+      bindOnNativeDismiss={(event) =>
+        onNativeDismiss?.(trace.context(event, 'onNativeDismiss'))
+      }
+      bindOnNativeDismissPrevented={trace.forward(
+        'onNativeDismissPrevented',
+        onNativeDismissPrevented,
+      )}
       bindOnDetentChanged={onDetentChangedEvent}
       {...rest}
     >

--- a/src/native_components/StackHostNativeComponent.tsx
+++ b/src/native_components/StackHostNativeComponent.tsx
@@ -1,20 +1,23 @@
 import * as Lynx from '@lynx-js/types';
+import { encodeTrace } from '../internal/trace/codec.js';
+import type { HostInternalTraceProps } from '../internal/trace/types.js';
 
 export const StackHostNativeComponent = ({
   children,
+  internalTrace,
 }: {
   children: NonNullable<Lynx.ViewProps['children']>;
-}) => {
-  return (
-    <ls-stack-host
-      style={{
-        display: 'flex',
-        flex: 1,
-        width: '100%',
-        height: '100%',
-      }}
-    >
-      {children}
-    </ls-stack-host>
-  );
-};
+  internalTrace?: HostInternalTraceProps | undefined;
+}) => (
+  <ls-stack-host
+    traceSession={
+      internalTrace ? encodeTrace(internalTrace.session) : undefined
+    }
+    navigationTraceContext={
+      internalTrace ? encodeTrace(internalTrace.envelope) : undefined
+    }
+    style={{ display: 'flex', flex: 1, width: '100%', height: '100%' }}
+  >
+    {children}
+  </ls-stack-host>
+);

--- a/src/native_components/StackScreenNativeComponent.tsx
+++ b/src/native_components/StackScreenNativeComponent.tsx
@@ -1,4 +1,5 @@
 import React from 'react';
+import { useScreenTrace } from '../internal/trace/bridge.js';
 import * as Lynx from '@lynx-js/types';
 import type {
   OnDismissEventPayload,
@@ -7,6 +8,7 @@ import type {
 
 export const StackScreenNativeComponent = ({
   children,
+  internalTrace,
   // Control
   activityMode,
   screenKey,
@@ -21,21 +23,22 @@ export const StackScreenNativeComponent = ({
   // Configuration
   preventNativeDismiss,
 }: StackScreenProps) => {
+  const trace = useScreenTrace(internalTrace);
   const onDismissWrapper = React.useCallback(
     (event: Lynx.BaseEventOrig<OnDismissEventPayload>) => {
       if (event.detail.isNativeDismiss) {
-        console.log('isNativeDismiss');
-        onNativeDismiss?.(screenKey);
+        onNativeDismiss?.(screenKey, trace.context(event, 'onNativeDismiss'));
       } else {
-        console.log('isDismiss');
-        onDismiss?.(screenKey);
+        onDismiss?.(screenKey, trace.context(event, 'onDismiss'));
       }
     },
-    [onDismiss, onNativeDismiss, screenKey],
+    [onDismiss, onNativeDismiss, screenKey, trace],
   );
 
   return (
     <ls-stack-screen
+      traceSession={trace.props.traceSession}
+      contentTraceContext={trace.props.contentTraceContext}
       style={{
         position: 'absolute',
         left: 0,
@@ -47,12 +50,15 @@ export const StackScreenNativeComponent = ({
       activityMode={activityMode}
       screenKey={screenKey}
       // Events
-      bindOnWillAppear={onWillAppear}
-      bindOnDidAppear={onDidAppear}
-      bindOnWillDisappear={onWillDisappear}
-      bindOnDidDisappear={onDidDisappear}
+      bindOnWillAppear={trace.forward('onWillAppear', onWillAppear)}
+      bindOnDidAppear={trace.forward('onDidAppear', onDidAppear)}
+      bindOnWillDisappear={trace.forward('onWillDisappear', onWillDisappear)}
+      bindOnDidDisappear={trace.forward('onDidDisappear', onDidDisappear)}
       bindOnDismiss={onDismissWrapper}
-      bindOnNativeDismissPrevented={onNativeDismissPrevented}
+      bindOnNativeDismissPrevented={trace.forward(
+        'onNativeDismissPrevented',
+        onNativeDismissPrevented,
+      )}
       // Configuration
       preventNativeDismiss={preventNativeDismiss}
     >

--- a/src/types/FormSheet.ts
+++ b/src/types/FormSheet.ts
@@ -1,3 +1,7 @@
+import type {
+  ScreenInternalTraceProps,
+  NativeEventContext,
+} from '../internal/trace/types.js';
 import type * as Lynx from '@lynx-js/types';
 
 export type FormSheetDetents = number[] | 'fitToContents';
@@ -7,8 +11,11 @@ export type FormSheetNativeContainerStyleProps = {
 };
 
 export type FormSheetProps = {
+  /** @internal Navigation framework diagnostics. */
+  internalTrace?: ScreenInternalTraceProps | undefined;
   children?: Lynx.ViewProps['children'] | undefined;
   isOpen: boolean;
+  traceScreenKey?: string | undefined;
   detents?: FormSheetDetents | undefined;
   prefersGrabberVisible?: boolean | undefined;
   preferredCornerRadius?: number | 'systemDefault' | undefined;
@@ -18,21 +25,16 @@ export type FormSheetProps = {
   preventNativeDismiss?: boolean | undefined;
   nativeContainerStyle?: FormSheetNativeContainerStyleProps | undefined;
   onWillAppear?:
-    | Lynx.EventHandler<Lynx.BaseEventOrig<Record<string, never>>>
-    | undefined;
+    Lynx.EventHandler<Lynx.BaseEventOrig<Record<string, never>>> | undefined;
   onDidAppear?:
-    | Lynx.EventHandler<Lynx.BaseEventOrig<Record<string, never>>>
-    | undefined;
+    Lynx.EventHandler<Lynx.BaseEventOrig<Record<string, never>>> | undefined;
   onWillDisappear?:
-    | Lynx.EventHandler<Lynx.BaseEventOrig<Record<string, never>>>
-    | undefined;
+    Lynx.EventHandler<Lynx.BaseEventOrig<Record<string, never>>> | undefined;
   onDidDisappear?:
-    | Lynx.EventHandler<Lynx.BaseEventOrig<Record<string, never>>>
-    | undefined;
-  onDismiss?: (() => void) | undefined;
-  onNativeDismiss?: (() => void) | undefined;
+    Lynx.EventHandler<Lynx.BaseEventOrig<Record<string, never>>> | undefined;
+  onDismiss?: ((context?: NativeEventContext) => void) | undefined;
+  onNativeDismiss?: ((context?: NativeEventContext) => void) | undefined;
   onNativeDismissPrevented?:
-    | Lynx.EventHandler<Lynx.BaseEventOrig<Record<string, never>>>
-    | undefined;
+    Lynx.EventHandler<Lynx.BaseEventOrig<Record<string, never>>> | undefined;
   onDetentChanged?: ((index: number) => void) | undefined;
 };

--- a/src/types/StackScreen.ts
+++ b/src/types/StackScreen.ts
@@ -1,3 +1,7 @@
+import type {
+  ScreenInternalTraceProps,
+  NativeEventContext,
+} from '../internal/trace/types.js';
 import type * as Lynx from '@lynx-js/types';
 
 export type StackScreenActivityMode = 'detached' | 'attached';
@@ -10,6 +14,8 @@ export type OnDismissEventPayload = Readonly<{
 }>;
 
 export type StackScreenProps = {
+  /** @internal Navigation framework diagnostics. */
+  internalTrace?: ScreenInternalTraceProps | undefined;
   children?: Lynx.ViewProps['children'] | undefined;
 
   // Control
@@ -18,24 +24,21 @@ export type StackScreenProps = {
 
   // Events
   onWillAppear?:
-    | Lynx.EventHandler<Lynx.BaseEventOrig<EmptyEventPayload>>
-    | undefined;
+    Lynx.EventHandler<Lynx.BaseEventOrig<EmptyEventPayload>> | undefined;
   onDidAppear?:
-    | Lynx.EventHandler<Lynx.BaseEventOrig<EmptyEventPayload>>
-    | undefined;
+    Lynx.EventHandler<Lynx.BaseEventOrig<EmptyEventPayload>> | undefined;
   onWillDisappear?:
-    | Lynx.EventHandler<Lynx.BaseEventOrig<EmptyEventPayload>>
-    | undefined;
+    Lynx.EventHandler<Lynx.BaseEventOrig<EmptyEventPayload>> | undefined;
   onDidDisappear?:
-    | Lynx.EventHandler<Lynx.BaseEventOrig<EmptyEventPayload>>
-    | undefined;
+    Lynx.EventHandler<Lynx.BaseEventOrig<EmptyEventPayload>> | undefined;
 
-  onDismiss?: ((screenKey: string) => void) | undefined;
-  onNativeDismiss?: ((screenKey: string) => void) | undefined;
+  onDismiss?:
+    ((screenKey: string, context?: NativeEventContext) => void) | undefined;
+  onNativeDismiss?:
+    ((screenKey: string, context?: NativeEventContext) => void) | undefined;
 
   onNativeDismissPrevented?:
-    | Lynx.EventHandler<Lynx.BaseEventOrig<EmptyEventPayload>>
-    | undefined;
+    Lynx.EventHandler<Lynx.BaseEventOrig<EmptyEventPayload>> | undefined;
 
   // Configuration
   preventNativeDismiss?: boolean | undefined;

--- a/tests/navigation-trace.test.mjs
+++ b/tests/navigation-trace.test.mjs
@@ -1,0 +1,63 @@
+import { test } from 'node:test';
+import assert from 'node:assert/strict';
+import { encodeTrace, decodeNativeEvent } from '../src/internal/trace/codec.ts';
+
+test('untraced native callbacks preserve existing fields without inventing identity', () => {
+  const result = decodeNativeEvent(
+    { detail: { isNativeDismiss: true, dismissCount: 2, channel: 'back' } },
+    'OnDismiss',
+  );
+  assert.equal(result.traceIdentity, undefined);
+  assert.equal(result.isNativeDismiss, true);
+  assert.equal(result.dismissCount, 2);
+  assert.equal(result.channel, 'back');
+});
+test('identity is copied, immutable, and excludes unknown fields', () => {
+  const identity = {
+    version: 1,
+    containerId: 'stack:1',
+    navigationTraceId: 'native:1',
+    contentScopeId: 'content:1',
+    secret: 'ignore',
+  };
+  const result = decodeNativeEvent(
+    { detail: { traceIdentity: identity } },
+    'OnDismiss',
+  );
+  identity.navigationTraceId = 'native:2';
+  assert.equal(result.traceIdentity.navigationTraceId, 'native:1');
+  assert.equal(result.traceIdentity.secret, undefined);
+  assert.ok(Object.isFrozen(result.traceIdentity));
+});
+test('unsupported, malformed and oversized identity safely remain unlinked', () => {
+  for (const identity of [
+    { version: 2, containerId: 's' },
+    { version: 1, containerId: '' },
+    { version: 1, containerId: 's', runtimeId: 1 },
+    { version: 1, containerId: 's', navigationTraceId: 'x'.repeat(1025) },
+  ]) {
+    assert.equal(
+      decodeNativeEvent({ detail: { traceIdentity: identity } }, 'OnDismiss')
+        .traceIdentity,
+      undefined,
+    );
+  }
+  assert.doesNotThrow(() =>
+    decodeNativeEvent(
+      {
+        get detail() {
+          throw Error('decoder');
+        },
+      },
+      'OnDismiss',
+    ),
+  );
+});
+test('serialization failures and oversized contexts do not escape the bridge', () => {
+  const cycle = {};
+  cycle.self = cycle;
+  assert.equal(encodeTrace(cycle), undefined);
+  assert.equal(encodeTrace({ data: 'x'.repeat(65537) }), undefined);
+  assert.equal(encodeTrace(undefined), undefined);
+  assert.equal(encodeTrace({ version: 1 }), '{"version":1}');
+});


### PR DESCRIPTION
Navigation traces need to connect native container work and callbacks with the request that caused them. This draft adds captured operation identities and trace events to the existing containers, plus a JS bridge for forwarding context in both directions.

The native writers call Lynx trace APIs. This is a reference implementation for discussing whether that approach should remain, or whether future code sharing with React Native Screens calls for a tracing abstraction with separate implementations.

### Scope and commits

1. `feat(android): add navigation trace events` — Stack and the built-in Material FormSheet backend, operation matching, captured callbacks and terminal guards.
2. `feat(ios): add stack navigation trace events` — Stack instrumentation, UIKit completion/cancellation and captured lifecycle identities.
3. `feat(screens): bridge navigation trace context` — versioned types, encoding/decoding, native attributes and optional callback context.

The scope follows the existing containers. iOS FormSheet is deferred. There is no first-frame probe, `FirstFrameSignalObserved`, automatic FCP timing flag injection or screen metric calculation. Navigation Core and Native-Stack instrumentation are outside this PR; the navigation adapter supplies the bridge props.

The event catalog, correlation rules and manual acceptance scenarios are documented in `docs/navigation-trace.md`. Submission, transition completion and lifecycle notification remain separate boundaries. Uncertain callback ownership stays unlinked.

### Validation

- Android example `assembleDebug`, library `assemble` and all 14 JVM unit tests passed.
- iOS example simulator build passed for arm64 and x86_64 with signing disabled.
- Pod source-export validation passed for repository, flattened archive and generated local Pod layouts: 93 source files, one private trace header.
- TypeScript checking, scoped ESLint, four codec tests and the example bundle build passed.
- Diff whitespace and added-content forbidden-keyword checks passed.

Full-repository lint reports existing example errors and a generated recorder asset; the affected tracked files are unchanged from the base. Local validation reused installed JS dependencies and CocoaPods 1.16.2 because the repository-locked Ruby environment was not available. JS/Ruby dependency manifests and lockfiles are unchanged.

Device trace capture and navigation regression testing remain pending. Build/test results do not establish runtime event ordering or end-to-end navigation correlation.
